### PR TITLE
Delete temporary files after test completion

### DIFF
--- a/src/test/java/com/fwdekker/randomness/word/DictionaryFileHelper.java
+++ b/src/test/java/com/fwdekker/randomness/word/DictionaryFileHelper.java
@@ -61,5 +61,7 @@ public final class DictionaryFileHelper {
                 Logger.getLogger(this.getClass().getName()).warning("Failed to clean up dictionary file.");
             }
         }
+
+        files.clear();
     }
 }

--- a/src/test/java/com/fwdekker/randomness/word/DictionaryFileHelper.java
+++ b/src/test/java/com/fwdekker/randomness/word/DictionaryFileHelper.java
@@ -4,18 +4,28 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Logger;
 
 import static org.assertj.core.api.Assertions.fail;
 
 
 /**
- * Helper class for tests of {@code Dictionary}s.
+ * Helper class for file manipulation for tests of {@code Dictionary}s.
  */
-public final class DictionaryHelper {
+public final class DictionaryFileHelper {
     /**
-     * Private constructor to prevent instantiation.
+     * The files that have been created by this helper.
      */
-    private DictionaryHelper() {
+    private final List<File> files;
+
+
+    /**
+     * Constructs a new {@code DictionaryFileHelper}.
+     */
+    public DictionaryFileHelper() {
+        files = new ArrayList<>();
     }
 
 
@@ -27,17 +37,29 @@ public final class DictionaryHelper {
      * @param contents the contents to write to the dictionary file
      * @return the created temporary dictionary file
      */
-    public static File setUpDictionary(final String contents) {
+    public File setUpDictionary(final String contents) {
         final File dictionaryFile;
 
         try {
             dictionaryFile = File.createTempFile("dictionary", ".dic");
             Files.write(dictionaryFile.toPath(), contents.getBytes(StandardCharsets.UTF_8));
+            files.add(dictionaryFile);
 
             return dictionaryFile;
         } catch (final IOException e) {
             fail("Could not set up dictionary file.");
             return new File("");
+        }
+    }
+
+    /**
+     * Cleans up the created dictionary files.
+     */
+    public void cleanUpDictionaries() {
+        for (final File dictionaryFile : files) {
+            if (dictionaryFile.exists() && !dictionaryFile.delete()) {
+                Logger.getLogger(this.getClass().getName()).warning("Failed to clean up dictionary file.");
+            }
         }
     }
 }

--- a/src/test/java/com/fwdekker/randomness/word/UserDictionaryTest.java
+++ b/src/test/java/com/fwdekker/randomness/word/UserDictionaryTest.java
@@ -1,12 +1,12 @@
 package com.fwdekker.randomness.word;
 
 import com.intellij.openapi.ui.ValidationInfo;
+import org.junit.AfterClass;
 import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
 
-import static com.fwdekker.randomness.word.DictionaryHelper.setUpDictionary;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -15,6 +15,15 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * Unit tests for {@link Dictionary.UserDictionary}.
  */
 public final class UserDictionaryTest {
+    private static final DictionaryFileHelper FILE_HELPER = new DictionaryFileHelper();
+
+
+    @AfterClass
+    public static void afterAll() {
+        FILE_HELPER.cleanUpDictionaries();
+    }
+
+
     @Test
     public void testInitDoesNotExist() {
         assertThatThrownBy(() -> Dictionary.UserDictionary.get("invalid_file"))
@@ -25,7 +34,7 @@ public final class UserDictionaryTest {
 
     @Test
     public void testInitEmpty() {
-        final File dictionaryFile = setUpDictionary("");
+        final File dictionaryFile = FILE_HELPER.setUpDictionary("");
 
         assertThatThrownBy(() -> Dictionary.UserDictionary.get(dictionaryFile.getAbsolutePath()))
                 .isInstanceOf(IllegalArgumentException.class)
@@ -34,7 +43,7 @@ public final class UserDictionaryTest {
 
     @Test
     public void testInitTwiceEquals() {
-        final File dictionaryFile = setUpDictionary("Fonded\nLustrum\nUpgale");
+        final File dictionaryFile = FILE_HELPER.setUpDictionary("Fonded\nLustrum\nUpgale");
 
         final Dictionary dictionaryA = Dictionary.UserDictionary.get(dictionaryFile.getAbsolutePath());
         final Dictionary dictionaryB = Dictionary.UserDictionary.get(dictionaryFile.getAbsolutePath());
@@ -45,7 +54,7 @@ public final class UserDictionaryTest {
 
     @Test
     public void testValidateInstanceSuccess() {
-        final File dictionaryFile = setUpDictionary("Rhodinal\nScruff\nPibrochs");
+        final File dictionaryFile = FILE_HELPER.setUpDictionary("Rhodinal\nScruff\nPibrochs");
         final Dictionary dictionary = Dictionary.UserDictionary.get(dictionaryFile.getAbsolutePath());
 
         final ValidationInfo validationInfo = dictionary.validate();
@@ -55,7 +64,7 @@ public final class UserDictionaryTest {
 
     @Test
     public void testValidateStaticSuccess() {
-        final File dictionaryFile = setUpDictionary("Bbls\nOverpray\nTreeward");
+        final File dictionaryFile = FILE_HELPER.setUpDictionary("Bbls\nOverpray\nTreeward");
 
         final ValidationInfo validationInfo = Dictionary.UserDictionary.validate(dictionaryFile.getAbsolutePath());
 
@@ -73,7 +82,7 @@ public final class UserDictionaryTest {
 
     @Test
     public void testValidateStaticFileEmpty() {
-        final File dictionaryFile = setUpDictionary("");
+        final File dictionaryFile = FILE_HELPER.setUpDictionary("");
         final String dictionaryName = dictionaryFile.getName();
 
         final ValidationInfo validationInfo = Dictionary.UserDictionary.validate(dictionaryFile.getAbsolutePath());
@@ -86,7 +95,7 @@ public final class UserDictionaryTest {
 
     @Test
     public void testToString() {
-        final File dictionaryFile = setUpDictionary("Cholers\nJaloused\nStopback");
+        final File dictionaryFile = FILE_HELPER.setUpDictionary("Cholers\nJaloused\nStopback");
         final String dictionaryName = dictionaryFile.getName();
 
         final Dictionary dictionary = Dictionary.UserDictionary.get(dictionaryFile.getAbsolutePath());

--- a/src/test/java/com/fwdekker/randomness/word/WordSettingsTest.java
+++ b/src/test/java/com/fwdekker/randomness/word/WordSettingsTest.java
@@ -1,6 +1,7 @@
 package com.fwdekker.randomness.word;
 
 import com.intellij.openapi.ui.ValidationInfo;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -11,7 +12,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import static com.fwdekker.randomness.word.DictionaryHelper.setUpDictionary;
 import static org.assertj.core.api.Assertions.assertThat;
 
 
@@ -19,8 +19,15 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Unit tests for {@link WordSettings}.
  */
 public final class WordSettingsTest {
+    private static final DictionaryFileHelper FILE_HELPER = new DictionaryFileHelper();
+
     private WordSettings wordSettings;
 
+
+    @AfterClass
+    public static void afterAll() {
+        FILE_HELPER.cleanUpDictionaries();
+    }
 
     @Before
     public void beforeEach() {
@@ -111,7 +118,7 @@ public final class WordSettingsTest {
 
     @Test
     public void testValidateAllDictionariesSuccessNonEmpty() {
-        final File userDictionary = setUpDictionary("Reflet\nHerniate\nBuz");
+        final File userDictionary = FILE_HELPER.setUpDictionary("Reflet\nHerniate\nBuz");
 
         wordSettings.setBundledDictionaries(new HashSet<>(Arrays.asList("dictionaries/simple.dic")));
         wordSettings.setUserDictionaries(new HashSet<>(Arrays.asList(userDictionary.getAbsolutePath())));
@@ -121,7 +128,7 @@ public final class WordSettingsTest {
 
     @Test
     public void testValidateAllDictionaryInvalidBundled() {
-        final File userDictionary = setUpDictionary("Inblow\nImmunes\nEnteroid");
+        final File userDictionary = FILE_HELPER.setUpDictionary("Inblow\nImmunes\nEnteroid");
 
         wordSettings.setBundledDictionaries(new HashSet<>(Arrays.asList("dictionaries/empty.dic")));
         wordSettings.setUserDictionaries(new HashSet<>(Arrays.asList(userDictionary.getAbsolutePath())));
@@ -135,7 +142,7 @@ public final class WordSettingsTest {
 
     @Test
     public void testValidateAllDictionaryInvalidUser() {
-        final File userDictionary = setUpDictionary("");
+        final File userDictionary = FILE_HELPER.setUpDictionary("");
         final String userDictionaryName = userDictionary.getName();
 
         wordSettings.setBundledDictionaries(new HashSet<>(Arrays.asList("dictionaries/simple.dic")));
@@ -158,7 +165,7 @@ public final class WordSettingsTest {
 
     @Test
     public void testValidateActiveDictionariesSuccessNonEmpty() {
-        final File userDictionary = setUpDictionary("Dicranum\nJiffy\nChatties");
+        final File userDictionary = FILE_HELPER.setUpDictionary("Dicranum\nJiffy\nChatties");
 
         wordSettings.setActiveBundledDictionaries(new HashSet<>(Arrays.asList("dictionaries/simple.dic")));
         wordSettings.setActiveUserDictionaries(new HashSet<>(Arrays.asList(userDictionary.getAbsolutePath())));
@@ -168,7 +175,7 @@ public final class WordSettingsTest {
 
     @Test
     public void testValidateActiveDictionaryInvalidBundled() {
-        final File userDictionary = setUpDictionary("Fastest\nWows\nBrimmers");
+        final File userDictionary = FILE_HELPER.setUpDictionary("Fastest\nWows\nBrimmers");
 
         wordSettings.setActiveBundledDictionaries(new HashSet<>(Arrays.asList("dictionaries/empty.dic")));
         wordSettings.setActiveUserDictionaries(new HashSet<>(Arrays.asList(userDictionary.getAbsolutePath())));
@@ -182,7 +189,7 @@ public final class WordSettingsTest {
 
     @Test
     public void testValidateActiveDictionaryInvalidUser() {
-        final File userDictionary = setUpDictionary("");
+        final File userDictionary = FILE_HELPER.setUpDictionary("");
         final String userDictionaryName = userDictionary.getName();
 
         wordSettings.setActiveBundledDictionaries(new HashSet<>(Arrays.asList("dictionaries/simple.dic")));
@@ -206,8 +213,8 @@ public final class WordSettingsTest {
 
     @Test
     public void testGetValidAllDictionariesFilterBoth() {
-        final File validUserDictionary = setUpDictionary("Resilium\nAncerata\nBylander");
-        final File invalidUserDictionary = setUpDictionary("");
+        final File validUserDictionary = FILE_HELPER.setUpDictionary("Resilium\nAncerata\nBylander");
+        final File invalidUserDictionary = FILE_HELPER.setUpDictionary("");
 
         wordSettings.setBundledDictionaries(new HashSet<>(Arrays.asList(
                 "dictionaries/simple.dic",
@@ -236,8 +243,8 @@ public final class WordSettingsTest {
 
     @Test
     public void testGetValidActiveDictionariesFilterBoth() {
-        final File validUserDictionary = setUpDictionary("Resilium\nAncerata\nBylander");
-        final File invalidUserDictionary = setUpDictionary("");
+        final File validUserDictionary = FILE_HELPER.setUpDictionary("Resilium\nAncerata\nBylander");
+        final File invalidUserDictionary = FILE_HELPER.setUpDictionary("");
 
         wordSettings.setActiveBundledDictionaries(new HashSet<>(Arrays.asList(
                 "dictionaries/simple.dic",


### PR DESCRIPTION
In the discussion on cafejojo/schaapi#45, it turned out that operating systems are not expected to clean up temporary files after use. Therefore, this PR adjusts the tests such that temporary files are deleted after running tests.

The `DictionaryHelper` class was renamed to `DictionaryFileHelper`, and has become stateful. Whenever a file is created through this helper, it is stored in a list. The `cleanUpDictionaries` method can then be called at any time to delete the files that have been created so far by that instance.
