### PR TITLE
Upgrade Gradle to version 4.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,12 @@ repositories {
     mavenCentral()
 }
 
+
+// Change the output directory for the main source set back to the old path
+sourceSets.main.output.classesDir = new File(buildDir, "classes/main")
+sourceSets.test.output.classesDir = new File(buildDir, "classes/test")
+
+
 intellij {
     version = intellijVersion
     updateSinceUntilBuild = false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.5.1-all.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-4.0.1-all.zip


### PR DESCRIPTION
The extra lines in `build.gradle` are there for backwards-compatibility with Gradle plugins that have not been updated yet.
