### PR TITLE
Upgrade to JUnit 5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,13 +17,15 @@ repositories {
 }
 
 dependencies {
-    compile group: "com.google.code.findbugs", name: "jsr305", version: findbugsVersion
     compile group: "com.google.code.findbugs", name: "annotations", version: findbugsVersion
+    compile group: "com.google.code.findbugs", name: "jsr305", version: findbugsVersion
 
-    testCompile group: "junit", name: "junit", version: junitVersion
     testCompile group: "nl.jqno.equalsverifier", name: "equalsverifier", version: equalsVerifierVersion
     testCompile group: "org.assertj", name: "assertj-core", version: assertjVersion
     testCompile group: "org.assertj", name: "assertj-swing-junit", version: assertjSwingVersion
+    testCompile group: "org.junit.jupiter", name: "junit-jupiter-api", version: junitVersion
+    testCompile group: "org.junit.jupiter", name: "junit-jupiter-engine", version: junitVersion
+    testCompile group: "org.junit.vintage", name: "junit-vintage-engine", version: junitVersion
     testCompile group: "org.mockito", name: "mockito-core", version: mockitoVersion
 }
 
@@ -31,6 +33,10 @@ configurations {
     codacy
 }
 
+
+test {
+    useJUnitPlatform()
+}
 
 intellij {
     version = intellijVersion

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     testCompile group: "org.assertj", name: "assertj-swing-junit", version: assertjSwingVersion
     testCompile group: "org.junit.jupiter", name: "junit-jupiter-api", version: junitVersion
     testCompile group: "org.junit.jupiter", name: "junit-jupiter-engine", version: junitVersion
+    testCompile group: "org.junit.jupiter", name: "junit-jupiter-params", version: junitVersion
     testCompile group: "org.junit.vintage", name: "junit-vintage-engine", version: junitVersion
     testCompile group: "org.mockito", name: "mockito-core", version: mockitoVersion
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,5 +6,5 @@ assertjSwingVersion   = 3.8.0
 equalsVerifierVersion = 2.4.6
 findbugsVersion       = 3.0.1
 intellijVersion       = 2017.3
-junitVersion          = 4.12
+junitVersion          = 5.2.0
 mockitoVersion        = 2.18.3

--- a/src/test/java/com/fwdekker/randomness/DataInsertActionTest.java
+++ b/src/test/java/com/fwdekker/randomness/DataInsertActionTest.java
@@ -4,8 +4,8 @@ import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
 import com.intellij.openapi.actionSystem.Presentation;
 import com.intellij.openapi.editor.Editor;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -19,7 +19,7 @@ import static org.mockito.Mockito.when;
 /**
  * Unit tests for {@link DataInsertAction}.
  */
-public final class DataInsertActionTest {
+final class DataInsertActionTest {
     /**
      * The recognizable string that is inserted by the insertion action.
      */
@@ -28,8 +28,8 @@ public final class DataInsertActionTest {
     private DataInsertAction dataInsertAction;
 
 
-    @Before
-    public void beforeEach() {
+    @BeforeEach
+    void beforeEach() {
         dataInsertAction = new SimpleInsertAction();
     }
 
@@ -38,7 +38,7 @@ public final class DataInsertActionTest {
      * Tests that no further actions are taken when the editor is {@code null}.
      */
     @Test
-    public void testActionPerformedNullEditor() {
+    void testActionPerformedNullEditor() {
         final AnActionEvent event = mock(AnActionEvent.class);
         when(event.getData(CommonDataKeys.EDITOR)).thenReturn(null);
 
@@ -52,7 +52,7 @@ public final class DataInsertActionTest {
      * Tests that the action's presentation is disabled when the editor is null.
      */
     @Test
-    public void testUpdateDisabled() {
+    void testUpdateDisabled() {
         final AnActionEvent event = mock(AnActionEvent.class);
         final Presentation presentation = spy(Presentation.class);
         when(event.getData(CommonDataKeys.EDITOR)).thenReturn(null);
@@ -67,7 +67,7 @@ public final class DataInsertActionTest {
      * Tests that the action's presentation is enabled when the editor is not null.
      */
     @Test
-    public void testUpdateEnabled() {
+    void testUpdateEnabled() {
         final AnActionEvent event = mock(AnActionEvent.class);
         final Presentation presentation = spy(Presentation.class);
         when(event.getData(CommonDataKeys.EDITOR)).thenReturn(mock(Editor.class));

--- a/src/test/java/com/fwdekker/randomness/array/ArraySettingsTest.java
+++ b/src/test/java/com/fwdekker/randomness/array/ArraySettingsTest.java
@@ -1,9 +1,10 @@
 package com.fwdekker.randomness.array;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import java.util.Arrays;
 import java.util.Collections;
-import org.junit.Before;
-import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -11,23 +12,23 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Unit tests for {@link ArraySettings}.
  */
-public final class ArraySettingsTest {
+final class ArraySettingsTest {
     private ArraySettings arraySettings;
 
 
-    @Before
-    public void beforeEach() {
+    @BeforeEach
+    void beforeEach() {
         arraySettings = new ArraySettings();
     }
 
 
     @Test
-    public void testGetComponentName() {
+    void testGetComponentName() {
         assertThat(arraySettings.getComponentName()).isEqualTo("ArraySettings");
     }
 
     @Test
-    public void testGetLoadState() {
+    void testGetLoadState() {
         arraySettings.setCount(997);
         arraySettings.setBrackets("0fWx<i6jTJ");
         arraySettings.setSeparator("f3hu)Rxiz1");
@@ -43,28 +44,28 @@ public final class ArraySettingsTest {
     }
 
     @Test
-    public void testGetSetCount() {
+    void testGetSetCount() {
         arraySettings.setCount(655);
 
         assertThat(arraySettings.getCount()).isEqualTo(655);
     }
 
     @Test
-    public void testGetSetBrackets() {
+    void testGetSetBrackets() {
         arraySettings.setBrackets("RLevljrzf0");
 
         assertThat(arraySettings.getBrackets()).isEqualTo("RLevljrzf0");
     }
 
     @Test
-    public void testGetSetSeparator() {
+    void testGetSetSeparator() {
         arraySettings.setBrackets("d2[tlXkGf{");
 
         assertThat(arraySettings.getBrackets()).isEqualTo("d2[tlXkGf{");
     }
 
     @Test
-    public void testGetSetSpaceAfterSeparator() {
+    void testGetSetSpaceAfterSeparator() {
         arraySettings.setSpaceAfterSeparator(false);
 
         assertThat(arraySettings.isSpaceAfterSeparator()).isEqualTo(false);
@@ -72,13 +73,13 @@ public final class ArraySettingsTest {
 
 
     @Test
-    public void testArrayifyEmpty() {
+    void testArrayifyEmpty() {
         assertThat(arraySettings.arrayify(Collections.emptyList()))
                 .isEqualTo("[]");
     }
 
     @Test
-    public void testArrayify() {
+    void testArrayify() {
         arraySettings.setCount(4);
         arraySettings.setBrackets("@#");
         arraySettings.setSeparator(";;");
@@ -89,7 +90,7 @@ public final class ArraySettingsTest {
     }
 
     @Test
-    public void testArrayifyNoBrackets() {
+    void testArrayifyNoBrackets() {
         arraySettings.setCount(8);
         arraySettings.setBrackets("");
         arraySettings.setSeparator("h");

--- a/src/test/java/com/fwdekker/randomness/decimal/DecimalInsertActionSymbolTest.java
+++ b/src/test/java/com/fwdekker/randomness/decimal/DecimalInsertActionSymbolTest.java
@@ -1,8 +1,7 @@
 package com.fwdekker.randomness.decimal;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -13,28 +12,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Unit tests for the symbols used in {@link DecimalInsertAction}.
  */
-@RunWith(Parameterized.class)
-public final class DecimalInsertActionSymbolTest {
-    private final double value;
-    private final int decimalCount;
-    private final char groupingSeparator;
-    private final char decimalSeparator;
-    private final String expectedString;
-
-
-    public DecimalInsertActionSymbolTest(final double value, final int decimalCount, final char groupingSeparator,
-                                         final char decimalSeparator, final String expectedString) {
-        this.value = value;
-        this.decimalCount = decimalCount;
-        this.groupingSeparator = groupingSeparator;
-        this.decimalSeparator = decimalSeparator;
-        this.expectedString = expectedString;
-    }
-
-
-    @Parameterized.Parameters
-    public static Collection<Object[]> params() {
-        return Arrays.asList(new Object[][] {
+final class DecimalInsertActionSymbolTest {
+    @SuppressWarnings("PMD.UnusedPrivateMethod") // Used as parameterized method source
+    private static Collection<Object[]> provider() {
+        return Arrays.asList(new Object[][]{
                 {4.2, 2, '.', '.', "4.20"},
                 {4.2, 2, '.', ',', "4,20"},
                 {4.2, 2, ',', '.', "4.20"},
@@ -49,8 +30,10 @@ public final class DecimalInsertActionSymbolTest {
     }
 
 
-    @Test
-    public void testValue() {
+    @ParameterizedTest
+    @MethodSource("provider")
+    void testValue(final double value, final int decimalCount, final char groupingSeparator,
+                   final char decimalSeparator, final String expectedString) {
         final DecimalSettings decimalSettings = new DecimalSettings();
         decimalSettings.setMinValue(value);
         decimalSettings.setMaxValue(value);

--- a/src/test/java/com/fwdekker/randomness/decimal/DecimalInsertActionSymbolTest.java
+++ b/src/test/java/com/fwdekker/randomness/decimal/DecimalInsertActionSymbolTest.java
@@ -1,10 +1,11 @@
 package com.fwdekker.randomness.decimal;
 
-import java.util.Arrays;
-import java.util.Collection;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/src/test/java/com/fwdekker/randomness/decimal/DecimalInsertActionTest.java
+++ b/src/test/java/com/fwdekker/randomness/decimal/DecimalInsertActionTest.java
@@ -1,10 +1,11 @@
 package com.fwdekker.randomness.decimal;
 
-import java.util.Arrays;
-import java.util.Collection;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/src/test/java/com/fwdekker/randomness/decimal/DecimalInsertActionTest.java
+++ b/src/test/java/com/fwdekker/randomness/decimal/DecimalInsertActionTest.java
@@ -1,8 +1,7 @@
 package com.fwdekker.randomness.decimal;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -13,26 +12,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Parameterized unit tests for {@link DecimalInsertAction}.
  */
-@RunWith(Parameterized.class)
-public final class DecimalInsertActionTest {
-    private final double minValue;
-    private final double maxValue;
-    private final int decimalCount;
-    private final String expectedString;
-
-
-    public DecimalInsertActionTest(final double minValue, final double maxValue, final int decimalCount,
-                                   final String expectedString) {
-        this.minValue = minValue;
-        this.maxValue = maxValue;
-        this.decimalCount = decimalCount;
-        this.expectedString = expectedString;
-    }
-
-
-    @Parameterized.Parameters
-    public static Collection<Object[]> params() {
-        return Arrays.asList(new Object[][] {
+final class DecimalInsertActionTest {
+    @SuppressWarnings("PMD.UnusedPrivateMethod") // Used as parameterized method source
+    private static Collection<Object[]> provider() {
+        return Arrays.asList(new Object[][]{
                 {5.0, 5.0, 0, "5"},
                 {7.0, 7.0, 1, "7.0"},
                 {8.0, 8.0, 2, "8.00"},
@@ -61,8 +44,9 @@ public final class DecimalInsertActionTest {
     }
 
 
-    @Test
-    public void testValue() {
+    @ParameterizedTest
+    @MethodSource("provider")
+    void testValue(final double minValue, final double maxValue, final int decimalCount, final String expectedString) {
         final DecimalSettings decimalSettings = new DecimalSettings();
         decimalSettings.setMinValue(minValue);
         decimalSettings.setMaxValue(maxValue);

--- a/src/test/java/com/fwdekker/randomness/decimal/DecimalSettingsTest.java
+++ b/src/test/java/com/fwdekker/randomness/decimal/DecimalSettingsTest.java
@@ -1,7 +1,7 @@
 package com.fwdekker.randomness.decimal;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -9,23 +9,23 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Unit tests for {@link DecimalSettings}.
  */
-public final class DecimalSettingsTest {
+final class DecimalSettingsTest {
     private DecimalSettings decimalSettings;
 
 
-    @Before
-    public void beforeEach() {
+    @BeforeEach
+    void beforeEach() {
         decimalSettings = new DecimalSettings();
     }
 
 
     @Test
-    public void testGetComponentName() {
+    void testGetComponentName() {
         assertThat(decimalSettings.getComponentName()).isEqualTo("DecimalSettings");
     }
 
     @Test
-    public void testGetLoadState() {
+    void testGetLoadState() {
         decimalSettings.setMinValue(399.75);
         decimalSettings.setMaxValue(928.22);
         decimalSettings.setDecimalCount(205);
@@ -39,63 +39,63 @@ public final class DecimalSettingsTest {
     }
 
     @Test
-    public void testGetSetMinValue() {
+    void testGetSetMinValue() {
         decimalSettings.setMinValue(720.41);
 
         assertThat(decimalSettings.getMinValue()).isEqualTo(720.41);
     }
 
     @Test
-    public void testGetSetMaxValue() {
+    void testGetSetMaxValue() {
         decimalSettings.setMaxValue(901.38);
 
         assertThat(decimalSettings.getMaxValue()).isEqualTo(901.38);
     }
 
     @Test
-    public void testGetSetDecimalCount() {
+    void testGetSetDecimalCount() {
         decimalSettings.setDecimalCount(987);
 
         assertThat(decimalSettings.getDecimalCount()).isEqualTo(987);
     }
 
     @Test
-    public void testGetSetGroupingSeparator() {
+    void testGetSetGroupingSeparator() {
         decimalSettings.setGroupingSeparator('L');
 
         assertThat(decimalSettings.getGroupingSeparator()).isEqualTo('L');
     }
 
     @Test
-    public void testGetSetGroupingSeparatorStringEmpty() {
+    void testGetSetGroupingSeparatorStringEmpty() {
         decimalSettings.setGroupingSeparator("");
 
         assertThat(decimalSettings.getGroupingSeparator()).isEqualTo('\0');
     }
 
     @Test
-    public void testGetSetGroupingSeparatorString() {
+    void testGetSetGroupingSeparatorString() {
         decimalSettings.setGroupingSeparator("3lk-c");
 
         assertThat(decimalSettings.getGroupingSeparator()).isEqualTo('3');
     }
 
     @Test
-    public void testGetSetDecimalSeparator() {
+    void testGetSetDecimalSeparator() {
         decimalSettings.setDecimalSeparator('}');
 
         assertThat(decimalSettings.getDecimalSeparator()).isEqualTo('}');
     }
 
     @Test
-    public void testGetSetDecimalSeparatorStringEmpty() {
+    void testGetSetDecimalSeparatorStringEmpty() {
         decimalSettings.setDecimalSeparator("");
 
         assertThat(decimalSettings.getDecimalSeparator()).isEqualTo('\0');
     }
 
     @Test
-    public void testGetSetDecimalSeparatorString() {
+    void testGetSetDecimalSeparatorString() {
         decimalSettings.setDecimalSeparator("Px@>[");
 
         assertThat(decimalSettings.getDecimalSeparator()).isEqualTo('P');

--- a/src/test/java/com/fwdekker/randomness/integer/IntegerInsertActionBaseTest.java
+++ b/src/test/java/com/fwdekker/randomness/integer/IntegerInsertActionBaseTest.java
@@ -1,8 +1,7 @@
 package com.fwdekker.randomness.integer;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -13,26 +12,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Unit tests for the base conversion used in {@link IntegerInsertAction}.
  */
-@RunWith(Parameterized.class)
-public final class IntegerInsertActionBaseTest {
-    private final long value;
-    private final int base;
-    private final char groupingSeparator;
-    private final String expectedString;
-
-
-    public IntegerInsertActionBaseTest(final long value, final int base,
-                                       final char groupingSeparator,
-                                       final String expectedString) {
-        this.value = value;
-        this.base = base;
-        this.groupingSeparator = groupingSeparator;
-        this.expectedString = expectedString;
-    }
-
-
-    @Parameterized.Parameters
-    public static Collection<Object[]> params() {
+final class IntegerInsertActionBaseTest {
+    @SuppressWarnings("PMD.UnusedPrivateMethod") // Used as parameterized method source
+    private static Collection<Object[]> provider() {
         return Arrays.asList(new Object[][]{
                 {33360, 10, '.', "33.360"},
                 {48345, 10, '.', "48.345"},
@@ -41,8 +23,9 @@ public final class IntegerInsertActionBaseTest {
     }
 
 
-    @Test
-    public void testValue() {
+    @ParameterizedTest
+    @MethodSource("provider")
+    void testValue(final long value, final int base, final char groupingSeparator, final String expectedString) {
         final IntegerSettings integerSettings = new IntegerSettings();
         integerSettings.setMinValue(value);
         integerSettings.setMaxValue(value);

--- a/src/test/java/com/fwdekker/randomness/integer/IntegerInsertActionSymbolTest.java
+++ b/src/test/java/com/fwdekker/randomness/integer/IntegerInsertActionSymbolTest.java
@@ -1,8 +1,7 @@
 package com.fwdekker.randomness.integer;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -13,23 +12,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Unit tests for the symbols used in {@link IntegerInsertAction}.
  */
-@RunWith(Parameterized.class)
-public final class IntegerInsertActionSymbolTest {
-    private final long value;
-    private final char groupingSeparator;
-    private final String expectedString;
-
-
-    public IntegerInsertActionSymbolTest(final long value, final char groupingSeparator, final String expectedString) {
-        this.value = value;
-        this.groupingSeparator = groupingSeparator;
-        this.expectedString = expectedString;
-    }
-
-
-    @Parameterized.Parameters
-    public static Collection<Object[]> params() {
-        return Arrays.asList(new Object[][] {
+final class IntegerInsertActionSymbolTest {
+    @SuppressWarnings("PMD.UnusedPrivateMethod") // Used as parameterized method source
+    private static Collection<Object[]> provider() {
+        return Arrays.asList(new Object[][]{
                 {95713, '\0', "95713"},
                 {163583, '.', "163.583"},
                 {351426, ',', "351,426"},
@@ -37,8 +23,9 @@ public final class IntegerInsertActionSymbolTest {
     }
 
 
-    @Test
-    public void testValue() {
+    @ParameterizedTest
+    @MethodSource("provider")
+    void testValue(final long value, final char groupingSeparator, final String expectedString) {
         final IntegerSettings integerSettings = new IntegerSettings();
         integerSettings.setMinValue(value);
         integerSettings.setMaxValue(value);

--- a/src/test/java/com/fwdekker/randomness/integer/IntegerInsertActionTest.java
+++ b/src/test/java/com/fwdekker/randomness/integer/IntegerInsertActionTest.java
@@ -1,10 +1,11 @@
 package com.fwdekker.randomness.integer;
 
-import java.util.Arrays;
-import java.util.Collection;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/src/test/java/com/fwdekker/randomness/integer/IntegerInsertActionTest.java
+++ b/src/test/java/com/fwdekker/randomness/integer/IntegerInsertActionTest.java
@@ -1,8 +1,7 @@
 package com.fwdekker.randomness.integer;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -13,23 +12,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Parameterized unit tests for {@link IntegerInsertAction}.
  */
-@RunWith(Parameterized.class)
-public final class IntegerInsertActionTest {
-    private final int minValue;
-    private final int maxValue;
-    private final String expectedString;
-
-
-    public IntegerInsertActionTest(final int minValue, final int maxValue, final String expectedString) {
-        this.minValue = minValue;
-        this.maxValue = maxValue;
-        this.expectedString = expectedString;
-    }
-
-
-    @Parameterized.Parameters
-    public static Collection<Object[]> params() {
-        return Arrays.asList(new Object[][] {
+final class IntegerInsertActionTest {
+    @SuppressWarnings("PMD.UnusedPrivateMethod") // Used as parameterized method source
+    private static Collection<Object[]> provider() {
+        return Arrays.asList(new Object[][]{
                 {0, 0, "0"},
                 {1, 1, "1"},
                 {-5, -5, "-5"},
@@ -39,8 +25,9 @@ public final class IntegerInsertActionTest {
     }
 
 
-    @Test
-    public void testValue() {
+    @ParameterizedTest
+    @MethodSource("provider")
+    void testValue(final int minValue, final int maxValue, final String expectedString) {
         final IntegerSettings integerSettings = new IntegerSettings();
         integerSettings.setMinValue(minValue);
         integerSettings.setMaxValue(maxValue);

--- a/src/test/java/com/fwdekker/randomness/integer/IntegerSettingsTest.java
+++ b/src/test/java/com/fwdekker/randomness/integer/IntegerSettingsTest.java
@@ -1,7 +1,7 @@
 package com.fwdekker.randomness.integer;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -9,23 +9,23 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Unit tests for {@link IntegerSettings}.
  */
-public final class IntegerSettingsTest {
+final class IntegerSettingsTest {
     private IntegerSettings integerSettings;
 
 
-    @Before
-    public void beforeEach() {
+    @BeforeEach
+    void beforeEach() {
         integerSettings = new IntegerSettings();
     }
 
 
     @Test
-    public void testGetComponentName() {
+    void testGetComponentName() {
         assertThat(integerSettings.getComponentName()).isEqualTo("IntegerSettings");
     }
 
     @Test
-    public void testGetLoadState() {
+    void testGetLoadState() {
         integerSettings.setMinValue(742);
         integerSettings.setMaxValue(908);
         integerSettings.setBase(12);
@@ -39,42 +39,42 @@ public final class IntegerSettingsTest {
     }
 
     @Test
-    public void testGetSetMinValue() {
+    void testGetSetMinValue() {
         integerSettings.setMinValue(366);
 
         assertThat(integerSettings.getMinValue()).isEqualTo(366);
     }
 
     @Test
-    public void testGetSetMaxValue() {
+    void testGetSetMaxValue() {
         integerSettings.setMaxValue(332);
 
         assertThat(integerSettings.getMaxValue()).isEqualTo(332);
     }
 
     @Test
-    public void testGetSetBase() {
+    void testGetSetBase() {
         integerSettings.setBase(7);
 
         assertThat(integerSettings.getBase()).isEqualTo(7);
     }
 
     @Test
-    public void testGetSetGroupingSeparator() {
+    void testGetSetGroupingSeparator() {
         integerSettings.setGroupingSeparator('6');
 
         assertThat(integerSettings.getGroupingSeparator()).isEqualTo('6');
     }
 
     @Test
-    public void testGetSetGroupingSeparatorStringEmpty() {
+    void testGetSetGroupingSeparatorStringEmpty() {
         integerSettings.setGroupingSeparator("");
 
         assertThat(integerSettings.getGroupingSeparator()).isEqualTo('\0');
     }
 
     @Test
-    public void testGetSetGroupingSeparatorString() {
+    void testGetSetGroupingSeparatorString() {
         integerSettings.setGroupingSeparator("tlRg}");
 
         assertThat(integerSettings.getGroupingSeparator()).isEqualTo('t');

--- a/src/test/java/com/fwdekker/randomness/string/AlphabetTest.java
+++ b/src/test/java/com/fwdekker/randomness/string/AlphabetTest.java
@@ -1,8 +1,9 @@
 package com.fwdekker.randomness.string;
 
+import org.junit.jupiter.api.Test;
+
 import java.util.Arrays;
 import java.util.List;
-import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -10,9 +11,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Unit tests for {@link Alphabet}.
  */
-public final class AlphabetTest {
+final class AlphabetTest {
     @Test
-    public void testConcatenate() {
+    void testConcatenate() {
         final List<Alphabet> alphabets = Arrays.asList(Alphabet.LOWERCASE, Alphabet.MINUS, Alphabet.SPECIAL);
 
         assertThat(Alphabet.concatenate(alphabets)).isEqualTo("abcdefghijklmnopqrstuvwxyz-!@#$%^&*");
@@ -20,17 +21,17 @@ public final class AlphabetTest {
 
 
     @Test
-    public void testGetName() {
+    void testGetName() {
         assertThat(Alphabet.UPPERCASE.getName()).isEqualTo("Uppercase (A, B, C, ...)");
     }
 
     @Test
-    public void testGetSymbols() {
+    void testGetSymbols() {
         assertThat(Alphabet.UPPERCASE.getSymbols()).isEqualTo("ABCDEFGHIJKLMNOPQRSTUVWXYZ");
     }
 
     @Test
-    public void testToString() {
+    void testToString() {
         assertThat(Alphabet.UPPERCASE.toString()).isEqualTo("Uppercase (A, B, C, ...)");
     }
 }

--- a/src/test/java/com/fwdekker/randomness/string/StringInsertActionTest.java
+++ b/src/test/java/com/fwdekker/randomness/string/StringInsertActionTest.java
@@ -1,13 +1,14 @@
 package com.fwdekker.randomness.string;
 
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.regex.Pattern;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/src/test/java/com/fwdekker/randomness/string/StringInsertActionTest.java
+++ b/src/test/java/com/fwdekker/randomness/string/StringInsertActionTest.java
@@ -1,8 +1,7 @@
 package com.fwdekker.randomness.string;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -16,57 +15,41 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Parameterized unit tests for {@link StringInsertAction}.
  */
-@RunWith(Parameterized.class)
-public final class StringInsertActionTest {
-    private final int minLength;
-    private final int maxLength;
-    private final String enclosure;
-    private final Set<Alphabet> alphabets;
+final class StringInsertActionTest {
+    @SuppressWarnings("PMD.UnusedPrivateMethod") // Used as parameterized method source
+    private static Collection<Object[]> provider() {
+        return Arrays.asList(new Object[][]{
+                {0, 0, "", new Alphabet[]{}},
+                {0, 0, "'", new Alphabet[]{}},
+                {0, 0, "a", new Alphabet[]{}},
+                {0, 0, "2Rv", new Alphabet[]{}},
 
-
-    public StringInsertActionTest(final int minLength, final int maxLength, final String enclosure,
-                                  final Alphabet... alphabets) {
-        this.minLength = minLength;
-        this.maxLength = maxLength;
-        this.enclosure = enclosure;
-        this.alphabets = new HashSet<>(Arrays.asList(alphabets));
-    }
-
-
-    @Parameterized.Parameters
-    public static Collection<Object[]> params() {
-        return Arrays.asList(new Object[][] {
-                {0, 0, "", new Alphabet[] {}},
-                {0, 0, "'", new Alphabet[] {}},
-                {0, 0, "a", new Alphabet[] {}},
-                {0, 0, "2Rv", new Alphabet[] {}},
-
-                {723, 723, "", new Alphabet[] {Alphabet.LOWERCASE}},
-                {466, 466, "z", new Alphabet[] {Alphabet.UPPERCASE, Alphabet.SPECIAL, Alphabet.UNDERSCORE}}
+                {723, 723, "", new Alphabet[]{Alphabet.LOWERCASE}},
+                {466, 466, "z", new Alphabet[]{Alphabet.UPPERCASE, Alphabet.SPECIAL, Alphabet.UNDERSCORE}}
         });
     }
 
 
-    @Test
-    public void testValue() {
+    @ParameterizedTest
+    @MethodSource("provider")
+    void testValue(final int minLength, final int maxLength, final String enclosure, final Alphabet... alphabets) {
+        final Set<Alphabet> alphabetSet = new HashSet<>(Arrays.asList(alphabets));
+
         final StringSettings stringSettings = new StringSettings();
         stringSettings.setMinLength(minLength);
         stringSettings.setMaxLength(maxLength);
         stringSettings.setEnclosure(enclosure);
-        stringSettings.setAlphabets(alphabets);
+        stringSettings.setAlphabets(alphabetSet);
 
         final StringInsertAction insertRandomString = new StringInsertAction(stringSettings);
+        final Pattern expectedPattern = buildExpectedPattern(minLength, maxLength, enclosure, alphabetSet);
 
-        assertThat(insertRandomString.generateString()).containsPattern(buildResultPattern());
+        assertThat(insertRandomString.generateString()).containsPattern(expectedPattern);
     }
 
 
-    /**
-     * Builds a pattern describing the expected format of generated string.
-     *
-     * @return a pattern describing the expected format of generated string
-     */
-    private Pattern buildResultPattern() {
+    private Pattern buildExpectedPattern(final int minLength, final int maxLength, final String enclosure,
+                                         final Set<Alphabet> alphabets) {
         final StringBuilder regex = new StringBuilder();
 
         regex.append(enclosure);

--- a/src/test/java/com/fwdekker/randomness/string/StringSettingsTest.java
+++ b/src/test/java/com/fwdekker/randomness/string/StringSettingsTest.java
@@ -1,11 +1,12 @@
 package com.fwdekker.randomness.string;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
-import org.junit.Before;
-import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -13,23 +14,23 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Unit tests for {@link StringSettings}.
  */
-public final class StringSettingsTest {
+final class StringSettingsTest {
     private StringSettings stringSettings;
 
 
-    @Before
-    public void beforeEach() {
+    @BeforeEach
+    void beforeEach() {
         stringSettings = new StringSettings();
     }
 
 
     @Test
-    public void testGetComponentName() {
+    void testGetComponentName() {
         assertThat(stringSettings.getComponentName()).isEqualTo("StringSettings");
     }
 
     @Test
-    public void testGetLoadState() {
+    void testGetLoadState() {
         final HashSet<Alphabet> alphabets = new HashSet<>(Collections.emptyList());
 
         stringSettings.setMinLength(730);
@@ -47,28 +48,28 @@ public final class StringSettingsTest {
     }
 
     @Test
-    public void testGetSetMinLength() {
+    void testGetSetMinLength() {
         stringSettings.setMinLength(173);
 
         assertThat(stringSettings.getMinLength()).isEqualTo(173);
     }
 
     @Test
-    public void testGetSetMaxLength() {
+    void testGetSetMaxLength() {
         stringSettings.setMaxLength(421);
 
         assertThat(stringSettings.getMaxLength()).isEqualTo(421);
     }
 
     @Test
-    public void testGetSetEnclosure() {
+    void testGetSetEnclosure() {
         stringSettings.setEnclosure("hWD");
 
         assertThat(stringSettings.getEnclosure()).isEqualTo("hWD");
     }
 
     @Test
-    public void testGetSetAlphabets() {
+    void testGetSetAlphabets() {
         final Set<Alphabet> alphabets
                 = new HashSet<>(Arrays.asList(Alphabet.LOWERCASE, Alphabet.BRACKETS, Alphabet.MINUS));
         stringSettings.setAlphabets(alphabets);

--- a/src/test/java/com/fwdekker/randomness/ui/ButtonGroupHelperTest.java
+++ b/src/test/java/com/fwdekker/randomness/ui/ButtonGroupHelperTest.java
@@ -1,7 +1,7 @@
 package com.fwdekker.randomness.ui;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.swing.AbstractButton;
 import javax.swing.ButtonGroup;
@@ -15,18 +15,18 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /**
  * Unit tests for {@link ButtonGroupHelper}.
  */
-public final class ButtonGroupHelperTest {
+final class ButtonGroupHelperTest {
     private ButtonGroup group;
 
 
-    @Before
-    public void beforeEach() {
+    @BeforeEach
+    void beforeEach() {
         group = new ButtonGroup();
     }
 
 
     @Test
-    public void testForEachEmpty() {
+    void testForEachEmpty() {
         final int[] sum = {0};
 
         ButtonGroupHelper.forEach(group, button -> sum[0]++);
@@ -35,7 +35,7 @@ public final class ButtonGroupHelperTest {
     }
 
     @Test
-    public void testForEach() {
+    void testForEach() {
         final AbstractButton buttonA = new JButton();
         final AbstractButton buttonB = new JButton();
         final AbstractButton buttonC = new JButton();
@@ -53,12 +53,12 @@ public final class ButtonGroupHelperTest {
 
 
     @Test
-    public void testGetValueEmpty() {
+    void testGetValueEmpty() {
         assertThat(ButtonGroupHelper.getValue(group)).isNull();
     }
 
     @Test
-    public void testGetValueNoneSelected() {
+    void testGetValueNoneSelected() {
         final AbstractButton button = new JButton();
 
         group.add(button);
@@ -67,7 +67,7 @@ public final class ButtonGroupHelperTest {
     }
 
     @Test
-    public void testGetValue() {
+    void testGetValue() {
         final AbstractButton buttonA = new JButton();
         buttonA.setActionCommand("29zo4");
         final AbstractButton buttonB = new JButton();
@@ -82,14 +82,14 @@ public final class ButtonGroupHelperTest {
 
 
     @Test
-    public void testSetValueEmpty() {
+    void testSetValueEmpty() {
         assertThatThrownBy(() -> ButtonGroupHelper.setValue(group, "syWR#"))
                 .isInstanceOf(NoSuchElementException.class)
                 .hasMessage("Could not find a button with action command `syWR#`.");
     }
 
     @Test
-    public void testSetValueNotFound() {
+    void testSetValueNotFound() {
         final AbstractButton buttonA = new JButton();
         buttonA.setActionCommand("*VgyA");
         final AbstractButton buttonB = new JButton();
@@ -104,7 +104,7 @@ public final class ButtonGroupHelperTest {
     }
 
     @Test
-    public void testSetValue() {
+    void testSetValue() {
         final AbstractButton buttonA = new JButton();
         buttonA.setActionCommand("TRUaN");
         final AbstractButton buttonB = new JButton();
@@ -122,7 +122,7 @@ public final class ButtonGroupHelperTest {
     }
 
     @Test
-    public void testSetValueObject() {
+    void testSetValueObject() {
         final AbstractButton buttonA = new JButton();
         buttonA.setActionCommand("iqGfVwJDLd");
         final AbstractButton buttonB = new JButton();

--- a/src/test/java/com/fwdekker/randomness/ui/JDoubleSpinnerTest.java
+++ b/src/test/java/com/fwdekker/randomness/ui/JDoubleSpinnerTest.java
@@ -1,7 +1,7 @@
 package com.fwdekker.randomness.ui;
 
 import com.fwdekker.randomness.ValidationException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -10,23 +10,23 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /**
  * Unit tests for {@link JDoubleSpinner}.
  */
-public final class JDoubleSpinnerTest {
+final class JDoubleSpinnerTest {
     @Test
-    public void testIllegalMinValue() {
+    void testIllegalMinValue() {
         assertThatThrownBy(() -> new JDoubleSpinner(-1E80, -477.23))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("minValue should not be smaller than -1.0E53.");
     }
 
     @Test
-    public void testIllegalMaxValue() {
+    void testIllegalMaxValue() {
         assertThatThrownBy(() -> new JDoubleSpinner(-161.29, 1E73))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("maxValue should not be greater than 1.0E53.");
     }
 
     @Test
-    public void testIllegalRange() {
+    void testIllegalRange() {
         assertThatThrownBy(() -> new JDoubleSpinner(-602.98, -929.41))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("minValue should be greater than maxValue.");
@@ -34,7 +34,7 @@ public final class JDoubleSpinnerTest {
 
 
     @Test
-    public void testGetSetValue() {
+    void testGetSetValue() {
         final JDoubleSpinner spinner = new JDoubleSpinner();
 
         spinner.setValue(179.40);
@@ -43,7 +43,7 @@ public final class JDoubleSpinnerTest {
     }
 
     @Test
-    public void testGetSetValueType() {
+    void testGetSetValueType() {
         final JDoubleSpinner spinner = new JDoubleSpinner();
 
         spinner.setValue(638L);
@@ -53,7 +53,7 @@ public final class JDoubleSpinnerTest {
 
 
     @Test
-    public void testValidateUnderflow() {
+    void testValidateUnderflow() {
         final JDoubleSpinner spinner = new JDoubleSpinner();
 
         spinner.setValue(-1E55);
@@ -64,7 +64,7 @@ public final class JDoubleSpinnerTest {
     }
 
     @Test
-    public void testValidateOverflow() {
+    void testValidateOverflow() {
         final JDoubleSpinner spinner = new JDoubleSpinner();
 
         spinner.setValue(1E98);
@@ -75,7 +75,7 @@ public final class JDoubleSpinnerTest {
     }
 
     @Test
-    public void testValidateUnderflowCustomRange() {
+    void testValidateUnderflowCustomRange() {
         final JDoubleSpinner spinner = new JDoubleSpinner(-738.33, 719.45);
 
         spinner.setValue(-808.68);
@@ -86,7 +86,7 @@ public final class JDoubleSpinnerTest {
     }
 
     @Test
-    public void testValidateOverflowCustomRange() {
+    void testValidateOverflowCustomRange() {
         final JDoubleSpinner spinner = new JDoubleSpinner(-972.80, -69.36);
 
         spinner.setValue(94.0);

--- a/src/test/java/com/fwdekker/randomness/ui/JEditableListTest.java
+++ b/src/test/java/com/fwdekker/randomness/ui/JEditableListTest.java
@@ -1,11 +1,12 @@
 package com.fwdekker.randomness.ui;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.NoSuchElementException;
-import org.junit.Before;
-import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -14,24 +15,24 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /**
  * Unit tests for {@link JEditableList}.
  */
-public final class JEditableListTest {
+final class JEditableListTest {
     private JEditableList<String> list;
 
 
-    @Before
-    public void beforeEach() {
+    @BeforeEach
+    void beforeEach() {
         list = new JEditableList<>();
     }
 
 
     @Test
-    public void testGetEntriesEmpty() {
+    void testGetEntriesEmpty() {
         assertThat(list.getEntries())
                 .isEmpty();
     }
 
     @Test
-    public void testAddEntry() {
+    void testAddEntry() {
         list.addEntry("sxTODMrLvE");
 
         assertThat(list.getEntries())
@@ -39,7 +40,7 @@ public final class JEditableListTest {
     }
 
     @Test
-    public void testAddEntryDuplicate() {
+    void testAddEntryDuplicate() {
         list.addEntry("6bqmI9JEkv");
         list.addEntry("6bqmI9JEkv");
 
@@ -48,7 +49,7 @@ public final class JEditableListTest {
     }
 
     @Test
-    public void testSetEntriesEmptyToEmpty() {
+    void testSetEntriesEmptyToEmpty() {
         list.setEntries(Collections.emptyList());
 
         assertThat(list.getEntries())
@@ -56,7 +57,7 @@ public final class JEditableListTest {
     }
 
     @Test
-    public void testSetEntriesEmptyToNonEmpty() {
+    void testSetEntriesEmptyToNonEmpty() {
         list.setEntries(Arrays.asList("[qOBxjKQ6P", "DGw{4ag(99"));
 
         assertThat(list.getEntries())
@@ -64,7 +65,7 @@ public final class JEditableListTest {
     }
 
     @Test
-    public void testSetEntriesNonemptyToEmpty() {
+    void testSetEntriesNonemptyToEmpty() {
         list.addEntry("u1}9]G<<CN");
         list.addEntry("SV9MUxo5yM");
         list.setEntries(Collections.emptyList());
@@ -74,7 +75,7 @@ public final class JEditableListTest {
     }
 
     @Test
-    public void testSetEntriesNonemptyToNonempty() {
+    void testSetEntriesNonemptyToNonempty() {
         list.addEntry("d>OO>rp2zJ");
         list.addEntry("Po(tiIXnxQ");
         list.addEntry("oq5BQYk0<7");
@@ -85,7 +86,7 @@ public final class JEditableListTest {
     }
 
     @Test
-    public void testRemoveEntry() {
+    void testRemoveEntry() {
         list.addEntry("><t1wfkCLz");
         list.addEntry("X0hxkJGK)7");
         list.addEntry("TI5i9bUyLc");
@@ -96,7 +97,7 @@ public final class JEditableListTest {
     }
 
     @Test
-    public void testRemoveEntryDuplicate() {
+    void testRemoveEntryDuplicate() {
         list.addEntry("UNIODenA]8");
         list.addEntry(">q(isDDjGx");
         list.addEntry("tyFoveRt5n");
@@ -108,7 +109,7 @@ public final class JEditableListTest {
     }
 
     @Test
-    public void testRemoveEntryNonExisting() {
+    void testRemoveEntryNonExisting() {
         list.addEntry("qiGIG5Slmn");
         list.addEntry("uxlt{9}FeZ");
         list.addEntry("a4BEQoJpLJ");
@@ -120,7 +121,7 @@ public final class JEditableListTest {
     }
 
     @Test
-    public void testClearEmpty() {
+    void testClearEmpty() {
         list.clear();
 
         assertThat(list.getEntries())
@@ -128,7 +129,7 @@ public final class JEditableListTest {
     }
 
     @Test
-    public void testClearNonempty() {
+    void testClearNonempty() {
         list.addEntry("4lbw4K>}UH");
         list.addEntry("CMVe{rkBl[");
         list.clear();
@@ -138,13 +139,13 @@ public final class JEditableListTest {
     }
 
     @Test
-    public void testGetEntryCountEmpty() {
+    void testGetEntryCountEmpty() {
         assertThat(list.getEntryCount())
                 .isEqualTo(0);
     }
 
     @Test
-    public void testGetEntryCount() {
+    void testGetEntryCount() {
         list.addEntry("1JfHiG[CiD");
         list.addEntry("gXsoY21wzb");
 
@@ -153,7 +154,7 @@ public final class JEditableListTest {
     }
 
     @Test
-    public void testGetEntryCountDuplicate() {
+    void testGetEntryCountDuplicate() {
         list.addEntry("jDwxzlHh]f");
         list.addEntry("A>)6q<f5kT");
         list.addEntry("A>)6q<f5kT");
@@ -164,13 +165,13 @@ public final class JEditableListTest {
 
 
     @Test
-    public void testActiveEntriesEmpty() {
+    void testActiveEntriesEmpty() {
         assertThat(list.getActiveEntries())
                 .isEmpty();
     }
 
     @Test
-    public void testActiveEntriesNone() {
+    void testActiveEntriesNone() {
         list.setEntries(Arrays.asList("DnqtROf4fd", "0<16CDsby2", "h0hu4XePhv"));
 
         assertThat(list.getActiveEntries())
@@ -178,7 +179,7 @@ public final class JEditableListTest {
     }
 
     @Test
-    public void testActiveEntriesSome() {
+    void testActiveEntriesSome() {
         final List<String> entries = Arrays.asList("9}juZWluy}", "UGuD08qUXr", "eQA[]AdpYR");
         list.setEntries(entries);
         list.setActiveEntries(Arrays.asList("UGuD08qUXr"));
@@ -188,7 +189,7 @@ public final class JEditableListTest {
     }
 
     @Test
-    public void testActiveEntriesAll() {
+    void testActiveEntriesAll() {
         final List<String> entries = Arrays.asList("o28ix>b}x(", "6Zzl>yi5LB", "XyEVdjv1VM");
         list.setEntries(entries);
         list.setActiveEntries(entries);
@@ -198,7 +199,7 @@ public final class JEditableListTest {
     }
 
     @Test
-    public void testSetActiveEntriesNonExistent() {
+    void testSetActiveEntriesNonExistent() {
         final List<String> entries = Arrays.asList("JXIPoWsGR{", ">Jq7ILgv9]");
         list.setEntries(entries);
         list.setActiveEntries(Arrays.asList("JXIPoWsGR{", "j>NBYo}DnW", ">Jq7ILgv9]"));
@@ -208,7 +209,7 @@ public final class JEditableListTest {
     }
 
     @Test
-    public void testIsActive() {
+    void testIsActive() {
         final List<String> entries = Arrays.asList("I85kO5f8}6", "qcSv3u((zE", "{jjD)iFxEr");
         list.setEntries(entries);
         list.setEntryActivity("I85kO5f8}6", true);
@@ -219,7 +220,7 @@ public final class JEditableListTest {
     }
 
     @Test
-    public void testIsActiveNonExistent() {
+    void testIsActiveNonExistent() {
         assertThatThrownBy(() -> list.isActive("Vr{1zIC9iH"))
                 .isInstanceOf(NoSuchElementException.class)
                 .hasMessage("No row with entry `Vr{1zIC9iH` found.")
@@ -227,7 +228,7 @@ public final class JEditableListTest {
     }
 
     @Test
-    public void testActivityListenerOnUpdate() {
+    void testActivityListenerOnUpdate() {
         final boolean[] fired = {false};
         list.addEntry("DsX[DtA>6{");
 
@@ -238,7 +239,7 @@ public final class JEditableListTest {
     }
 
     @Test
-    public void testActivityListenerNoChangeOnInsert() {
+    void testActivityListenerNoChangeOnInsert() {
         final boolean[] fired = {false};
 
         list.addEntryActivityChangeListener(event -> fired[0] = true);
@@ -248,7 +249,7 @@ public final class JEditableListTest {
     }
 
     @Test
-    public void testActivityListenerRemoveNoFire() {
+    void testActivityListenerRemoveNoFire() {
         final boolean[] fired = {false};
         list.addEntry("bvDAPSZFG3");
 
@@ -262,12 +263,12 @@ public final class JEditableListTest {
 
 
     @Test
-    public void testGetHighlightedEntryNone() {
+    void testGetHighlightedEntryNone() {
         assertThat(list.getHighlightedEntry()).isNotPresent();
     }
 
     @Test
-    public void testGetHighlightedEntrySingle() {
+    void testGetHighlightedEntrySingle() {
         list.setEntries(Arrays.asList("Bb]CEbJlAD", "8QNk5l<]ln", "U5Hbo0whnn"));
         list.addRowSelectionInterval(0, 0);
 
@@ -276,7 +277,7 @@ public final class JEditableListTest {
     }
 
     @Test
-    public void testGetHighlightedEntryMultiple() {
+    void testGetHighlightedEntryMultiple() {
         list.setEntries(Arrays.asList("k<Goz2<IG9", "E4nRBR>wKG", "sCxbg}sfy("));
         list.addRowSelectionInterval(0, 0);
         list.addRowSelectionInterval(2, 2);
@@ -287,7 +288,7 @@ public final class JEditableListTest {
 
 
     @Test
-    public void testGetColumnClasses() {
+    void testGetColumnClasses() {
         assertThat(list.getColumnClass(0)).isEqualTo(Boolean.class);
         assertThat(list.getColumnClass(1)).isEqualTo(String.class);
 
@@ -302,7 +303,7 @@ public final class JEditableListTest {
     }
 
     @Test
-    public void testIsCellEditable() {
+    void testIsCellEditable() {
         assertThat(list.isCellEditable(10, 5)).isFalse();
         assertThat(list.isCellEditable(7, 10)).isFalse();
         assertThat(list.isCellEditable(8, 2)).isFalse();

--- a/src/test/java/com/fwdekker/randomness/ui/JLongSpinnerTest.java
+++ b/src/test/java/com/fwdekker/randomness/ui/JLongSpinnerTest.java
@@ -1,7 +1,7 @@
 package com.fwdekker.randomness.ui;
 
 import com.fwdekker.randomness.ValidationException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -10,9 +10,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /**
  * Unit tests for {@link JLongSpinner}.
  */
-public final class JLongSpinnerTest {
+final class JLongSpinnerTest {
     @Test
-    public void testIllegalRange() {
+    void testIllegalRange() {
         assertThatThrownBy(() -> new JLongSpinner(414, 989, -339))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("(minimum <= value <= maximum) is false");
@@ -20,7 +20,7 @@ public final class JLongSpinnerTest {
 
 
     @Test
-    public void testGetSetValue() {
+    void testGetSetValue() {
         final JLongSpinner spinner = new JLongSpinner();
 
         spinner.setValue(-583L);
@@ -29,7 +29,7 @@ public final class JLongSpinnerTest {
     }
 
     @Test
-    public void testGetSetValueType() {
+    void testGetSetValueType() {
         final JLongSpinner spinner = new JLongSpinner();
 
         spinner.setValue(125);
@@ -38,7 +38,7 @@ public final class JLongSpinnerTest {
     }
 
     @Test
-    public void testGetSetValueTruncation() {
+    void testGetSetValueTruncation() {
         final JLongSpinner spinner = new JLongSpinner();
 
         spinner.setValue(786.79);
@@ -48,7 +48,7 @@ public final class JLongSpinnerTest {
 
 
     @Test
-    public void testGetSetMinValue() {
+    void testGetSetMinValue() {
         final JLongSpinner spinner = new JLongSpinner();
 
         spinner.setMinValue(979L);
@@ -57,7 +57,7 @@ public final class JLongSpinnerTest {
     }
 
     @Test
-    public void testGetSetMaxValue() {
+    void testGetSetMaxValue() {
         final JLongSpinner spinner = new JLongSpinner();
 
         spinner.setMaxValue(166L);
@@ -67,7 +67,7 @@ public final class JLongSpinnerTest {
 
 
     @Test
-    public void testValidateUnderflowCustomRange() {
+    void testValidateUnderflowCustomRange() {
         final JLongSpinner spinner = new JLongSpinner(-665, -950, -559);
 
         spinner.setValue(-979);
@@ -78,7 +78,7 @@ public final class JLongSpinnerTest {
     }
 
     @Test
-    public void testValidateOverflowCustomRange() {
+    void testValidateOverflowCustomRange() {
         final JLongSpinner spinner = new JLongSpinner(424, 279, 678);
 
         spinner.setValue(838);

--- a/src/test/java/com/fwdekker/randomness/ui/JSpinnerRangeTest.java
+++ b/src/test/java/com/fwdekker/randomness/ui/JSpinnerRangeTest.java
@@ -1,9 +1,10 @@
 package com.fwdekker.randomness.ui;
 
 import com.fwdekker.randomness.ValidationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import javax.swing.JSpinner;
-import org.junit.Before;
-import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
@@ -13,20 +14,20 @@ import static org.mockito.Mockito.when;
 /**
  * Unit tests for {@link JSpinnerRange}.
  */
-public final class JSpinnerRangeTest {
+final class JSpinnerRangeTest {
     private JSpinner min;
     private JSpinner max;
 
 
-    @Before
-    public void beforeEach() {
+    @BeforeEach
+    void beforeEach() {
         min = mock(JSpinner.class);
         max = mock(JSpinner.class);
     }
 
 
     @Test
-    public void testIllegalMaxRange() {
+    void testIllegalMaxRange() {
         assertThatThrownBy(() -> new JSpinnerRange(min, max, -37.20))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("maxRange must be a positive number.");
@@ -34,7 +35,7 @@ public final class JSpinnerRangeTest {
 
 
     @Test
-    public void testRangeRelative() {
+    void testRangeRelative() {
         when(min.getValue()).thenReturn(85.20);
         when(max.getValue()).thenReturn(-636.33);
 
@@ -46,7 +47,7 @@ public final class JSpinnerRangeTest {
     }
 
     @Test
-    public void testRangeSize() {
+    void testRangeSize() {
         when(min.getValue()).thenReturn(-1E53);
         when(max.getValue()).thenReturn(1E53);
 
@@ -58,7 +59,7 @@ public final class JSpinnerRangeTest {
     }
 
     @Test
-    public void testRangeSizeCustomRange() {
+    void testRangeSizeCustomRange() {
         when(min.getValue()).thenReturn(-794.90);
         when(max.getValue()).thenReturn(769.52);
 

--- a/src/test/java/com/fwdekker/randomness/word/BundledDictionaryTest.java
+++ b/src/test/java/com/fwdekker/randomness/word/BundledDictionaryTest.java
@@ -1,7 +1,7 @@
 package com.fwdekker.randomness.word;
 
 import com.intellij.openapi.ui.ValidationInfo;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -10,9 +10,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /**
  * Unit tests for {@link Dictionary.BundledDictionary}.
  */
-public final class BundledDictionaryTest {
+final class BundledDictionaryTest {
     @Test
-    public void testInitDoesNotExist() {
+    void testInitDoesNotExist() {
         assertThatThrownBy(() -> Dictionary.BundledDictionary.get("invalid_resource"))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Failed to read dictionary into memory.")
@@ -20,7 +20,7 @@ public final class BundledDictionaryTest {
     }
 
     @Test
-    public void testInitEmpty() {
+    void testInitEmpty() {
         assertThatThrownBy(() -> Dictionary.BundledDictionary.get("dictionaries/empty.dic"))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Dictionary must be non-empty.")
@@ -28,7 +28,7 @@ public final class BundledDictionaryTest {
     }
 
     @Test
-    public void testInitTwiceEquals() {
+    void testInitTwiceEquals() {
         final Dictionary dictionaryA = Dictionary.BundledDictionary.get("dictionaries/varied.dic");
         final Dictionary dictionaryB = Dictionary.BundledDictionary.get("dictionaries/varied.dic");
 
@@ -37,7 +37,7 @@ public final class BundledDictionaryTest {
 
 
     @Test
-    public void testValidateInstanceSuccess() {
+    void testValidateInstanceSuccess() {
         final Dictionary dictionary = Dictionary.BundledDictionary.get("dictionaries/simple.dic");
 
         final ValidationInfo validationInfo = dictionary.validate();
@@ -46,14 +46,14 @@ public final class BundledDictionaryTest {
     }
 
     @Test
-    public void testValidateStaticSuccess() {
+    void testValidateStaticSuccess() {
         final ValidationInfo validationInfo = Dictionary.BundledDictionary.validate("dictionaries/simple.dic");
 
         assertThat(validationInfo).isNull();
     }
 
     @Test
-    public void testValidateStaticFileDoesNotExist() {
+    void testValidateStaticFileDoesNotExist() {
         final ValidationInfo validationInfo = Dictionary.BundledDictionary.validate("invalid_resource");
 
         assertThat(validationInfo).isNotNull();
@@ -62,7 +62,7 @@ public final class BundledDictionaryTest {
     }
 
     @Test
-    public void testValidateStaticFileEmpty() {
+    void testValidateStaticFileEmpty() {
         final ValidationInfo validationInfo = Dictionary.BundledDictionary.validate("dictionaries/empty.dic");
 
         assertThat(validationInfo).isNotNull();
@@ -72,7 +72,7 @@ public final class BundledDictionaryTest {
 
 
     @Test
-    public void testToString() {
+    void testToString() {
         final Dictionary dictionary = Dictionary.BundledDictionary.get("dictionaries/simple.dic");
 
         assertThat(dictionary.toString()).isEqualTo("[bundled] simple.dic");

--- a/src/test/java/com/fwdekker/randomness/word/CapitalizationModeTest.java
+++ b/src/test/java/com/fwdekker/randomness/word/CapitalizationModeTest.java
@@ -1,6 +1,6 @@
 package com.fwdekker.randomness.word;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.NoSuchElementException;
 
@@ -11,114 +11,114 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /**
  * Unit tests for {@link CapitalizationMode}.
  */
-public final class CapitalizationModeTest {
+final class CapitalizationModeTest {
     @Test
-    public void testRetainTransform() {
+    void testRetainTransform() {
         assertThat(CapitalizationMode.RETAIN.getTransform().apply("AwfJYzzUoR")).isEqualTo("AwfJYzzUoR");
     }
 
     @Test
-    public void testSentenceTransformEmptyString() {
+    void testSentenceTransformEmptyString() {
         assertThat(CapitalizationMode.SENTENCE.getTransform().apply("")).isEqualTo("");
     }
 
     @Test
-    public void testSentenceTransform() {
+    void testSentenceTransform() {
         assertThat(CapitalizationMode.SENTENCE.getTransform().apply("cOoKiE")).isEqualTo("Cookie");
     }
 
     @Test
-    public void testUpperTransform() {
+    void testUpperTransform() {
         assertThat(CapitalizationMode.UPPER.getTransform().apply("vAnDaLisM")).isEqualTo("VANDALISM");
     }
 
     @Test
-    public void testLowerTransform() {
+    void testLowerTransform() {
         assertThat(CapitalizationMode.LOWER.getTransform().apply("ChAnnEl")).isEqualTo("channel");
     }
 
     @Test
-    public void testFirstLetterTransform() {
+    void testFirstLetterTransform() {
         assertThat(CapitalizationMode.FIRST_LETTER.getTransform().apply("bgiOP SMQpR")).isEqualTo("Bgiop Smqpr");
     }
 
     @Test
-    public void testGetNameRetain() {
+    void testGetNameRetain() {
         assertThat(CapitalizationMode.RETAIN.getName()).isEqualTo("retain");
     }
 
     @Test
-    public void testGetNameSentence() {
+    void testGetNameSentence() {
         assertThat(CapitalizationMode.SENTENCE.getName()).isEqualTo("sentence");
     }
 
     @Test
-    public void testGetNameUpper() {
+    void testGetNameUpper() {
         assertThat(CapitalizationMode.UPPER.getName()).isEqualTo("upper");
     }
 
     @Test
-    public void testGetNameLower() {
+    void testGetNameLower() {
         assertThat(CapitalizationMode.LOWER.getName()).isEqualTo("lower");
     }
 
     @Test
-    public void testGetNameFirstLetter() {
+    void testGetNameFirstLetter() {
         assertThat(CapitalizationMode.FIRST_LETTER.getName()).isEqualTo("first letter");
     }
 
     @Test
-    public void testToStringRetain() {
+    void testToStringRetain() {
         assertThat(CapitalizationMode.RETAIN.toString()).isEqualTo("retain");
     }
 
     @Test
-    public void testToStringSentence() {
+    void testToStringSentence() {
         assertThat(CapitalizationMode.SENTENCE.toString()).isEqualTo("sentence");
     }
 
     @Test
-    public void testToStringUpper() {
+    void testToStringUpper() {
         assertThat(CapitalizationMode.UPPER.toString()).isEqualTo("upper");
     }
 
     @Test
-    public void testToStringLower() {
+    void testToStringLower() {
         assertThat(CapitalizationMode.LOWER.toString()).isEqualTo("lower");
     }
 
     @Test
-    public void testToStringFirstLetter() {
+    void testToStringFirstLetter() {
         assertThat(CapitalizationMode.FIRST_LETTER.toString()).isEqualTo("first letter");
     }
 
     @Test
-    public void testGetModeRetain() {
+    void testGetModeRetain() {
         assertThat(CapitalizationMode.getMode("retain")).isEqualTo(CapitalizationMode.RETAIN);
     }
 
     @Test
-    public void testGetModeSentence() {
+    void testGetModeSentence() {
         assertThat(CapitalizationMode.getMode("sentence")).isEqualTo(CapitalizationMode.SENTENCE);
     }
 
     @Test
-    public void testGetModeUpper() {
+    void testGetModeUpper() {
         assertThat(CapitalizationMode.getMode("upper")).isEqualTo(CapitalizationMode.UPPER);
     }
 
     @Test
-    public void testGetModeLower() {
+    void testGetModeLower() {
         assertThat(CapitalizationMode.getMode("lower")).isEqualTo(CapitalizationMode.LOWER);
     }
 
     @Test
-    public void testGetModeFirstLetter() {
+    void testGetModeFirstLetter() {
         assertThat(CapitalizationMode.getMode("first letter")).isEqualTo(CapitalizationMode.FIRST_LETTER);
     }
 
     @Test
-    public void testGetModeOther() {
+    void testGetModeOther() {
         assertThatThrownBy(() -> CapitalizationMode.getMode(""))
                 .isInstanceOf(NoSuchElementException.class)
                 .hasMessage("There does not exist a capitalization mode with name ``.")

--- a/src/test/java/com/fwdekker/randomness/word/DictionaryFileHelper.java
+++ b/src/test/java/com/fwdekker/randomness/word/DictionaryFileHelper.java
@@ -14,7 +14,7 @@ import static org.assertj.core.api.Assertions.fail;
 /**
  * Helper class for file manipulation for tests of {@code Dictionary}s.
  */
-public final class DictionaryFileHelper {
+final class DictionaryFileHelper {
     /**
      * The files that have been created by this helper.
      */
@@ -24,7 +24,7 @@ public final class DictionaryFileHelper {
     /**
      * Constructs a new {@code DictionaryFileHelper}.
      */
-    public DictionaryFileHelper() {
+    DictionaryFileHelper() {
         files = new ArrayList<>();
     }
 
@@ -37,7 +37,7 @@ public final class DictionaryFileHelper {
      * @param contents the contents to write to the dictionary file
      * @return the created temporary dictionary file
      */
-    public File setUpDictionary(final String contents) {
+    File setUpDictionary(final String contents) {
         final File dictionaryFile;
 
         try {
@@ -55,7 +55,7 @@ public final class DictionaryFileHelper {
     /**
      * Cleans up the created dictionary files.
      */
-    public void cleanUpDictionaries() {
+    void cleanUpDictionaries() {
         for (final File dictionaryFile : files) {
             if (dictionaryFile.exists() && !dictionaryFile.delete()) {
                 Logger.getLogger(this.getClass().getName()).warning("Failed to clean up dictionary file.");

--- a/src/test/java/com/fwdekker/randomness/word/DictionaryTest.java
+++ b/src/test/java/com/fwdekker/randomness/word/DictionaryTest.java
@@ -1,7 +1,7 @@
 package com.fwdekker.randomness.word;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 
@@ -12,12 +12,12 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /**
  * Unit tests for {@link Dictionary}.
  */
-public final class DictionaryTest {
+final class DictionaryTest {
     private Dictionary dictionary;
 
 
     @Test
-    public void testEmptyDictionary() {
+    void testEmptyDictionary() {
         assertThatThrownBy(() -> Dictionary.BundledDictionary.get("dictionaries/empty.dic"))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Dictionary must be non-empty.")
@@ -26,7 +26,7 @@ public final class DictionaryTest {
 
 
     @Test
-    public void testGetPath() {
+    void testGetPath() {
         useDictionary("simple");
 
         assertThat(dictionary.getUid())
@@ -34,7 +34,7 @@ public final class DictionaryTest {
     }
 
     @Test
-    public void testGetWords() {
+    void testGetWords() {
         useDictionary("simple");
 
         assertThat(dictionary.getWords())
@@ -43,7 +43,7 @@ public final class DictionaryTest {
 
 
     @Test
-    public void testGetWordsWithLengthInRangeInvertedRange() {
+    void testGetWordsWithLengthInRangeInvertedRange() {
         useDictionary("simple");
 
         assertThat(dictionary.getWordsWithLengthInRange(696, 54))
@@ -51,7 +51,7 @@ public final class DictionaryTest {
     }
 
     @Test
-    public void testGetWordsWithLengthInRangeNegativeLength() {
+    void testGetWordsWithLengthInRangeNegativeLength() {
         useDictionary("simple");
 
         assertThat(dictionary.getWordsWithLengthInRange(-4, -2))
@@ -59,7 +59,7 @@ public final class DictionaryTest {
     }
 
     @Test
-    public void testGetWordsWithLengthInRangeEmptyRange() {
+    void testGetWordsWithLengthInRangeEmptyRange() {
         useDictionary("simple");
 
         assertThat(dictionary.getWordsWithLengthInRange(0, 0))
@@ -67,7 +67,7 @@ public final class DictionaryTest {
     }
 
     @Test
-    public void testGetWordsWithLengthInRangeOvershortWord() {
+    void testGetWordsWithLengthInRangeOvershortWord() {
         useDictionary("varied");
 
         assertThat(dictionary.getWordsWithLengthInRange(0, 1))
@@ -75,7 +75,7 @@ public final class DictionaryTest {
     }
 
     @Test
-    public void testGetWordsWithLengthInRangeShortWord() {
+    void testGetWordsWithLengthInRangeShortWord() {
         useDictionary("simple");
 
         assertThat(dictionary.getWordsWithLengthInRange(1, 1))
@@ -83,7 +83,7 @@ public final class DictionaryTest {
     }
 
     @Test
-    public void testGetWordsWithLengthInRangeLongWord() {
+    void testGetWordsWithLengthInRangeLongWord() {
         useDictionary("varied");
 
         assertThat(dictionary.getWordsWithLengthInRange(40, 50))
@@ -91,7 +91,7 @@ public final class DictionaryTest {
     }
 
     @Test
-    public void testGetWordsWithLengthInRangeOverlongWord() {
+    void testGetWordsWithLengthInRangeOverlongWord() {
         useDictionary("simple");
 
         assertThat(dictionary.getWordsWithLengthInRange(1000, 1001))
@@ -100,7 +100,7 @@ public final class DictionaryTest {
 
 
     @Test
-    public void testGetShortestWordSimple() {
+    void testGetShortestWordSimple() {
         useDictionary("simple");
 
         assertThat(dictionary.getShortestWord())
@@ -108,7 +108,7 @@ public final class DictionaryTest {
     }
 
     @Test
-    public void testGetShortestWordVaried() {
+    void testGetShortestWordVaried() {
         useDictionary("varied");
 
         assertThat(dictionary.getShortestWord())
@@ -116,7 +116,7 @@ public final class DictionaryTest {
     }
 
     @Test
-    public void testGetLongestWordSimple() {
+    void testGetLongestWordSimple() {
         useDictionary("simple");
 
         assertThat(dictionary.getLongestWord())
@@ -124,7 +124,7 @@ public final class DictionaryTest {
     }
 
     @Test
-    public void testGetLongestWordVaried() {
+    void testGetLongestWordVaried() {
         useDictionary("varied");
 
         assertThat(dictionary.getLongestWord())
@@ -133,7 +133,7 @@ public final class DictionaryTest {
 
 
     @Test
-    public void testCombine() {
+    void testCombine() {
         final Dictionary combined = Dictionary.combine(Arrays.asList(
                 Dictionary.BundledDictionary.get("dictionaries/simple.dic"),
                 Dictionary.BundledDictionary.get("dictionaries/varied.dic")));
@@ -144,7 +144,7 @@ public final class DictionaryTest {
     }
 
     @Test
-    public void testCombineDuplicates() {
+    void testCombineDuplicates() {
         final Dictionary combined = Dictionary.combine(Arrays.asList(
                 Dictionary.BundledDictionary.get("dictionaries/simple.dic"),
                 Dictionary.BundledDictionary.get("dictionaries/simple.dic")));
@@ -155,7 +155,7 @@ public final class DictionaryTest {
 
 
     @Test
-    public void testEqualsContract() {
+    void testEqualsContract() {
         EqualsVerifier.forClass(Dictionary.class)
                 .usingGetClass()
                 .withIgnoredFields("name", "words")

--- a/src/test/java/com/fwdekker/randomness/word/UserDictionaryTest.java
+++ b/src/test/java/com/fwdekker/randomness/word/UserDictionaryTest.java
@@ -1,8 +1,8 @@
 package com.fwdekker.randomness.word;
 
 import com.intellij.openapi.ui.ValidationInfo;
-import org.junit.AfterClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -14,18 +14,18 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /**
  * Unit tests for {@link Dictionary.UserDictionary}.
  */
-public final class UserDictionaryTest {
+final class UserDictionaryTest {
     private static final DictionaryFileHelper FILE_HELPER = new DictionaryFileHelper();
 
 
-    @AfterClass
-    public static void afterAll() {
+    @AfterAll
+    static void afterAll() {
         FILE_HELPER.cleanUpDictionaries();
     }
 
 
     @Test
-    public void testInitDoesNotExist() {
+    void testInitDoesNotExist() {
         assertThatThrownBy(() -> Dictionary.UserDictionary.get("invalid_file"))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Failed to read dictionary into memory.")
@@ -33,7 +33,7 @@ public final class UserDictionaryTest {
     }
 
     @Test
-    public void testInitEmpty() {
+    void testInitEmpty() {
         final File dictionaryFile = FILE_HELPER.setUpDictionary("");
 
         assertThatThrownBy(() -> Dictionary.UserDictionary.get(dictionaryFile.getAbsolutePath()))
@@ -42,7 +42,7 @@ public final class UserDictionaryTest {
     }
 
     @Test
-    public void testInitTwiceEquals() {
+    void testInitTwiceEquals() {
         final File dictionaryFile = FILE_HELPER.setUpDictionary("Fonded\nLustrum\nUpgale");
 
         final Dictionary dictionaryA = Dictionary.UserDictionary.get(dictionaryFile.getAbsolutePath());
@@ -53,7 +53,7 @@ public final class UserDictionaryTest {
 
 
     @Test
-    public void testValidateInstanceSuccess() {
+    void testValidateInstanceSuccess() {
         final File dictionaryFile = FILE_HELPER.setUpDictionary("Rhodinal\nScruff\nPibrochs");
         final Dictionary dictionary = Dictionary.UserDictionary.get(dictionaryFile.getAbsolutePath());
 
@@ -63,7 +63,7 @@ public final class UserDictionaryTest {
     }
 
     @Test
-    public void testValidateStaticSuccess() {
+    void testValidateStaticSuccess() {
         final File dictionaryFile = FILE_HELPER.setUpDictionary("Bbls\nOverpray\nTreeward");
 
         final ValidationInfo validationInfo = Dictionary.UserDictionary.validate(dictionaryFile.getAbsolutePath());
@@ -72,7 +72,7 @@ public final class UserDictionaryTest {
     }
 
     @Test
-    public void testValidateStaticFileDoesNotExist() {
+    void testValidateStaticFileDoesNotExist() {
         final ValidationInfo validationInfo = Dictionary.UserDictionary.validate("invalid_path");
 
         assertThat(validationInfo).isNotNull();
@@ -81,7 +81,7 @@ public final class UserDictionaryTest {
     }
 
     @Test
-    public void testValidateStaticFileEmpty() {
+    void testValidateStaticFileEmpty() {
         final File dictionaryFile = FILE_HELPER.setUpDictionary("");
         final String dictionaryName = dictionaryFile.getName();
 
@@ -94,7 +94,7 @@ public final class UserDictionaryTest {
 
 
     @Test
-    public void testToString() {
+    void testToString() {
         final File dictionaryFile = FILE_HELPER.setUpDictionary("Cholers\nJaloused\nStopback");
         final String dictionaryName = dictionaryFile.getName();
 

--- a/src/test/java/com/fwdekker/randomness/word/WordInsertActionTest.java
+++ b/src/test/java/com/fwdekker/randomness/word/WordInsertActionTest.java
@@ -1,8 +1,7 @@
 package com.fwdekker.randomness.word;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -13,22 +12,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Parameterized unit tests for {@link WordInsertAction}.
  */
-@RunWith(Parameterized.class)
-public final class WordInsertActionTest {
-    private final int minLength;
-    private final int maxLength;
-    private final String enclosure;
-
-
-    public WordInsertActionTest(final int minLength, final int maxLength, final String enclosure) {
-        this.minLength = minLength;
-        this.maxLength = maxLength;
-        this.enclosure = enclosure;
-    }
-
-
-    @Parameterized.Parameters
-    public static Collection<Object[]> params() {
+final class WordInsertActionTest {
+    @SuppressWarnings("PMD.UnusedPrivateMethod") // Used as parameterized method source
+    private static Collection<Object[]> provider() {
         return Arrays.asList(new Object[][] {
                 {0, 1, ""},
                 {1, 1, ""},
@@ -40,8 +26,9 @@ public final class WordInsertActionTest {
     }
 
 
-    @Test
-    public void testValue() {
+    @ParameterizedTest
+    @MethodSource("provider")
+    void testValue(final int minLength, final int maxLength, final String enclosure) {
         final WordSettings wordSettings = new WordSettings();
         wordSettings.setMinLength(minLength);
         wordSettings.setMaxLength(maxLength);

--- a/src/test/java/com/fwdekker/randomness/word/WordInsertActionTest.java
+++ b/src/test/java/com/fwdekker/randomness/word/WordInsertActionTest.java
@@ -1,10 +1,11 @@
 package com.fwdekker.randomness.word;
 
-import java.util.Arrays;
-import java.util.Collection;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/src/test/java/com/fwdekker/randomness/word/WordSettingsTest.java
+++ b/src/test/java/com/fwdekker/randomness/word/WordSettingsTest.java
@@ -1,9 +1,9 @@
 package com.fwdekker.randomness.word;
 
 import com.intellij.openapi.ui.ValidationInfo;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.Arrays;
@@ -18,30 +18,30 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Unit tests for {@link WordSettings}.
  */
-public final class WordSettingsTest {
+final class WordSettingsTest {
     private static final DictionaryFileHelper FILE_HELPER = new DictionaryFileHelper();
 
     private WordSettings wordSettings;
 
 
-    @AfterClass
-    public static void afterAll() {
+    @AfterAll
+    static void afterAll() {
         FILE_HELPER.cleanUpDictionaries();
     }
 
-    @Before
-    public void beforeEach() {
+    @BeforeEach
+    void beforeEach() {
         wordSettings = new WordSettings();
     }
 
 
     @Test
-    public void testGetComponentName() {
+    void testGetComponentName() {
         assertThat(wordSettings.getComponentName()).isEqualTo("WordSettings");
     }
 
     @Test
-    public void testGetLoadState() {
+    void testGetLoadState() {
         wordSettings.setMinLength(502);
         wordSettings.setMaxLength(812);
         wordSettings.setEnclosure("QJ8S4UrFaa");
@@ -55,28 +55,28 @@ public final class WordSettingsTest {
     }
 
     @Test
-    public void testGetSetMinLength() {
+    void testGetSetMinLength() {
         wordSettings.setMinLength(905);
 
         assertThat(wordSettings.getMinLength()).isEqualTo(905);
     }
 
     @Test
-    public void testGetSetMaxLength() {
+    void testGetSetMaxLength() {
         wordSettings.setMaxLength(756);
 
         assertThat(wordSettings.getMaxLength()).isEqualTo(756);
     }
 
     @Test
-    public void testGetSetEnclosure() {
+    void testGetSetEnclosure() {
         wordSettings.setEnclosure("IERMV6Q5Qx");
 
         assertThat(wordSettings.getEnclosure()).isEqualTo("IERMV6Q5Qx");
     }
 
     @Test
-    public void testGetSetBundledDictionaries() {
+    void testGetSetBundledDictionaries() {
         final Set<String> bundledDictionaries = new HashSet<>(Arrays.asList("6OE]SfZj6(", "HGeldsz2XM", "V6AhkeIKX6"));
         wordSettings.setBundledDictionaries(bundledDictionaries);
 
@@ -84,7 +84,7 @@ public final class WordSettingsTest {
     }
 
     @Test
-    public void testGetSetUserDictionaries() {
+    void testGetSetUserDictionaries() {
         final Set<String> userDictionaries = new HashSet<>(Arrays.asList(")asQAYwW[u", "Bz>GSRlNA1", "Cjsg{Olylo"));
         wordSettings.setUserDictionaries(userDictionaries);
 
@@ -92,7 +92,7 @@ public final class WordSettingsTest {
     }
 
     @Test
-    public void testGetSetActiveBundledDictionaries() {
+    void testGetSetActiveBundledDictionaries() {
         final Set<String> bundledDictionaries = new HashSet<>(Arrays.asList("6QeMvZ>uHQ", "Onb]HUugM1", "008xGJhIXE"));
         wordSettings.setActiveBundledDictionaries(bundledDictionaries);
 
@@ -100,7 +100,7 @@ public final class WordSettingsTest {
     }
 
     @Test
-    public void testGetSetActiveUserDictionaries() {
+    void testGetSetActiveUserDictionaries() {
         final Set<String> userDictionaries = new HashSet<>(Arrays.asList("ukeB8}RLbm", "JRcuz7sm4(", "{QZGJQli36"));
         wordSettings.setActiveUserDictionaries(userDictionaries);
 
@@ -109,7 +109,7 @@ public final class WordSettingsTest {
 
 
     @Test
-    public void testValidateAllDictionariesSuccessEmpty() {
+    void testValidateAllDictionariesSuccessEmpty() {
         wordSettings.setBundledDictionaries(Collections.emptySet());
         wordSettings.setUserDictionaries(Collections.emptySet());
 
@@ -117,7 +117,7 @@ public final class WordSettingsTest {
     }
 
     @Test
-    public void testValidateAllDictionariesSuccessNonEmpty() {
+    void testValidateAllDictionariesSuccessNonEmpty() {
         final File userDictionary = FILE_HELPER.setUpDictionary("Reflet\nHerniate\nBuz");
 
         wordSettings.setBundledDictionaries(new HashSet<>(Arrays.asList("dictionaries/simple.dic")));
@@ -127,7 +127,7 @@ public final class WordSettingsTest {
     }
 
     @Test
-    public void testValidateAllDictionaryInvalidBundled() {
+    void testValidateAllDictionaryInvalidBundled() {
         final File userDictionary = FILE_HELPER.setUpDictionary("Inblow\nImmunes\nEnteroid");
 
         wordSettings.setBundledDictionaries(new HashSet<>(Arrays.asList("dictionaries/empty.dic")));
@@ -141,7 +141,7 @@ public final class WordSettingsTest {
     }
 
     @Test
-    public void testValidateAllDictionaryInvalidUser() {
+    void testValidateAllDictionaryInvalidUser() {
         final File userDictionary = FILE_HELPER.setUpDictionary("");
         final String userDictionaryName = userDictionary.getName();
 
@@ -156,7 +156,7 @@ public final class WordSettingsTest {
     }
 
     @Test
-    public void testValidateActiveDictionariesSuccessEmpty() {
+    void testValidateActiveDictionariesSuccessEmpty() {
         wordSettings.setActiveBundledDictionaries(Collections.emptySet());
         wordSettings.setActiveUserDictionaries(Collections.emptySet());
 
@@ -164,7 +164,7 @@ public final class WordSettingsTest {
     }
 
     @Test
-    public void testValidateActiveDictionariesSuccessNonEmpty() {
+    void testValidateActiveDictionariesSuccessNonEmpty() {
         final File userDictionary = FILE_HELPER.setUpDictionary("Dicranum\nJiffy\nChatties");
 
         wordSettings.setActiveBundledDictionaries(new HashSet<>(Arrays.asList("dictionaries/simple.dic")));
@@ -174,7 +174,7 @@ public final class WordSettingsTest {
     }
 
     @Test
-    public void testValidateActiveDictionaryInvalidBundled() {
+    void testValidateActiveDictionaryInvalidBundled() {
         final File userDictionary = FILE_HELPER.setUpDictionary("Fastest\nWows\nBrimmers");
 
         wordSettings.setActiveBundledDictionaries(new HashSet<>(Arrays.asList("dictionaries/empty.dic")));
@@ -188,7 +188,7 @@ public final class WordSettingsTest {
     }
 
     @Test
-    public void testValidateActiveDictionaryInvalidUser() {
+    void testValidateActiveDictionaryInvalidUser() {
         final File userDictionary = FILE_HELPER.setUpDictionary("");
         final String userDictionaryName = userDictionary.getName();
 
@@ -204,7 +204,7 @@ public final class WordSettingsTest {
 
 
     @Test
-    public void testGetValidAllDictionariesEmpty() {
+    void testGetValidAllDictionariesEmpty() {
         wordSettings.setBundledDictionaries(Collections.emptySet());
         wordSettings.setUserDictionaries(Collections.emptySet());
 
@@ -212,7 +212,7 @@ public final class WordSettingsTest {
     }
 
     @Test
-    public void testGetValidAllDictionariesFilterBoth() {
+    void testGetValidAllDictionariesFilterBoth() {
         final File validUserDictionary = FILE_HELPER.setUpDictionary("Resilium\nAncerata\nBylander");
         final File invalidUserDictionary = FILE_HELPER.setUpDictionary("");
 
@@ -234,7 +234,7 @@ public final class WordSettingsTest {
     }
 
     @Test
-    public void testGetValidActiveDictionariesEmpty() {
+    void testGetValidActiveDictionariesEmpty() {
         wordSettings.setActiveBundledDictionaries(Collections.emptySet());
         wordSettings.setActiveUserDictionaries(Collections.emptySet());
 
@@ -242,7 +242,7 @@ public final class WordSettingsTest {
     }
 
     @Test
-    public void testGetValidActiveDictionariesFilterBoth() {
+    void testGetValidActiveDictionariesFilterBoth() {
         final File validUserDictionary = FILE_HELPER.setUpDictionary("Resilium\nAncerata\nBylander");
         final File invalidUserDictionary = FILE_HELPER.setUpDictionary("");
 


### PR DESCRIPTION
(Finally) implements #51.

* Uses the [Gradle 4.6 native support for JUnit 5](https://docs.gradle.org/4.6/release-notes.html#junit-5-support).
* Upgrades test classes to JUnit 5:
  - Makes test classes and test methods package-private.
  - Replaces `org.junit` imports with `org.junit.jupiter.api` imports.
* Upgrades parameterized test classes to JUnit 5:
  - Uses the `@MethodSource` approach because this is closest to the JUnit 4 approach.
  - Suppresses `PMD.UnusedPrivateMethod` because PMD 5.6.1 does not understand that the provider method is actually used by JUnit. Perhaps a more recent version of PMD does not suffer this problem, but I haven't looked into upgrading to PMD 6 yet.

The `*SettingsDialogTest` classes could not be upgraded to JUnit 5 because the Swing test library is not compatible. These tests therefore still use the JUnit 4 annotations and are run with the JUnit 5 Vintage module.
