### PR TITLE
Remove unused methods in test classes

### DIFF
--- a/src/test/java/com/fwdekker/randomness/decimal/DecimalSettingsDialogTest.java
+++ b/src/test/java/com/fwdekker/randomness/decimal/DecimalSettingsDialogTest.java
@@ -6,9 +6,6 @@ import org.assertj.swing.fixture.FrameFixture;
 import org.assertj.swing.junit.testcase.AssertJSwingJUnitTestCase;
 import org.junit.Test;
 
-import java.text.NumberFormat;
-import java.util.Locale;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.swing.fixture.Containers.showInFrame;
 
@@ -159,19 +156,5 @@ public final class DecimalSettingsDialogTest extends AssertJSwingJUnitTestCase {
         assertThat(decimalSettings.getDecimalCount()).isEqualTo(485);
         assertThat(decimalSettings.getGroupingSeparator()).isEqualTo('_');
         assertThat(decimalSettings.getDecimalSeparator()).isEqualTo(',');
-    }
-
-
-    /**
-     * Locale-dependently converts a double into a string.
-     *
-     * @param decimal a double
-     * @return the user's locale's representation of the given double
-     */
-    private static String doubleToString(final double decimal) {
-        final Locale locale = Locale.US;
-        final NumberFormat formatter = NumberFormat.getInstance(locale);
-
-        return formatter.format(decimal);
     }
 }

--- a/src/test/java/com/fwdekker/randomness/string/StringSettingsDialogTest.java
+++ b/src/test/java/com/fwdekker/randomness/string/StringSettingsDialogTest.java
@@ -169,18 +169,6 @@ public final class StringSettingsDialogTest extends AssertJSwingJUnitTestCase {
     }
 
     /**
-     * Calls {@code toString} on each alphabet and returns the result as an array.
-     *
-     * @param alphabets a collection of alphabets
-     * @return the {@code toString} of each alphabet
-     */
-    private String[] toStringForEach(final Collection<Alphabet> alphabets) {
-        return alphabets.stream()
-                .map(Object::toString)
-                .toArray(String[]::new);
-    }
-
-    /**
      * Returns the enumeration index of each alphabet as an array.
      *
      * @param alphabets a collection of alphabets


### PR DESCRIPTION
When the flaky tests were removed in #77, the utility methods used by those tests (and only by those tests) were left in place. This triggered two PMD errors, which were not caught because the build is not set to fail on static analysis errors. This PR removes the aforementioned unused methods.