### PR TITLE
Dictionary fixes

### DIFF
--- a/src/main/java/com/fwdekker/randomness/word/Dictionary.java
+++ b/src/main/java/com/fwdekker/randomness/word/Dictionary.java
@@ -3,6 +3,7 @@ package com.fwdekker.randomness.word;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -16,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 
@@ -29,9 +31,13 @@ public abstract class Dictionary {
     public static final String DEFAULT_DICTIONARY_FILE = "words_alpha.dic";
 
     /**
-     * The filename of the dictionary file.
+     * The unique identifier of the dictionary.
      */
-    private final String path;
+    private final String uid;
+    /**
+     * The human-readable name of the dictionary.
+     */
+    private final String name;
     /**
      * A set of all words in the dictionary.
      */
@@ -42,23 +48,24 @@ public abstract class Dictionary {
      * Constructs an empty {@code Dictionary}.
      */
     private Dictionary() {
-        path = "";
+        uid = UUID.randomUUID().toString();
+        name = uid;
         words = new HashSet<>();
     }
 
     /**
      * Constructs a new {@code Dictionary} from the given resource file.
      *
-     * @param path the filename of the dictionary file
+     * @param uid   the unique identifier of the dictionary
+     * @param name  the human-readable name of the dictionary
+     * @param input the {@code InputStream} containing the dictionary's contents
      */
-    private Dictionary(final String path) {
-        this.path = path;
+    private Dictionary(final String uid, final String name, final InputStream input) {
+        this.uid = uid;
+        this.name = name;
 
-        // Read dictionary into memory
-        try (InputStream iStream = getInputStream(path)) {
-            final BufferedReader reader = new BufferedReader(new InputStreamReader(iStream, StandardCharsets.UTF_8));
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(input, StandardCharsets.UTF_8))) {
             words = reader.lines().collect(Collectors.toSet());
-            reader.close();
         } catch (final IOException e) {
             throw new IllegalArgumentException("Failed to read dictionary into memory.", e);
         }
@@ -70,24 +77,21 @@ public abstract class Dictionary {
 
 
     /**
-     * Returns an {@link InputStream} for the given dictionary file.
-     * <p>
-     * Different kinds of dictionaries may need a different method of accessing the source file.
+     * Returns the unique identifier of the dictionary.
      *
-     * @param dictionary the location of the dictionary file
-     * @return an {@link InputStream} for the given dictionary file
-     * @throws IOException if the dictionary file could not be read
+     * @return the unique identifier of the dictionary
      */
-    protected abstract InputStream getInputStream(String dictionary) throws IOException;
-
+    public final String getUid() {
+        return uid;
+    }
 
     /**
-     * Returns the filename of the dictionary file.
+     * Returns the human-readable name of the dictionary.
      *
-     * @return the filename of the dictionary file
+     * @return the human-readable name of the dictionary
      */
-    public final String getPath() {
-        return path;
+    public final String getName() {
+        return name;
     }
 
     /**
@@ -160,12 +164,12 @@ public abstract class Dictionary {
         }
 
         final Dictionary that = (Dictionary) other;
-        return Objects.equals(this.path, that.path);
+        return Objects.equals(this.uid, that.uid);
     }
 
     @Override
     public final int hashCode() {
-        return Objects.hash(path);
+        return Objects.hash(uid);
     }
 
 
@@ -184,28 +188,34 @@ public abstract class Dictionary {
         /**
          * Constructs a new {@link BundledDictionary} for the given dictionary resource.
          *
-         * @param dictionary the location of the dictionary resource
+         * @param path the path to the dictionary resource
          */
-        private BundledDictionary(final String dictionary) {
-            super(dictionary);
+        private BundledDictionary(final String path) {
+            super(path, new File(path).getName(), getInputStream(path));
         }
 
         /**
          * Constructs a new {@code BundledDictionary} for the given dictionary resource, or returns the previously
          * created instance of this resource if there is one.
          *
-         * @param dictionary the location of the dictionary resource
+         * @param path the path to the dictionary resource
          * @return a new {@code BundledDictionary} for the given dictionary resource, or returns the previously
          * created instance of this resource if there is one
          */
-        public static BundledDictionary get(final String dictionary) {
+        public static BundledDictionary get(final String path) {
             synchronized (BundledDictionary.class) {
-                if (!CACHE.containsKey(dictionary)) {
-                    CACHE.put(dictionary, new BundledDictionary(dictionary));
+                if (!CACHE.containsKey(path)) {
+                    CACHE.put(path, new BundledDictionary(path));
                 }
             }
 
-            return CACHE.get(dictionary);
+            return CACHE.get(path);
+        }
+
+
+        @Override
+        public String toString() {
+            return "[bundled] " + new File(getUid()).getName();
         }
 
 
@@ -215,14 +225,8 @@ public abstract class Dictionary {
          * @param dictionary the location of the dictionary resource
          * @return an {@link InputStream} to the given dictionary resource
          */
-        @Override
-        protected InputStream getInputStream(final String dictionary) {
+        private static InputStream getInputStream(final String dictionary) {
             return Dictionary.class.getClassLoader().getResourceAsStream(dictionary);
-        }
-
-        @Override
-        public String toString() {
-            return "[bundled] " + new File(getPath()).getName();
         }
     }
 
@@ -239,28 +243,34 @@ public abstract class Dictionary {
         /**
          * Constructs a new {@code UserDictionary} for the given dictionary file.
          *
-         * @param dictionary the location of the dictionary file
+         * @param path the absolute path to the dictionary file
          */
-        private UserDictionary(final String dictionary) {
-            super(dictionary);
+        private UserDictionary(final String path) {
+            super(path, new File(path).getName(), getInputStream(path));
         }
 
         /**
          * Constructs a new {@code UserDictionary} for the given dictionary file, or returns the previously created
          * instance of this file if there is one.
          *
-         * @param dictionary the location of the dictionary file
+         * @param path the absolute path to the dictionary file
          * @return a new {@code UserDictionary} for the given dictionary file, or returns the previously created
          * instance of this file if there is one
          */
-        public static UserDictionary get(final String dictionary) {
+        public static UserDictionary get(final String path) {
             synchronized (UserDictionary.class) {
-                if (!CACHE.containsKey(dictionary)) {
-                    CACHE.put(dictionary, new UserDictionary(dictionary));
+                if (!CACHE.containsKey(path)) {
+                    CACHE.put(path, new UserDictionary(path));
                 }
             }
 
-            return CACHE.get(dictionary);
+            return CACHE.get(path);
+        }
+
+
+        @Override
+        public String toString() {
+            return "[custom] " + getName();
         }
 
 
@@ -271,14 +281,12 @@ public abstract class Dictionary {
          * @return an {@link InputStream} of the file at the given absolute path
          * @throws IOException if the given file could not be found
          */
-        @Override
-        protected InputStream getInputStream(final String dictionary) throws IOException {
-            return new FileInputStream(dictionary);
-        }
-
-        @Override
-        public String toString() {
-            return "[custom] " + new File(getPath()).getName();
+        private static InputStream getInputStream(final String dictionary) {
+            try {
+                return new FileInputStream(dictionary);
+            } catch (final FileNotFoundException e) {
+                throw new IllegalArgumentException("Failed to read dictionary into memory.", e);
+            }
         }
     }
 
@@ -291,18 +299,6 @@ public abstract class Dictionary {
          */
         SimpleDictionary() {
             super();
-        }
-
-
-        /**
-         * Throws {@link IllegalStateException}.
-         *
-         * @param dictionary ignored
-         * @return never
-         */
-        @Override
-        protected InputStream getInputStream(final String dictionary) {
-            throw new IllegalStateException("This method should not be called.");
         }
     }
 }

--- a/src/main/java/com/fwdekker/randomness/word/Dictionary.java
+++ b/src/main/java/com/fwdekker/randomness/word/Dictionary.java
@@ -141,7 +141,7 @@ public abstract class Dictionary {
      * @param dictionaries the {@code Dictionary Dictionary(s)} to combine
      * @return a {@code Dictionary} containing all words in the given {@code Dictionary Dictionary(s)}
      */
-    public static final Dictionary combine(final Collection<Dictionary> dictionaries) {
+    public static Dictionary combine(final Collection<Dictionary> dictionaries) {
         final Dictionary combinedDictionary = new SimpleDictionary();
 
         dictionaries.forEach(dictionary -> combinedDictionary.words.addAll(dictionary.words));

--- a/src/main/java/com/fwdekker/randomness/word/Dictionary.java
+++ b/src/main/java/com/fwdekker/randomness/word/Dictionary.java
@@ -234,7 +234,7 @@ public abstract class Dictionary {
             try {
                 getInputStream(getUid());
             } catch (final IllegalArgumentException e) {
-                return new ValidationInfo("The dictionary resource for " + getName() + " does not exist.");
+                return new ValidationInfo("The dictionary resource for " + getName() + " no longer exists.");
             }
 
             return null;
@@ -299,7 +299,7 @@ public abstract class Dictionary {
         public ValidationInfo validate() {
             final File file = new File(getUid());
             if (!file.exists()) {
-                return new ValidationInfo("The dictionary file for " + getName() + " does not exist.");
+                return new ValidationInfo("The dictionary file for " + getName() + " no longer exists.");
             }
             if (!file.canRead()) {
                 return new ValidationInfo("The dictionary file for " + getName() + " exists, but could not be read.");

--- a/src/main/java/com/fwdekker/randomness/word/WordSettingsDialog.java
+++ b/src/main/java/com/fwdekker/randomness/word/WordSettingsDialog.java
@@ -18,6 +18,7 @@ import javax.swing.JButton;
 import javax.swing.JComponent;
 import javax.swing.JPanel;
 import javax.swing.event.ListSelectionEvent;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -132,11 +133,19 @@ final class WordSettingsDialog extends SettingsDialog<WordSettings> {
     @Override
     @Nullable
     protected ValidationInfo doValidate() {
-        try {
-            if (dictionaries.getActiveEntries().isEmpty()) {
-                throw new ValidationException("Select at least one dictionary.", dictionaries);
-            }
+        if (dictionaries.getActiveEntries().isEmpty()) {
+            return new ValidationInfo("Select at least one dictionary.", dictionaries);
+        }
 
+        final Optional<ValidationInfo> invalidDictionary = dictionaries.getActiveEntries().stream()
+                .map(Dictionary::validate)
+                .filter(Objects::nonNull)
+                .findFirst();
+        if (invalidDictionary.isPresent()) {
+            return new ValidationInfo(invalidDictionary.get().message, dictionaries);
+        }
+
+        try {
             minLength.validateValue();
             maxLength.validateValue();
             lengthRange.validate();

--- a/src/main/java/com/fwdekker/randomness/word/WordSettingsDialog.java
+++ b/src/main/java/com/fwdekker/randomness/word/WordSettingsDialog.java
@@ -113,19 +113,19 @@ final class WordSettingsDialog extends SettingsDialog<WordSettings> {
 
         settings.setBundledDictionaries(dictionaries.getEntries().stream()
                 .filter(Dictionary.BundledDictionary.class::isInstance)
-                .map(Dictionary::getPath)
+                .map(Dictionary::getUid)
                 .collect(Collectors.toSet()));
         settings.setActiveBundledDictionaries(dictionaries.getActiveEntries().stream()
                 .filter(Dictionary.BundledDictionary.class::isInstance)
-                .map(Dictionary::getPath)
+                .map(Dictionary::getUid)
                 .collect(Collectors.toSet()));
         settings.setUserDictionaries(dictionaries.getEntries().stream()
                 .filter(Dictionary.UserDictionary.class::isInstance)
-                .map(Dictionary::getPath)
+                .map(Dictionary::getUid)
                 .collect(Collectors.toSet()));
         settings.setActiveUserDictionaries(dictionaries.getActiveEntries().stream()
                 .filter(Dictionary.UserDictionary.class::isInstance)
-                .map(Dictionary::getPath)
+                .map(Dictionary::getUid)
                 .collect(Collectors.toSet()));
     }
 

--- a/src/test/java/com/fwdekker/randomness/word/BundledDictionaryTest.java
+++ b/src/test/java/com/fwdekker/randomness/word/BundledDictionaryTest.java
@@ -1,0 +1,37 @@
+package com.fwdekker.randomness.word;
+
+import com.intellij.openapi.ui.ValidationInfo;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+
+/**
+ * Unit tests for {@link Dictionary.BundledDictionary}.
+ */
+public final class BundledDictionaryTest {
+    @Test
+    public void testConstructorDoesNotExist() {
+        assertThatThrownBy(() -> Dictionary.BundledDictionary.get("invalid resource"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Failed to read dictionary into memory.")
+                .hasNoCause();
+    }
+
+    @Test
+    public void testValidateSuccess() {
+        final Dictionary dictionary = Dictionary.BundledDictionary.get("dictionaries/simple.dic");
+
+        final ValidationInfo validationInfo = dictionary.validate();
+
+        assertThat(validationInfo).isNull();
+    }
+
+    @Test
+    public void testToString() {
+        final Dictionary dictionary = Dictionary.BundledDictionary.get("dictionaries/simple.dic");
+
+        assertThat(dictionary.toString()).isEqualTo("[bundled] simple.dic");
+    }
+}

--- a/src/test/java/com/fwdekker/randomness/word/DictionaryTest.java
+++ b/src/test/java/com/fwdekker/randomness/word/DictionaryTest.java
@@ -1,9 +1,10 @@
 package com.fwdekker.randomness.word;
 
-import java.io.IOException;
-import java.util.Arrays;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -37,7 +38,7 @@ public final class DictionaryTest {
     public void testGetPath() {
         useDictionary("simple");
 
-        assertThat(dictionary.getPath())
+        assertThat(dictionary.getUid())
                 .isEqualTo("dictionaries/simple.dic");
     }
 
@@ -166,7 +167,7 @@ public final class DictionaryTest {
     public void testEqualsContract() {
         EqualsVerifier.forClass(Dictionary.class)
                 .usingGetClass()
-                .withIgnoredFields("words")
+                .withIgnoredFields("name", "words")
                 .verify();
     }
 

--- a/src/test/java/com/fwdekker/randomness/word/DictionaryTest.java
+++ b/src/test/java/com/fwdekker/randomness/word/DictionaryTest.java
@@ -3,7 +3,6 @@ package com.fwdekker.randomness.word;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Test;
 
-import java.io.IOException;
 import java.util.Arrays;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -23,14 +22,6 @@ public final class DictionaryTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Dictionary must be non-empty.")
                 .hasNoCause();
-    }
-
-    @Test
-    public void testInvalidFile() {
-        assertThatThrownBy(() -> Dictionary.UserDictionary.get("invalid_file"))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Failed to read dictionary into memory.")
-                .hasCauseInstanceOf(IOException.class);
     }
 
 
@@ -149,7 +140,7 @@ public final class DictionaryTest {
 
         assertThat(combined.getWords())
                 .containsExactlyInAnyOrder("a", "the", "dog", "woof", "cat", "meow", "simplicity", "bend",
-                                           "consideration", "pneumonoultramicroscopicsilicovolcanoconiosis");
+                        "consideration", "pneumonoultramicroscopicsilicovolcanoconiosis");
     }
 
     @Test

--- a/src/test/java/com/fwdekker/randomness/word/UserDictionaryTest.java
+++ b/src/test/java/com/fwdekker/randomness/word/UserDictionaryTest.java
@@ -1,0 +1,95 @@
+package com.fwdekker.randomness.word;
+
+import com.intellij.openapi.ui.ValidationInfo;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.util.logging.Logger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
+
+
+/**
+ * Unit tests for {@link Dictionary.UserDictionary}.
+ */
+public final class UserDictionaryTest {
+    private File dictionaryFile;
+    private Dictionary dictionary;
+
+
+    @Before
+    public void beforeEach() throws IOException {
+        dictionaryFile = new File("test/test.dic");
+        if (!dictionaryFile.getParentFile().mkdirs()) {
+            fail("Failed to set up test directory.");
+        }
+        if (!dictionaryFile.createNewFile()) {
+            fail("Failed to set up test file.");
+        }
+
+        createDictionary(dictionaryFile, "Spanners\nHeralds\nTree");
+    }
+
+    @After
+    public void afterEach() {
+        if (!dictionaryFile.delete() || !dictionaryFile.getParentFile().delete()) {
+            Logger.getLogger(getClass().getName()).warning("Failed to clean up test directory.");
+        }
+    }
+
+
+    @Test
+    public void testInvalidFile() {
+        assertThatThrownBy(() -> Dictionary.UserDictionary.get("invalid_file"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Failed to read dictionary into memory.")
+                .hasCauseInstanceOf(IOException.class);
+    }
+
+    @Test
+    public void testValidateSuccess() {
+        dictionary = Dictionary.UserDictionary.get(dictionaryFile.getAbsolutePath());
+
+        final ValidationInfo validationInfo = dictionary.validate();
+
+        assertThat(validationInfo).isNull();
+    }
+
+    @Test
+    public void testValidateFileDoesNotExist() {
+        dictionary = Dictionary.UserDictionary.get(dictionaryFile.getAbsolutePath());
+
+        if (!dictionaryFile.delete()) {
+            fail("Failed to delete test file as part of test.");
+        }
+
+        final ValidationInfo validationInfo = dictionary.validate();
+
+        assertThat(validationInfo).isNotNull();
+        assertThat(validationInfo.message).isEqualTo("The dictionary file for test.dic does not exist.");
+        assertThat(validationInfo.component).isNull();
+    }
+
+    @Test
+    public void testToString() {
+        dictionary = Dictionary.UserDictionary.get(dictionaryFile.getAbsolutePath());
+
+        assertThat(dictionary.toString()).isEqualTo("[custom] test.dic");
+    }
+
+
+    private void createDictionary(final File target, final String contents) throws IOException {
+        try (Writer writer = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(target), "utf-8"))) {
+            writer.write(contents);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #69 and implements part of the proposal in #65.

In particular, this PR
* Restructures the `Dictionary` class so that imlementations no longer need to work with files. As long as they can provide an `InputStream` to the dictionary content it's OK.
* Adds a `validate` method to `Dictionary` and co. that returns a `ValidationInfo`, similar to how other UI components do that. Admittedly, `ValidationInfo` may not have been the most suitable class semantically, but it does exactly what I want.
* Integrates this check into the word dialog.

Essentially, this PR makes sure that invalid dictionaries cannot be saved in the dialog, and progresses towards the other points proposed in #65.
