### PR TITLE
Word capitalisation rules

### DIFF
--- a/src/main/java/com/fwdekker/randomness/word/CapitalizationMode.java
+++ b/src/main/java/com/fwdekker/randomness/word/CapitalizationMode.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 import java.util.Locale;
 import java.util.NoSuchElementException;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 
 /**
@@ -27,7 +28,12 @@ public enum CapitalizationMode {
     /**
      * Makes all characters lowercase.
      */
-    LOWER("lower", string -> string.toLowerCase(Locale.getDefault()));
+    LOWER("lower", string -> string.toLowerCase(Locale.getDefault())),
+    /**
+     * Makes the first letter of each word uppercase.
+     */
+    FIRST_LETTER("first letter", string ->
+            Arrays.stream(string.split(" ")).map(SENTENCE.transform).collect(Collectors.joining(" ")));
 
 
     /**

--- a/src/main/java/com/fwdekker/randomness/word/CapitalizationMode.java
+++ b/src/main/java/com/fwdekker/randomness/word/CapitalizationMode.java
@@ -11,6 +11,10 @@ import java.util.function.Function;
  */
 public enum CapitalizationMode {
     /**
+     * Does not change the string.
+     */
+    RETAIN("retain", string -> string),
+    /**
      * Makes the first character uppercase and all characters after that lowercase.
      */
     NORMAL("normal", string -> (string.length() == 0

--- a/src/main/java/com/fwdekker/randomness/word/CapitalizationMode.java
+++ b/src/main/java/com/fwdekker/randomness/word/CapitalizationMode.java
@@ -17,7 +17,7 @@ public enum CapitalizationMode {
     /**
      * Makes the first character uppercase and all characters after that lowercase.
      */
-    NORMAL("normal", string -> (string.length() == 0
+    SENTENCE("sentence", string -> (string.length() == 0
             ? ""
             : Character.toUpperCase(string.charAt(0)) + string.substring(1).toLowerCase(Locale.getDefault()))),
     /**

--- a/src/main/java/com/fwdekker/randomness/word/WordSettings.java
+++ b/src/main/java/com/fwdekker/randomness/word/WordSettings.java
@@ -42,7 +42,7 @@ public final class WordSettings extends Settings implements PersistentStateCompo
     /**
      * The way in which the generated word should be capitalized.
      */
-    private CapitalizationMode capitalization = CapitalizationMode.NORMAL;
+    private CapitalizationMode capitalization = CapitalizationMode.RETAIN;
     /**
      * The list of all dictionaries provided by the plugin.
      */

--- a/src/main/java/com/fwdekker/randomness/word/WordSettingsDialog.form
+++ b/src/main/java/com/fwdekker/randomness/word/WordSettingsDialog.form
@@ -172,9 +172,9 @@
           <grid row="3" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
-          <actionCommand value="normal"/>
-          <name value="capitalizationNormal"/>
-          <text value="Normal"/>
+          <actionCommand value="sentence"/>
+          <name value="capitalizationSentence"/>
+          <text value="Sentence"/>
         </properties>
       </component>
       <component id="5bc1d" class="javax.swing.JRadioButton" default-binding="true">

--- a/src/main/java/com/fwdekker/randomness/word/WordSettingsDialog.form
+++ b/src/main/java/com/fwdekker/randomness/word/WordSettingsDialog.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.fwdekker.randomness.word.WordSettingsDialog">
-  <grid id="27dc6" binding="contentPane" layout-manager="GridLayoutManager" row-count="7" column-count="5" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="contentPane" layout-manager="GridLayoutManager" row-count="7" column-count="6" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="527" height="400"/>
@@ -19,7 +19,7 @@
       </component>
       <component id="8a66f" class="com.fwdekker.randomness.ui.JLongSpinner" binding="minLength" custom-create="true">
         <constraints>
-          <grid row="0" column="1" row-span="1" col-span="4" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+          <grid row="0" column="1" row-span="1" col-span="5" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
             <minimum-size width="75" height="-1"/>
           </grid>
         </constraints>
@@ -38,7 +38,7 @@
       </component>
       <component id="2e2f" class="com.fwdekker.randomness.ui.JLongSpinner" binding="maxLength" custom-create="true">
         <constraints>
-          <grid row="1" column="1" row-span="1" col-span="4" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+          <grid row="1" column="1" row-span="1" col-span="5" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
             <minimum-size width="75" height="-1"/>
           </grid>
         </constraints>
@@ -64,15 +64,6 @@
           <text value="None"/>
         </properties>
       </component>
-      <component id="4715d" class="javax.swing.JRadioButton" default-binding="true">
-        <constraints>
-          <grid row="2" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <name value="enclosureDouble"/>
-          <text value="&quot;"/>
-        </properties>
-      </component>
       <component id="d5ff3" class="javax.swing.JRadioButton" default-binding="true">
         <constraints>
           <grid row="2" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
@@ -80,15 +71,6 @@
         <properties>
           <name value="enclosureSingle"/>
           <text value="'"/>
-        </properties>
-      </component>
-      <component id="65560" class="javax.swing.JRadioButton" default-binding="true">
-        <constraints>
-          <grid row="2" column="4" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <name value="enclosureBacktick"/>
-          <text value="`"/>
         </properties>
       </component>
       <component id="19950" class="javax.swing.JLabel">
@@ -117,7 +99,7 @@
       </scrollpane>
       <component id="6090f" class="javax.swing.JButton" binding="dictionaryAddButton" custom-create="true">
         <constraints>
-          <grid row="4" column="4" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="4" column="5" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <actionCommand value="add"/>
@@ -127,7 +109,7 @@
       </component>
       <component id="21b61" class="javax.swing.JButton" binding="dictionaryRemoveButton" custom-create="true">
         <constraints>
-          <grid row="5" column="4" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="5" column="5" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <actionCommand value="remove"/>
@@ -137,7 +119,7 @@
       </component>
       <vspacer id="f49c8">
         <constraints>
-          <grid row="6" column="4" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="6" column="5" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
       <component id="fb562" class="javax.swing.JLabel">
@@ -150,7 +132,7 @@
       </component>
       <component id="bf7aa" class="javax.swing.JRadioButton" default-binding="true">
         <constraints>
-          <grid row="3" column="4" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="3" column="5" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <name value="capitalizationLower"/>
@@ -159,7 +141,7 @@
       </component>
       <component id="2d597" class="javax.swing.JRadioButton" default-binding="true">
         <constraints>
-          <grid row="3" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="3" column="4" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <actionCommand value="upper"/>
@@ -187,6 +169,34 @@
           <text value="RETaiN"/>
         </properties>
       </component>
+      <component id="5602b" class="javax.swing.JRadioButton" default-binding="true">
+        <constraints>
+          <grid row="3" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <actionCommand value="first letter"/>
+          <name value="capitalizationFirstLetter"/>
+          <text value="First Letter"/>
+        </properties>
+      </component>
+      <component id="4715d" class="javax.swing.JRadioButton" default-binding="true">
+        <constraints>
+          <grid row="2" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <name value="enclosureDouble"/>
+          <text value="&quot;"/>
+        </properties>
+      </component>
+      <component id="65560" class="javax.swing.JRadioButton" default-binding="true">
+        <constraints>
+          <grid row="2" column="4" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <name value="enclosureBacktick"/>
+          <text value="`"/>
+        </properties>
+      </component>
     </children>
   </grid>
   <buttonGroups>
@@ -201,6 +211,7 @@
       <member id="2d597"/>
       <member id="bf7aa"/>
       <member id="5bc1d"/>
+      <member id="5602b"/>
     </group>
   </buttonGroups>
 </form>

--- a/src/main/java/com/fwdekker/randomness/word/WordSettingsDialog.form
+++ b/src/main/java/com/fwdekker/randomness/word/WordSettingsDialog.form
@@ -99,35 +99,6 @@
           <text value="Capitalization"/>
         </properties>
       </component>
-      <component id="85d22" class="javax.swing.JRadioButton" default-binding="true">
-        <constraints>
-          <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <actionCommand value="normal"/>
-          <name value="capitalizationNormal"/>
-          <text value="Normal"/>
-        </properties>
-      </component>
-      <component id="2d597" class="javax.swing.JRadioButton" default-binding="true">
-        <constraints>
-          <grid row="3" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <actionCommand value="upper"/>
-          <name value="capitalizationUpper"/>
-          <text value="UPPER"/>
-        </properties>
-      </component>
-      <component id="bf7aa" class="javax.swing.JRadioButton" default-binding="true">
-        <constraints>
-          <grid row="3" column="3" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <name value="capitalizationLower"/>
-          <text value="lower"/>
-        </properties>
-      </component>
       <scrollpane id="c5804">
         <constraints>
           <grid row="4" column="1" row-span="3" col-span="3" vsize-policy="7" hsize-policy="7" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -177,6 +148,45 @@
           <text value="Dictionaries"/>
         </properties>
       </component>
+      <component id="bf7aa" class="javax.swing.JRadioButton" default-binding="true">
+        <constraints>
+          <grid row="3" column="4" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <name value="capitalizationLower"/>
+          <text value="lower"/>
+        </properties>
+      </component>
+      <component id="2d597" class="javax.swing.JRadioButton" default-binding="true">
+        <constraints>
+          <grid row="3" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <actionCommand value="upper"/>
+          <name value="capitalizationUpper"/>
+          <text value="UPPER"/>
+        </properties>
+      </component>
+      <component id="85d22" class="javax.swing.JRadioButton" default-binding="true">
+        <constraints>
+          <grid row="3" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <actionCommand value="normal"/>
+          <name value="capitalizationNormal"/>
+          <text value="Normal"/>
+        </properties>
+      </component>
+      <component id="5bc1d" class="javax.swing.JRadioButton" default-binding="true">
+        <constraints>
+          <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <actionCommand value="retain"/>
+          <name value="capitalizationRetain"/>
+          <text value="RETaiN"/>
+        </properties>
+      </component>
     </children>
   </grid>
   <buttonGroups>
@@ -190,6 +200,7 @@
       <member id="85d22"/>
       <member id="2d597"/>
       <member id="bf7aa"/>
+      <member id="5bc1d"/>
     </group>
   </buttonGroups>
 </form>

--- a/src/main/java/com/fwdekker/randomness/word/WordSettingsDialog.java
+++ b/src/main/java/com/fwdekker/randomness/word/WordSettingsDialog.java
@@ -17,7 +17,6 @@ import javax.swing.ButtonGroup;
 import javax.swing.JButton;
 import javax.swing.JComponent;
 import javax.swing.JPanel;
-import javax.swing.JRadioButton;
 import javax.swing.event.ListSelectionEvent;
 import java.util.Optional;
 import java.util.stream.Collectors;

--- a/src/main/java/com/fwdekker/randomness/word/WordSettingsDialog.java
+++ b/src/main/java/com/fwdekker/randomness/word/WordSettingsDialog.java
@@ -17,6 +17,7 @@ import javax.swing.ButtonGroup;
 import javax.swing.JButton;
 import javax.swing.JComponent;
 import javax.swing.JPanel;
+import javax.swing.JRadioButton;
 import javax.swing.event.ListSelectionEvent;
 import java.util.Optional;
 import java.util.stream.Collectors;

--- a/src/test/java/com/fwdekker/randomness/word/CapitalizationModeTest.java
+++ b/src/test/java/com/fwdekker/randomness/word/CapitalizationModeTest.java
@@ -1,7 +1,8 @@
 package com.fwdekker.randomness.word;
 
-import java.util.NoSuchElementException;
 import org.junit.Test;
+
+import java.util.NoSuchElementException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -11,6 +12,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * Unit tests for {@link CapitalizationMode}.
  */
 public final class CapitalizationModeTest {
+    @Test
+    public void testRetainTransform() {
+        assertThat(CapitalizationMode.RETAIN.getTransform().apply("AwfJYzzUoR")).isEqualTo("AwfJYzzUoR");
+    }
+
     @Test
     public void testNormalTransformEmptyString() {
         assertThat(CapitalizationMode.NORMAL.getTransform().apply("")).isEqualTo("");
@@ -32,6 +38,11 @@ public final class CapitalizationModeTest {
     }
 
     @Test
+    public void testGetNameRetain() {
+        assertThat(CapitalizationMode.RETAIN.getName()).isEqualTo("retain");
+    }
+
+    @Test
     public void testGetNameNormal() {
         assertThat(CapitalizationMode.NORMAL.getName()).isEqualTo("normal");
     }
@@ -47,6 +58,11 @@ public final class CapitalizationModeTest {
     }
 
     @Test
+    public void testToStringRetain() {
+        assertThat(CapitalizationMode.RETAIN.toString()).isEqualTo("retain");
+    }
+
+    @Test
     public void testToStringNormal() {
         assertThat(CapitalizationMode.NORMAL.toString()).isEqualTo("normal");
     }
@@ -59,6 +75,11 @@ public final class CapitalizationModeTest {
     @Test
     public void testToStringLower() {
         assertThat(CapitalizationMode.LOWER.toString()).isEqualTo("lower");
+    }
+
+    @Test
+    public void testGetModeRetain() {
+        assertThat(CapitalizationMode.getMode("retain")).isEqualTo(CapitalizationMode.RETAIN);
     }
 
     @Test

--- a/src/test/java/com/fwdekker/randomness/word/CapitalizationModeTest.java
+++ b/src/test/java/com/fwdekker/randomness/word/CapitalizationModeTest.java
@@ -18,13 +18,13 @@ public final class CapitalizationModeTest {
     }
 
     @Test
-    public void testNormalTransformEmptyString() {
-        assertThat(CapitalizationMode.NORMAL.getTransform().apply("")).isEqualTo("");
+    public void testSentenceTransformEmptyString() {
+        assertThat(CapitalizationMode.SENTENCE.getTransform().apply("")).isEqualTo("");
     }
 
     @Test
-    public void testNormalTransform() {
-        assertThat(CapitalizationMode.NORMAL.getTransform().apply("cOoKiE")).isEqualTo("Cookie");
+    public void testSentenceTransform() {
+        assertThat(CapitalizationMode.SENTENCE.getTransform().apply("cOoKiE")).isEqualTo("Cookie");
     }
 
     @Test
@@ -43,8 +43,8 @@ public final class CapitalizationModeTest {
     }
 
     @Test
-    public void testGetNameNormal() {
-        assertThat(CapitalizationMode.NORMAL.getName()).isEqualTo("normal");
+    public void testGetNameSentence() {
+        assertThat(CapitalizationMode.SENTENCE.getName()).isEqualTo("sentence");
     }
 
     @Test
@@ -63,8 +63,8 @@ public final class CapitalizationModeTest {
     }
 
     @Test
-    public void testToStringNormal() {
-        assertThat(CapitalizationMode.NORMAL.toString()).isEqualTo("normal");
+    public void testToStringSentence() {
+        assertThat(CapitalizationMode.SENTENCE.toString()).isEqualTo("sentence");
     }
 
     @Test
@@ -83,8 +83,8 @@ public final class CapitalizationModeTest {
     }
 
     @Test
-    public void testGetModeNormal() {
-        assertThat(CapitalizationMode.getMode("normal")).isEqualTo(CapitalizationMode.NORMAL);
+    public void testGetModeSentence() {
+        assertThat(CapitalizationMode.getMode("sentence")).isEqualTo(CapitalizationMode.SENTENCE);
     }
 
     @Test

--- a/src/test/java/com/fwdekker/randomness/word/CapitalizationModeTest.java
+++ b/src/test/java/com/fwdekker/randomness/word/CapitalizationModeTest.java
@@ -38,6 +38,11 @@ public final class CapitalizationModeTest {
     }
 
     @Test
+    public void testFirstLetterTransform() {
+        assertThat(CapitalizationMode.FIRST_LETTER.getTransform().apply("bgiOP SMQpR")).isEqualTo("Bgiop Smqpr");
+    }
+
+    @Test
     public void testGetNameRetain() {
         assertThat(CapitalizationMode.RETAIN.getName()).isEqualTo("retain");
     }
@@ -55,6 +60,11 @@ public final class CapitalizationModeTest {
     @Test
     public void testGetNameLower() {
         assertThat(CapitalizationMode.LOWER.getName()).isEqualTo("lower");
+    }
+
+    @Test
+    public void testGetNameFirstLetter() {
+        assertThat(CapitalizationMode.FIRST_LETTER.getName()).isEqualTo("first letter");
     }
 
     @Test
@@ -78,6 +88,11 @@ public final class CapitalizationModeTest {
     }
 
     @Test
+    public void testToStringFirstLetter() {
+        assertThat(CapitalizationMode.FIRST_LETTER.toString()).isEqualTo("first letter");
+    }
+
+    @Test
     public void testGetModeRetain() {
         assertThat(CapitalizationMode.getMode("retain")).isEqualTo(CapitalizationMode.RETAIN);
     }
@@ -95,6 +110,11 @@ public final class CapitalizationModeTest {
     @Test
     public void testGetModeLower() {
         assertThat(CapitalizationMode.getMode("lower")).isEqualTo(CapitalizationMode.LOWER);
+    }
+
+    @Test
+    public void testGetModeFirstLetter() {
+        assertThat(CapitalizationMode.getMode("first letter")).isEqualTo(CapitalizationMode.FIRST_LETTER);
     }
 
     @Test

--- a/src/test/java/com/fwdekker/randomness/word/WordSettingsDialogTest.java
+++ b/src/test/java/com/fwdekker/randomness/word/WordSettingsDialogTest.java
@@ -2,13 +2,14 @@ package com.fwdekker.randomness.word;
 
 import com.fwdekker.randomness.ui.JEditableList;
 import com.intellij.openapi.ui.ValidationInfo;
-import java.io.File;
 import org.assertj.swing.edt.GuiActionRunner;
 import org.assertj.swing.finder.JFileChooserFinder;
 import org.assertj.swing.fixture.FrameFixture;
 import org.assertj.swing.junit.testcase.AssertJSwingJUnitTestCase;
 import org.junit.Ignore;
 import org.junit.Test;
+
+import java.io.File;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.swing.fixture.Containers.showInFrame;
@@ -68,7 +69,9 @@ public final class WordSettingsDialogTest extends AssertJSwingJUnitTestCase {
 
     @Test
     public void testLoadSettingsCapitalization() {
-        frame.radioButton("capitalizationNormal").requireSelected();
+        frame.radioButton("capitalizationRetain").requireSelected();
+        frame.radioButton("capitalizationSentence").requireNotSelected();
+        frame.radioButton("capitalizationFirstLetter").requireNotSelected();
         frame.radioButton("capitalizationUpper").requireNotSelected();
         frame.radioButton("capitalizationLower").requireNotSelected();
     }
@@ -91,7 +94,7 @@ public final class WordSettingsDialogTest extends AssertJSwingJUnitTestCase {
     public void testAddDictionaryDuplicate() {
         GuiActionRunner.execute(() -> dialogDictionaries
                 .addEntry(Dictionary.UserDictionary.get(getDictionaryFile("dictionaries/simple.dic")
-                                                                .getCanonicalPath())));
+                        .getCanonicalPath())));
 
         frame.button("dictionaryAdd").click();
         JFileChooserFinder.findFileChooser().using(robot())
@@ -117,7 +120,7 @@ public final class WordSettingsDialogTest extends AssertJSwingJUnitTestCase {
     public void testRemoveUserDictionary() {
         GuiActionRunner.execute(() -> {
             dialogDictionaries.addEntry(Dictionary.UserDictionary.get(getDictionaryFile("dictionaries/simple.dic")
-                                                                              .getCanonicalPath()));
+                    .getCanonicalPath()));
             frame.table("dictionaries").target().clearSelection();
             frame.table("dictionaries").target().addRowSelectionInterval(1, 1);
             frame.button("dictionaryRemove").target().doClick();


### PR DESCRIPTION
Fixes #61 and #62 by adding two new capitalisation rules:
* `First letter`: Capitalise The First Letter Of Each Word
* `Retain`: dO NoT ChAnGe The CapiTALIsatioN

Furthermore:
* The capitalisation mode `Normal` was renamed to `Sentence` to better explain its meaning.
* The default mode was changed from `Sentence` to `Retain`.
