### PR TITLE
Dictionary dialog fixes

### DIFF
--- a/src/main/java/com/fwdekker/randomness/ui/JBPopupHelper.java
+++ b/src/main/java/com/fwdekker/randomness/ui/JBPopupHelper.java
@@ -1,5 +1,6 @@
 package com.fwdekker.randomness.ui;
 
+import com.intellij.openapi.ui.popup.JBPopupFactory;
 import com.intellij.ui.popup.list.ListPopupImpl;
 import com.intellij.ui.speedSearch.SpeedSearch;
 
@@ -123,5 +124,25 @@ public final class JBPopupHelper {
                                 popup.handleSelect(true, keyEvent);
                             }
                         }));
+    }
+
+    /**
+     * Displays a popup with a title and two messages.
+     *
+     * @param title    the title of the popup
+     * @param messageA the first message
+     * @param messageB the second message
+     */
+    public static void showMessagePopup(final String title, final String messageA, final String messageB) {
+        final Runnable nop = () -> {
+        };
+
+        JBPopupFactory.getInstance().createConfirmation(
+                title,
+                messageA,
+                messageB,
+                nop,
+                1
+        ).showInFocusCenter();
     }
 }

--- a/src/main/java/com/fwdekker/randomness/word/Dictionary.java
+++ b/src/main/java/com/fwdekker/randomness/word/Dictionary.java
@@ -212,7 +212,7 @@ public abstract class Dictionary {
 
         /**
          * Constructs a new {@code BundledDictionary} for the given dictionary resource, or returns the previously
-         * created instance of this resource if there is one.
+         * created instance for this resource if there is one.
          *
          * @param path the path to the dictionary resource
          * @return a new {@code BundledDictionary} for the given dictionary resource, or returns the previously
@@ -228,14 +228,22 @@ public abstract class Dictionary {
             return CACHE.get(path);
         }
 
+        /**
+         * Constructs a new {@code BundledDictionary} for each of the given dictionary resources, or returns the
+         * previously created instance for a resource if there is one.
+         *
+         * @param paths the paths to the dictionary resources
+         * @return a new {@code BundledDictionary} for each of the given dictionary resources, or returns the
+         * previously created instance for a resource if there is one
+         */
+        public static List<BundledDictionary> get(final Collection<String> paths) {
+            return paths.stream().map(BundledDictionary::get).collect(Collectors.toList());
+        }
+
 
         @Override
         public ValidationInfo validate() {
-            if (getInputStream(getUid()) == null) {
-                return new ValidationInfo("The dictionary resource for " + getName() + " no longer exists.");
-            }
-
-            return null;
+            return validate(getUid());
         }
 
         @Override
@@ -243,6 +251,36 @@ public abstract class Dictionary {
             return "[bundled] " + getName();
         }
 
+
+        /**
+         * Detects whether the dictionary at the given resource would be valid.
+         *
+         * @param path the path to the dictionary resource
+         * @return {@code null} if the dictionary would be valid, or a {@code ValidationInfo} explaining why it would be
+         * invalid
+         */
+        public static ValidationInfo validate(final String path) {
+            if (getInputStream(path) == null) {
+                final String name = new File(path).getName();
+                return new ValidationInfo("The dictionary resource for " + name + " no longer exists.");
+            }
+
+            return null;
+        }
+
+        /**
+         * Detects whether the dictionaries at the given resources would be valid.
+         *
+         * @param paths the paths to the dictionary resources
+         * @return {@code null} if all dictionaries would be valid, or a {@code ValidationInfo} explaining why they
+         * would be invalid
+         */
+        public static ValidationInfo validate(final Collection<String> paths) {
+            return paths.stream().map(BundledDictionary::validate)
+                    .filter(Objects::nonNull)
+                    .findFirst()
+                    .orElse(null);
+        }
 
         /**
          * Returns an {@link InputStream} to the given dictionary resource.
@@ -275,11 +313,11 @@ public abstract class Dictionary {
         }
 
         /**
-         * Constructs a new {@code UserDictionary} for the given dictionary file, or returns the previously created
-         * instance of this file if there is one.
+         * Constructs a new {@code UserDictionary} for the given dictionary path, or returns the previously created
+         * instance for the file if there is one.
          *
          * @param path the absolute path to the dictionary file
-         * @return a new {@code UserDictionary} for the given dictionary file, or returns the previously created
+         * @return a new {@code UserDictionary} for the given dictionary path, or returns the previously created
          * instance of this file if there is one
          */
         public static UserDictionary get(final String path) {
@@ -292,18 +330,22 @@ public abstract class Dictionary {
             return CACHE.get(path);
         }
 
+        /**
+         * Constructs a new {@code UserDictionary} for each of the given dictionary paths, or returns the previously
+         * created instance for a file if there is one.
+         *
+         * @param paths the absolute paths to the dictionary files
+         * @return a new {@code UserDictionary} for each of the given dictionary paths, or returns the previously
+         * created instance for a file if there is one
+         */
+        public static List<UserDictionary> get(final Collection<String> paths) {
+            return paths.stream().map(UserDictionary::get).collect(Collectors.toList());
+        }
+
 
         @Override
         public ValidationInfo validate() {
-            final File file = new File(getUid());
-            if (!file.exists()) {
-                return new ValidationInfo("The dictionary file for " + getName() + " no longer exists.");
-            }
-            if (!file.canRead()) {
-                return new ValidationInfo("The dictionary file for " + getName() + " exists, but could not be read.");
-            }
-
-            return null;
+            return validate(getUid());
         }
 
         @Override
@@ -311,6 +353,41 @@ public abstract class Dictionary {
             return "[custom] " + getName();
         }
 
+
+        /**
+         * Detects whether the dictionary at the given path would be valid.
+         *
+         * @param path the absolute path to the dictionary file
+         * @return {@code null} if the dictionary would be valid, or a {@code ValidationInfo} explaining why it would be
+         * invalid
+         */
+        public static ValidationInfo validate(final String path) {
+            final File file = new File(path);
+            final String name = file.getName();
+
+            if (!file.exists()) {
+                return new ValidationInfo("The dictionary file for " + name + " no longer exists.");
+            }
+            if (!file.canRead()) {
+                return new ValidationInfo("The dictionary file for " + name + " exists, but could not be read.");
+            }
+
+            return null;
+        }
+
+        /**
+         * Detects whether the dictionaries at the given paths would be valid.
+         *
+         * @param paths the absolute paths to the dictionary files
+         * @return {@code null} if all dictionaries would be valid, or a {@code ValidationInfo} explaining why they
+         * would be invalid
+         */
+        public static ValidationInfo validate(final Collection<String> paths) {
+            return paths.stream().map(UserDictionary::validate)
+                    .filter(Objects::nonNull)
+                    .findFirst()
+                    .orElse(null);
+        }
 
         /**
          * Returns an {@link InputStream} of the file at the given absolute path.

--- a/src/main/java/com/fwdekker/randomness/word/Dictionary.java
+++ b/src/main/java/com/fwdekker/randomness/word/Dictionary.java
@@ -231,9 +231,7 @@ public abstract class Dictionary {
 
         @Override
         public ValidationInfo validate() {
-            try {
-                getInputStream(getUid());
-            } catch (final IllegalArgumentException e) {
+            if (getInputStream(getUid()) == null) {
                 return new ValidationInfo("The dictionary resource for " + getName() + " no longer exists.");
             }
 

--- a/src/main/java/com/fwdekker/randomness/word/Dictionary.java
+++ b/src/main/java/com/fwdekker/randomness/word/Dictionary.java
@@ -229,18 +229,6 @@ public abstract class Dictionary {
             return CACHE.get(path);
         }
 
-        /**
-         * Constructs a new {@code BundledDictionary} for each of the given dictionary resources, or returns the
-         * previously created instance for a resource if there is one.
-         *
-         * @param paths the paths to the dictionary resources
-         * @return a new {@code BundledDictionary} for each of the given dictionary resources, or returns the
-         * previously created instance for a resource if there is one
-         */
-        public static List<BundledDictionary> get(final Collection<String> paths) {
-            return paths.stream().map(BundledDictionary::get).collect(Collectors.toList());
-        }
-
 
         @Override
         public ValidationInfo validate() {
@@ -276,20 +264,6 @@ public abstract class Dictionary {
             }
 
             return null;
-        }
-
-        /**
-         * Detects whether the dictionaries at the given resources would be valid.
-         *
-         * @param paths the paths to the dictionary resources
-         * @return {@code null} if all dictionaries would be valid, or a {@code ValidationInfo} explaining why they
-         * would be invalid
-         */
-        public static ValidationInfo validate(final Collection<String> paths) {
-            return paths.stream().map(BundledDictionary::validate)
-                    .filter(Objects::nonNull)
-                    .findFirst()
-                    .orElse(null);
         }
 
         /**
@@ -340,18 +314,6 @@ public abstract class Dictionary {
             return CACHE.get(path);
         }
 
-        /**
-         * Constructs a new {@code UserDictionary} for each of the given dictionary paths, or returns the previously
-         * created instance for a file if there is one.
-         *
-         * @param paths the absolute paths to the dictionary files
-         * @return a new {@code UserDictionary} for each of the given dictionary paths, or returns the previously
-         * created instance for a file if there is one
-         */
-        public static List<UserDictionary> get(final Collection<String> paths) {
-            return paths.stream().map(UserDictionary::get).collect(Collectors.toList());
-        }
-
 
         @Override
         public ValidationInfo validate() {
@@ -390,20 +352,6 @@ public abstract class Dictionary {
             }
 
             return null;
-        }
-
-        /**
-         * Detects whether the dictionaries at the given paths would be valid.
-         *
-         * @param paths the absolute paths to the dictionary files
-         * @return {@code null} if all dictionaries would be valid, or a {@code ValidationInfo} explaining why they
-         * would be invalid
-         */
-        public static ValidationInfo validate(final Collection<String> paths) {
-            return paths.stream().map(UserDictionary::validate)
-                    .filter(Objects::nonNull)
-                    .findFirst()
-                    .orElse(null);
         }
 
         /**

--- a/src/main/java/com/fwdekker/randomness/word/WordInsertAction.java
+++ b/src/main/java/com/fwdekker/randomness/word/WordInsertAction.java
@@ -1,6 +1,8 @@
 package com.fwdekker.randomness.word;
 
 import com.fwdekker.randomness.DataInsertAction;
+import com.fwdekker.randomness.ui.JBPopupHelper;
+import com.intellij.openapi.ui.ValidationInfo;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
@@ -43,8 +45,27 @@ public final class WordInsertAction extends DataInsertAction {
      */
     @Override
     public String generateString() {
-        final List<String> words = Dictionary.combine(wordSettings.getActiveDictionaries())
+        final ValidationInfo validationInfo = wordSettings.validateActiveDictionaries();
+        if (validationInfo != null) {
+            JBPopupHelper.showMessagePopup(
+                    "Randomness error",
+                    validationInfo.message,
+                    "Please check your Randomness `word` settings."
+            );
+            return "";
+        }
+
+        final List<String> words = Dictionary.combine(wordSettings.getValidActiveDictionaries())
                 .getWordsWithLengthInRange(wordSettings.getMinLength(), wordSettings.getMaxLength());
+        if (words.isEmpty()) {
+            JBPopupHelper.showMessagePopup(
+                    "Randomness error",
+                    "There are no words compatible with the current settings.",
+                    "Please check your Randomness `word` settings."
+            );
+            return "";
+        }
+
         final int randomIndex = ThreadLocalRandom.current().nextInt(0, words.size());
         final String randomWord = wordSettings.getCapitalization().getTransform().apply(words.get(randomIndex));
 

--- a/src/main/java/com/fwdekker/randomness/word/WordSettings.java
+++ b/src/main/java/com/fwdekker/randomness/word/WordSettings.java
@@ -229,34 +229,6 @@ public final class WordSettings extends Settings implements PersistentStateCompo
 
 
     /**
-     * Returns the list of all dictionaries.
-     *
-     * @return the list of all dictionaries
-     */
-    public List<String> getDictionaries() {
-        final List<String> dictionaries = new ArrayList<>();
-
-        dictionaries.addAll(bundledDictionaries);
-        dictionaries.addAll(userDictionaries);
-
-        return dictionaries;
-    }
-
-    /**
-     * Returns the list of all dictionaries that are currently active.
-     *
-     * @return the list of all dictionaries that are currently active
-     */
-    public List<String> getActiveDictionaries() {
-        final List<String> dictionaries = new ArrayList<>();
-
-        dictionaries.addAll(activeBundledDictionaries);
-        dictionaries.addAll(activeUserDictionaries);
-
-        return dictionaries;
-    }
-
-    /**
      * Validates all dictionaries.
      *
      * @return {@code null} if all dictionaries are valid, or a {@code ValidationInfo} explaining why there is an

--- a/src/main/java/com/fwdekker/randomness/word/WordSettings.java
+++ b/src/main/java/com/fwdekker/randomness/word/WordSettings.java
@@ -11,6 +11,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
@@ -229,12 +230,15 @@ public final class WordSettings extends Settings implements PersistentStateCompo
 
 
     /**
-     * Validates all dictionaries.
+     * Validates all dictionaries in the given collections.
      *
+     * @param bundledDictionaries a list of {@code BundledDictionary}s
+     * @param userDictionaries    a list of {@code UserDictionary}s
      * @return {@code null} if all dictionaries are valid, or a {@code ValidationInfo} explaining why there is an
      * invalid dictionary
      */
-    public ValidationInfo validateDictionaries() {
+    private ValidationInfo validateDictionaries(final Collection<String> bundledDictionaries,
+                                                final Collection<String> userDictionaries) {
         final ValidationInfo bundledValidationInfo = bundledDictionaries.stream()
                 .map(Dictionary.BundledDictionary::validate)
                 .filter(Objects::nonNull)
@@ -250,10 +254,20 @@ public final class WordSettings extends Settings implements PersistentStateCompo
                 .findFirst()
                 .orElse(null);
         if (userValidationInfo != null) {
-            return bundledValidationInfo;
+            return userValidationInfo;
         }
 
         return null;
+    }
+
+    /**
+     * Validates all dictionaries.
+     *
+     * @return {@code null} if all dictionaries are valid, or a {@code ValidationInfo} explaining why there is an
+     * invalid dictionary
+     */
+    public ValidationInfo validateAllDictionaries() {
+        return validateDictionaries(bundledDictionaries, userDictionaries);
     }
 
     /**
@@ -263,33 +277,18 @@ public final class WordSettings extends Settings implements PersistentStateCompo
      * invalid dictionary
      */
     public ValidationInfo validateActiveDictionaries() {
-        final ValidationInfo bundledValidationInfo = activeBundledDictionaries.stream()
-                .map(Dictionary.BundledDictionary::validate)
-                .filter(Objects::nonNull)
-                .findFirst()
-                .orElse(null);
-        if (bundledValidationInfo != null) {
-            return bundledValidationInfo;
-        }
-
-        final ValidationInfo userValidationInfo = activeUserDictionaries.stream()
-                .map(Dictionary.UserDictionary::validate)
-                .filter(Objects::nonNull)
-                .findFirst()
-                .orElse(null);
-        if (userValidationInfo != null) {
-            return userValidationInfo;
-        }
-
-        return null;
+        return validateDictionaries(activeBundledDictionaries, activeUserDictionaries);
     }
 
     /**
-     * Returns the list of all dictionaries that are valid.
+     * Returns the list of all dictionaries in the given collections that are valid.
      *
-     * @return the list of all dictionaries that are valid
+     * @param bundledDictionaries a list of {@code BundledDictionary}s
+     * @param userDictionaries    a list of {@code UserDictionary}s
+     * @return the list of all dictionaries in the given lists that are valid
      */
-    public List<Dictionary> getValidDictionaries() {
+    private List<Dictionary> getValidDictionaries(final Collection<String> bundledDictionaries,
+                                                  final Collection<String> userDictionaries) {
         final List<Dictionary> dictionaries = new ArrayList<>();
 
         dictionaries.addAll(bundledDictionaries.stream()
@@ -305,22 +304,20 @@ public final class WordSettings extends Settings implements PersistentStateCompo
     }
 
     /**
+     * Returns the list of all dictionaries that are valid.
+     *
+     * @return the list of all dictionaries that are valid
+     */
+    public List<Dictionary> getValidAllDictionaries() {
+        return getValidDictionaries(bundledDictionaries, userDictionaries);
+    }
+
+    /**
      * Returns the list of all dictionaries that are valid and currently active.
      *
      * @return the list of all dictionaries that are valid and currently active
      */
     public List<Dictionary> getValidActiveDictionaries() {
-        final List<Dictionary> dictionaries = new ArrayList<>();
-
-        dictionaries.addAll(activeBundledDictionaries.stream()
-                .filter(dictionary -> Dictionary.BundledDictionary.validate(dictionary) == null)
-                .map(Dictionary.BundledDictionary::get)
-                .collect(Collectors.toList()));
-        dictionaries.addAll(activeUserDictionaries.stream()
-                .filter(dictionary -> Dictionary.UserDictionary.validate(dictionary) == null)
-                .map(Dictionary.UserDictionary::get)
-                .collect(Collectors.toList()));
-
-        return dictionaries;
+        return getValidDictionaries(activeBundledDictionaries, activeUserDictionaries);
     }
 }

--- a/src/main/java/com/fwdekker/randomness/word/WordSettingsDialog.form
+++ b/src/main/java/com/fwdekker/randomness/word/WordSettingsDialog.form
@@ -83,7 +83,7 @@
       </component>
       <scrollpane id="c5804">
         <constraints>
-          <grid row="4" column="1" row-span="3" col-span="3" vsize-policy="7" hsize-policy="7" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="4" column="1" row-span="3" col-span="4" vsize-policy="7" hsize-policy="7" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>

--- a/src/main/java/com/fwdekker/randomness/word/WordSettingsDialog.java
+++ b/src/main/java/com/fwdekker/randomness/word/WordSettingsDialog.java
@@ -100,8 +100,8 @@ final class WordSettingsDialog extends SettingsDialog<WordSettings> {
         ButtonGroupHelper.setValue(enclosureGroup, settings.getEnclosure());
         ButtonGroupHelper.setValue(capitalizationGroup, settings.getCapitalization());
 
-        dictionaries.setEntries(settings.getDictionaries());
-        dictionaries.setActiveEntries(settings.getActiveDictionaries());
+        dictionaries.setEntries(settings.getValidDictionaries());
+        dictionaries.setActiveEntries(settings.getValidActiveDictionaries());
     }
 
     @Override

--- a/src/main/java/com/fwdekker/randomness/word/WordSettingsDialog.java
+++ b/src/main/java/com/fwdekker/randomness/word/WordSettingsDialog.java
@@ -100,7 +100,7 @@ final class WordSettingsDialog extends SettingsDialog<WordSettings> {
         ButtonGroupHelper.setValue(enclosureGroup, settings.getEnclosure());
         ButtonGroupHelper.setValue(capitalizationGroup, settings.getCapitalization());
 
-        dictionaries.setEntries(settings.getValidDictionaries());
+        dictionaries.setEntries(settings.getValidAllDictionaries());
         dictionaries.setActiveEntries(settings.getValidActiveDictionaries());
     }
 

--- a/src/test/java/com/fwdekker/randomness/word/BundledDictionaryTest.java
+++ b/src/test/java/com/fwdekker/randomness/word/BundledDictionaryTest.java
@@ -3,9 +3,6 @@ package com.fwdekker.randomness.word;
 import com.intellij.openapi.ui.ValidationInfo;
 import org.junit.Test;
 
-import java.util.Arrays;
-import java.util.List;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -38,17 +35,6 @@ public final class BundledDictionaryTest {
         assertThat(dictionaryA).isEqualTo(dictionaryB);
     }
 
-    @Test
-    public void testInitListTwiceEquals() {
-        final List<Dictionary.BundledDictionary> dictionaries = Dictionary.BundledDictionary.get(Arrays.asList(
-                "dictionaries/simple.dic",
-                "dictionaries/simple.dic"
-        ));
-
-        assertThat(dictionaries).hasSize(2);
-        assertThat(dictionaries.get(0)).isEqualTo(dictionaries.get(1));
-    }
-
 
     @Test
     public void testValidateInstanceSuccess() {
@@ -78,28 +64,6 @@ public final class BundledDictionaryTest {
     @Test
     public void testValidateStaticFileEmpty() {
         final ValidationInfo validationInfo = Dictionary.BundledDictionary.validate("dictionaries/empty.dic");
-
-        assertThat(validationInfo).isNotNull();
-        assertThat(validationInfo.message).isEqualTo("The dictionary resource for empty.dic is empty.");
-        assertThat(validationInfo.component).isNull();
-    }
-
-    @Test
-    public void testValidateStaticListSuccess() {
-        final ValidationInfo validationInfo = Dictionary.BundledDictionary.validate(Arrays.asList(
-                "dictionaries/simple.dic",
-                "dictionaries/varied.dic"
-        ));
-
-        assertThat(validationInfo).isNull();
-    }
-
-    @Test
-    public void testValidateStaticListPartial() {
-        final ValidationInfo validationInfo = Dictionary.BundledDictionary.validate(Arrays.asList(
-                "dictionaries/varied.dic",
-                "dictionaries/empty.dic"
-        ));
 
         assertThat(validationInfo).isNotNull();
         assertThat(validationInfo.message).isEqualTo("The dictionary resource for empty.dic is empty.");

--- a/src/test/java/com/fwdekker/randomness/word/DictionaryHelper.java
+++ b/src/test/java/com/fwdekker/randomness/word/DictionaryHelper.java
@@ -1,0 +1,43 @@
+package com.fwdekker.randomness.word;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+import static org.assertj.core.api.Assertions.fail;
+
+
+/**
+ * Helper class for tests of {@code Dictionary}s.
+ */
+public final class DictionaryHelper {
+    /**
+     * Private constructor to prevent instantiation.
+     */
+    private DictionaryHelper() {
+    }
+
+
+    /**
+     * Creates a temporary dictionary file with the given contents.
+     * <p>
+     * Because the created file is a temporary file, it does not have to be cleaned up afterwards.
+     *
+     * @param contents the contents to write to the dictionary file
+     * @return the created temporary dictionary file
+     */
+    public static File setUpDictionary(final String contents) {
+        final File dictionaryFile;
+
+        try {
+            dictionaryFile = File.createTempFile("dictionary", ".dic");
+            Files.write(dictionaryFile.toPath(), contents.getBytes(StandardCharsets.UTF_8));
+
+            return dictionaryFile;
+        } catch (final IOException e) {
+            fail("Could not set up dictionary file.");
+            return new File("");
+        }
+    }
+}

--- a/src/test/java/com/fwdekker/randomness/word/UserDictionaryTest.java
+++ b/src/test/java/com/fwdekker/randomness/word/UserDictionaryTest.java
@@ -7,8 +7,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.util.Arrays;
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -44,19 +42,6 @@ public final class UserDictionaryTest {
         final Dictionary dictionaryB = Dictionary.UserDictionary.get(dictionaryFile.getAbsolutePath());
 
         assertThat(dictionaryA).isEqualTo(dictionaryB);
-    }
-
-    @Test
-    public void testInitListTwiceEquals() {
-        final File dictionaryFile = setUpDictionary("Fomenter\nOutwits\nManqu");
-
-        final List<Dictionary.UserDictionary> dictionaries = Dictionary.UserDictionary.get(Arrays.asList(
-                dictionaryFile.getAbsolutePath(),
-                dictionaryFile.getAbsolutePath()
-        ));
-
-        assertThat(dictionaries).hasSize(2);
-        assertThat(dictionaries.get(0)).isEqualTo(dictionaries.get(1));
     }
 
 
@@ -97,35 +82,6 @@ public final class UserDictionaryTest {
 
         assertThat(validationInfo).isNotNull();
         assertThat(validationInfo.message).isEqualTo("The dictionary file for " + dictionaryName + " is empty.");
-        assertThat(validationInfo.component).isNull();
-    }
-
-    @Test
-    public void testValidateStaticListSuccess() {
-        final File dictionaryFileA = setUpDictionary("Hexaxon\nChuse\nFricace");
-        final File dictionaryFileB = setUpDictionary("Psyllid\nRefroze\nRoving");
-
-        final ValidationInfo validationInfo = Dictionary.UserDictionary.validate(Arrays.asList(
-                dictionaryFileA.getAbsolutePath(),
-                dictionaryFileB.getAbsolutePath()
-        ));
-
-        assertThat(validationInfo).isNull();
-    }
-
-    @Test
-    public void testValidateStaticListPartial() {
-        final File dictionaryFileA = setUpDictionary("Hexaxon\nChuse\nFricace");
-        final File dictionaryFileB = setUpDictionary("");
-        final String dictionaryFileBName = dictionaryFileB.getName();
-
-        final ValidationInfo validationInfo = Dictionary.UserDictionary.validate(Arrays.asList(
-                dictionaryFileA.getAbsolutePath(),
-                dictionaryFileB.getAbsolutePath()
-        ));
-
-        assertThat(validationInfo).isNotNull();
-        assertThat(validationInfo.message).isEqualTo("The dictionary file for " + dictionaryFileBName + " is empty.");
         assertThat(validationInfo.component).isNull();
     }
 

--- a/src/test/java/com/fwdekker/randomness/word/UserDictionaryTest.java
+++ b/src/test/java/com/fwdekker/randomness/word/UserDictionaryTest.java
@@ -5,12 +5,10 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 
+import static com.fwdekker.randomness.word.DictionaryHelper.setUpDictionary;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.fail;
 
 
 /**
@@ -94,28 +92,5 @@ public final class UserDictionaryTest {
         final Dictionary dictionary = Dictionary.UserDictionary.get(dictionaryFile.getAbsolutePath());
 
         assertThat(dictionary.toString()).isEqualTo("[custom] " + dictionaryName);
-    }
-
-
-    /**
-     * Creates a temporary dictionary file with the given contents.
-     * <p>
-     * Because the created file is a temporary file, it does not have to be cleaned up afterwards.
-     *
-     * @param contents the contents to write to the dictionary file
-     * @return the created temporary dictionary file
-     */
-    private File setUpDictionary(final String contents) {
-        final File dictionaryFile;
-
-        try {
-            dictionaryFile = File.createTempFile("dictionary", ".dic");
-            Files.write(dictionaryFile.toPath(), contents.getBytes(StandardCharsets.UTF_8));
-
-            return dictionaryFile;
-        } catch (final IOException e) {
-            fail("Could not set up dictionary file.");
-            return new File("");
-        }
     }
 }

--- a/src/test/java/com/fwdekker/randomness/word/UserDictionaryTest.java
+++ b/src/test/java/com/fwdekker/randomness/word/UserDictionaryTest.java
@@ -7,6 +7,8 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -18,7 +20,7 @@ import static org.assertj.core.api.Assertions.fail;
  */
 public final class UserDictionaryTest {
     @Test
-    public void testInvalidFile() {
+    public void testInitDoesNotExist() {
         assertThatThrownBy(() -> Dictionary.UserDictionary.get("invalid_file"))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Failed to read dictionary into memory.")
@@ -26,8 +28,41 @@ public final class UserDictionaryTest {
     }
 
     @Test
-    public void testValidateSuccess() {
-        final File dictionaryFile = setUpDictionary("Bbls\nOverpray\nTreeward");
+    public void testInitEmpty() {
+        final File dictionaryFile = setUpDictionary("");
+
+        assertThatThrownBy(() -> Dictionary.UserDictionary.get(dictionaryFile.getAbsolutePath()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Dictionary must be non-empty.");
+    }
+
+    @Test
+    public void testInitTwiceEquals() {
+        final File dictionaryFile = setUpDictionary("Fonded\nLustrum\nUpgale");
+
+        final Dictionary dictionaryA = Dictionary.UserDictionary.get(dictionaryFile.getAbsolutePath());
+        final Dictionary dictionaryB = Dictionary.UserDictionary.get(dictionaryFile.getAbsolutePath());
+
+        assertThat(dictionaryA).isEqualTo(dictionaryB);
+    }
+
+    @Test
+    public void testInitListTwiceEquals() {
+        final File dictionaryFile = setUpDictionary("Fomenter\nOutwits\nManqu");
+
+        final List<Dictionary.UserDictionary> dictionaries = Dictionary.UserDictionary.get(Arrays.asList(
+                dictionaryFile.getAbsolutePath(),
+                dictionaryFile.getAbsolutePath()
+        ));
+
+        assertThat(dictionaries).hasSize(2);
+        assertThat(dictionaries.get(0)).isEqualTo(dictionaries.get(1));
+    }
+
+
+    @Test
+    public void testValidateInstanceSuccess() {
+        final File dictionaryFile = setUpDictionary("Rhodinal\nScruff\nPibrochs");
         final Dictionary dictionary = Dictionary.UserDictionary.get(dictionaryFile.getAbsolutePath());
 
         final ValidationInfo validationInfo = dictionary.validate();
@@ -36,27 +71,73 @@ public final class UserDictionaryTest {
     }
 
     @Test
-    public void testValidateFileDoesNotExist() {
-        final File dictionaryFile = setUpDictionary("Loafer\nAquavit\nSpahees");
-        final Dictionary dictionary = Dictionary.UserDictionary.get(dictionaryFile.getAbsolutePath());
+    public void testValidateStaticSuccess() {
+        final File dictionaryFile = setUpDictionary("Bbls\nOverpray\nTreeward");
 
-        if (!dictionaryFile.delete()) {
-            fail("Failed to delete test file as part of test.");
-        }
+        final ValidationInfo validationInfo = Dictionary.UserDictionary.validate(dictionaryFile.getAbsolutePath());
 
-        final ValidationInfo validationInfo = dictionary.validate();
+        assertThat(validationInfo).isNull();
+    }
+
+    @Test
+    public void testValidateStaticFileDoesNotExist() {
+        final ValidationInfo validationInfo = Dictionary.UserDictionary.validate("invalid_path");
 
         assertThat(validationInfo).isNotNull();
-        assertThat(validationInfo.message).matches("The dictionary file for .* no longer exists\\.");
+        assertThat(validationInfo.message).isEqualTo("The dictionary file for invalid_path no longer exists.");
         assertThat(validationInfo.component).isNull();
     }
 
     @Test
+    public void testValidateStaticFileEmpty() {
+        final File dictionaryFile = setUpDictionary("");
+        final String dictionaryName = dictionaryFile.getName();
+
+        final ValidationInfo validationInfo = Dictionary.UserDictionary.validate(dictionaryFile.getAbsolutePath());
+
+        assertThat(validationInfo).isNotNull();
+        assertThat(validationInfo.message).isEqualTo("The dictionary file for " + dictionaryName + " is empty.");
+        assertThat(validationInfo.component).isNull();
+    }
+
+    @Test
+    public void testValidateStaticListSuccess() {
+        final File dictionaryFileA = setUpDictionary("Hexaxon\nChuse\nFricace");
+        final File dictionaryFileB = setUpDictionary("Psyllid\nRefroze\nRoving");
+
+        final ValidationInfo validationInfo = Dictionary.UserDictionary.validate(Arrays.asList(
+                dictionaryFileA.getAbsolutePath(),
+                dictionaryFileB.getAbsolutePath()
+        ));
+
+        assertThat(validationInfo).isNull();
+    }
+
+    @Test
+    public void testValidateStaticListPartial() {
+        final File dictionaryFileA = setUpDictionary("Hexaxon\nChuse\nFricace");
+        final File dictionaryFileB = setUpDictionary("");
+        final String dictionaryFileBName = dictionaryFileB.getName();
+
+        final ValidationInfo validationInfo = Dictionary.UserDictionary.validate(Arrays.asList(
+                dictionaryFileA.getAbsolutePath(),
+                dictionaryFileB.getAbsolutePath()
+        ));
+
+        assertThat(validationInfo).isNotNull();
+        assertThat(validationInfo.message).isEqualTo("The dictionary file for " + dictionaryFileBName + " is empty.");
+        assertThat(validationInfo.component).isNull();
+    }
+
+
+    @Test
     public void testToString() {
         final File dictionaryFile = setUpDictionary("Cholers\nJaloused\nStopback");
+        final String dictionaryName = dictionaryFile.getName();
+
         final Dictionary dictionary = Dictionary.UserDictionary.get(dictionaryFile.getAbsolutePath());
 
-        assertThat(dictionary.toString()).matches("\\[custom\\] .*\\.dic");
+        assertThat(dictionary.toString()).isEqualTo("[custom] " + dictionaryName);
     }
 
 

--- a/src/test/java/com/fwdekker/randomness/word/WordSettingsTest.java
+++ b/src/test/java/com/fwdekker/randomness/word/WordSettingsTest.java
@@ -1,11 +1,17 @@
 package com.fwdekker.randomness.word;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
+import com.intellij.openapi.ui.ValidationInfo;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static com.fwdekker.randomness.word.DictionaryHelper.setUpDictionary;
 import static org.assertj.core.api.Assertions.assertThat;
 
 
@@ -64,8 +70,7 @@ public final class WordSettingsTest {
 
     @Test
     public void testGetSetBundledDictionaries() {
-        final Set<String> bundledDictionaries
-                = new HashSet<>(Arrays.asList("6OE]SfZj6(", "HGeldsz2XM", "V6AhkeIKX6"));
+        final Set<String> bundledDictionaries = new HashSet<>(Arrays.asList("6OE]SfZj6(", "HGeldsz2XM", "V6AhkeIKX6"));
         wordSettings.setBundledDictionaries(bundledDictionaries);
 
         assertThat(wordSettings.getBundledDictionaries()).isEqualTo(bundledDictionaries);
@@ -73,8 +78,7 @@ public final class WordSettingsTest {
 
     @Test
     public void testGetSetUserDictionaries() {
-        final Set<String> userDictionaries
-                = new HashSet<>(Arrays.asList(")asQAYwW[u", "Bz>GSRlNA1", "Cjsg{Olylo"));
+        final Set<String> userDictionaries = new HashSet<>(Arrays.asList(")asQAYwW[u", "Bz>GSRlNA1", "Cjsg{Olylo"));
         wordSettings.setUserDictionaries(userDictionaries);
 
         assertThat(wordSettings.getUserDictionaries()).isEqualTo(userDictionaries);
@@ -82,8 +86,7 @@ public final class WordSettingsTest {
 
     @Test
     public void testGetSetActiveBundledDictionaries() {
-        final Set<String> bundledDictionaries
-                = new HashSet<>(Arrays.asList("6QeMvZ>uHQ", "Onb]HUugM1", "008xGJhIXE"));
+        final Set<String> bundledDictionaries = new HashSet<>(Arrays.asList("6QeMvZ>uHQ", "Onb]HUugM1", "008xGJhIXE"));
         wordSettings.setActiveBundledDictionaries(bundledDictionaries);
 
         assertThat(wordSettings.getActiveBundledDictionaries()).isEqualTo(bundledDictionaries);
@@ -91,10 +94,165 @@ public final class WordSettingsTest {
 
     @Test
     public void testGetSetActiveUserDictionaries() {
-        final Set<String> userDictionaries
-                = new HashSet<>(Arrays.asList("ukeB8}RLbm", "JRcuz7sm4(", "{QZGJQli36"));
+        final Set<String> userDictionaries = new HashSet<>(Arrays.asList("ukeB8}RLbm", "JRcuz7sm4(", "{QZGJQli36"));
         wordSettings.setActiveUserDictionaries(userDictionaries);
 
         assertThat(wordSettings.getActiveUserDictionaries()).isEqualTo(userDictionaries);
+    }
+
+
+    @Test
+    public void testValidateAllDictionariesSuccessEmpty() {
+        wordSettings.setBundledDictionaries(Collections.emptySet());
+        wordSettings.setUserDictionaries(Collections.emptySet());
+
+        assertThat(wordSettings.validateAllDictionaries()).isNull();
+    }
+
+    @Test
+    public void testValidateAllDictionariesSuccessNonEmpty() {
+        final File userDictionary = setUpDictionary("Reflet\nHerniate\nBuz");
+
+        wordSettings.setBundledDictionaries(new HashSet<>(Arrays.asList("dictionaries/simple.dic")));
+        wordSettings.setUserDictionaries(new HashSet<>(Arrays.asList(userDictionary.getAbsolutePath())));
+
+        assertThat(wordSettings.validateAllDictionaries()).isNull();
+    }
+
+    @Test
+    public void testValidateAllDictionaryInvalidBundled() {
+        final File userDictionary = setUpDictionary("Inblow\nImmunes\nEnteroid");
+
+        wordSettings.setBundledDictionaries(new HashSet<>(Arrays.asList("dictionaries/empty.dic")));
+        wordSettings.setUserDictionaries(new HashSet<>(Arrays.asList(userDictionary.getAbsolutePath())));
+
+        final ValidationInfo validationInfo = wordSettings.validateAllDictionaries();
+
+        assertThat(validationInfo).isNotNull();
+        assertThat(validationInfo.message).isEqualTo("The dictionary resource for empty.dic is empty.");
+        assertThat(validationInfo.component).isNull();
+    }
+
+    @Test
+    public void testValidateAllDictionaryInvalidUser() {
+        final File userDictionary = setUpDictionary("");
+        final String userDictionaryName = userDictionary.getName();
+
+        wordSettings.setBundledDictionaries(new HashSet<>(Arrays.asList("dictionaries/simple.dic")));
+        wordSettings.setUserDictionaries(new HashSet<>(Arrays.asList(userDictionary.getAbsolutePath())));
+
+        final ValidationInfo validationInfo = wordSettings.validateAllDictionaries();
+
+        assertThat(validationInfo).isNotNull();
+        assertThat(validationInfo.message).isEqualTo("The dictionary file for " + userDictionaryName + " is empty.");
+        assertThat(validationInfo.component).isNull();
+    }
+
+    @Test
+    public void testValidateActiveDictionariesSuccessEmpty() {
+        wordSettings.setActiveBundledDictionaries(Collections.emptySet());
+        wordSettings.setActiveUserDictionaries(Collections.emptySet());
+
+        assertThat(wordSettings.validateActiveDictionaries()).isNull();
+    }
+
+    @Test
+    public void testValidateActiveDictionariesSuccessNonEmpty() {
+        final File userDictionary = setUpDictionary("Dicranum\nJiffy\nChatties");
+
+        wordSettings.setActiveBundledDictionaries(new HashSet<>(Arrays.asList("dictionaries/simple.dic")));
+        wordSettings.setActiveUserDictionaries(new HashSet<>(Arrays.asList(userDictionary.getAbsolutePath())));
+
+        assertThat(wordSettings.validateActiveDictionaries()).isNull();
+    }
+
+    @Test
+    public void testValidateActiveDictionaryInvalidBundled() {
+        final File userDictionary = setUpDictionary("Fastest\nWows\nBrimmers");
+
+        wordSettings.setActiveBundledDictionaries(new HashSet<>(Arrays.asList("dictionaries/empty.dic")));
+        wordSettings.setActiveUserDictionaries(new HashSet<>(Arrays.asList(userDictionary.getAbsolutePath())));
+
+        final ValidationInfo validationInfo = wordSettings.validateActiveDictionaries();
+
+        assertThat(validationInfo).isNotNull();
+        assertThat(validationInfo.message).isEqualTo("The dictionary resource for empty.dic is empty.");
+        assertThat(validationInfo.component).isNull();
+    }
+
+    @Test
+    public void testValidateActiveDictionaryInvalidUser() {
+        final File userDictionary = setUpDictionary("");
+        final String userDictionaryName = userDictionary.getName();
+
+        wordSettings.setActiveBundledDictionaries(new HashSet<>(Arrays.asList("dictionaries/simple.dic")));
+        wordSettings.setActiveUserDictionaries(new HashSet<>(Arrays.asList(userDictionary.getAbsolutePath())));
+
+        final ValidationInfo validationInfo = wordSettings.validateActiveDictionaries();
+
+        assertThat(validationInfo).isNotNull();
+        assertThat(validationInfo.message).isEqualTo("The dictionary file for " + userDictionaryName + " is empty.");
+        assertThat(validationInfo.component).isNull();
+    }
+
+
+    @Test
+    public void testGetValidAllDictionariesEmpty() {
+        wordSettings.setBundledDictionaries(Collections.emptySet());
+        wordSettings.setUserDictionaries(Collections.emptySet());
+
+        assertThat(wordSettings.getValidAllDictionaries()).isEmpty();
+    }
+
+    @Test
+    public void testGetValidAllDictionariesFilterBoth() {
+        final File validUserDictionary = setUpDictionary("Resilium\nAncerata\nBylander");
+        final File invalidUserDictionary = setUpDictionary("");
+
+        wordSettings.setBundledDictionaries(new HashSet<>(Arrays.asList(
+                "dictionaries/simple.dic",
+                "dictionaries/empty.dic"
+        )));
+        wordSettings.setUserDictionaries(new HashSet<>(Arrays.asList(
+                validUserDictionary.getAbsolutePath(),
+                invalidUserDictionary.getAbsolutePath()
+        )));
+
+        final List<Dictionary> dictionaries = wordSettings.getValidAllDictionaries();
+
+        assertThat(dictionaries).containsExactlyInAnyOrder(
+                Dictionary.UserDictionary.get(validUserDictionary.getAbsolutePath()),
+                Dictionary.BundledDictionary.get("dictionaries/simple.dic")
+        );
+    }
+
+    @Test
+    public void testGetValidActiveDictionariesEmpty() {
+        wordSettings.setActiveBundledDictionaries(Collections.emptySet());
+        wordSettings.setActiveUserDictionaries(Collections.emptySet());
+
+        assertThat(wordSettings.getValidActiveDictionaries()).isEmpty();
+    }
+
+    @Test
+    public void testGetValidActiveDictionariesFilterBoth() {
+        final File validUserDictionary = setUpDictionary("Resilium\nAncerata\nBylander");
+        final File invalidUserDictionary = setUpDictionary("");
+
+        wordSettings.setActiveBundledDictionaries(new HashSet<>(Arrays.asList(
+                "dictionaries/simple.dic",
+                "dictionaries/empty.dic"
+        )));
+        wordSettings.setActiveUserDictionaries(new HashSet<>(Arrays.asList(
+                validUserDictionary.getAbsolutePath(),
+                invalidUserDictionary.getAbsolutePath()
+        )));
+
+        final List<Dictionary> dictionaries = wordSettings.getValidActiveDictionaries();
+
+        assertThat(dictionaries).containsExactlyInAnyOrder(
+                Dictionary.UserDictionary.get(validUserDictionary.getAbsolutePath()),
+                Dictionary.BundledDictionary.get("dictionaries/simple.dic")
+        );
     }
 }


### PR DESCRIPTION
Fixes #65.

* Implementations of `Dictionary` now have a static `validate(String)` method that returns whether the dictionary at the given path would be valid, and have an instance method `validate()` that returns whether the current instance is still valid.
* The above-mentioned `validate` methods are used in the `loadSettings` method of the `WordSettingsDialog` to filter out the invalid dictionaries so that these are not loaded.
* The `validate` methods are also used in `WordInsertAction` to display a popup indicating that at least one of the dictionaries has become invalid. No word will be inserted, and the user is directed towards the settings menu.

The responsibility of the filtering and validating lies with the `WordSettings` class because it is the only class that actually puts a strict limit on which subclasses of `Dictionary` are being used.
