### PR TITLE
Set up Codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,10 @@ before_script:
   - sleep 3 # give xvfb some time to start
 
 script:
-  - ./gradlew check codacyUpload
+  - ./gradlew check
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)
 
 # Caching
 before_cache:


### PR DESCRIPTION
Replaces [Codacy](https://codacy.com/) with [Codecov](https://codecov.io/) because all Codacy does is performing checks that are already done by Gradle plugins and tracking coverage, which Codecov also does but with nice comments and the cool sunburst.