### PR TITLE
Dictionary dynamic reload

### DIFF
--- a/src/main/java/com/fwdekker/randomness/word/Dictionary.java
+++ b/src/main/java/com/fwdekker/randomness/word/Dictionary.java
@@ -212,16 +212,29 @@ public abstract class Dictionary {
         }
 
         /**
+         * Calls {@link #get(String, boolean)} with {@code useCache} set to {@code true}.
+         *
+         * @param path the path to the dictionary resource
+         * @return a new {@code BundledDictionary} for the given dictionary resource, or the previously created instance
+         * of this dictionary if there is one
+         */
+        public static BundledDictionary get(final String path) {
+            return get(path, true);
+        }
+
+        /**
          * Constructs a new {@code BundledDictionary} for the given dictionary resource, or returns the previously
          * created instance for this resource if there is one.
          *
-         * @param path the path to the dictionary resource
-         * @return a new {@code BundledDictionary} for the given dictionary resource, or returns the previously
-         * created instance of this resource if there is one
+         * @param path     the path to the dictionary resource
+         * @param useCache {@code true} if a cached version of the dictionary should be returned if it exists,
+         *                 {@code false} if the cache should always be updated
+         * @return a new {@code BundledDictionary} for the given dictionary resource, or the previously created instance
+         * of this dictionary if there is one
          */
-        public static BundledDictionary get(final String path) {
+        public static BundledDictionary get(final String path, final boolean useCache) {
             synchronized (BundledDictionary.class) {
-                if (!CACHE.containsKey(path)) {
+                if (!useCache || !CACHE.containsKey(path)) {
                     CACHE.put(path, new BundledDictionary(path));
                 }
             }
@@ -297,16 +310,29 @@ public abstract class Dictionary {
         }
 
         /**
+         * Calls {@link #get(String, boolean)} with {@code useCache} set to {@code true}.
+         *
+         * @param path the absolute path to the dictionary file
+         * @return a new {@code UserDictionary} for the given dictionary path, or the previously created instance of
+         * this dictionary if there is one
+         */
+        public static UserDictionary get(final String path) {
+            return get(path, true);
+        }
+
+        /**
          * Constructs a new {@code UserDictionary} for the given dictionary path, or returns the previously created
          * instance for the file if there is one.
          *
-         * @param path the absolute path to the dictionary file
-         * @return a new {@code UserDictionary} for the given dictionary path, or returns the previously created
-         * instance of this file if there is one
+         * @param path     the absolute path to the dictionary file
+         * @param useCache {@code true} if a cached version of the dictionary should be returned if it exists,
+         *                 {@code false} if the cache should always be updated
+         * @return a new {@code UserDictionary} for the given dictionary path, or the previously created instance of
+         * this dictionary if there is one
          */
-        public static UserDictionary get(final String path) {
+        public static UserDictionary get(final String path, final boolean useCache) {
             synchronized (UserDictionary.class) {
-                if (!CACHE.containsKey(path)) {
+                if (!useCache || !CACHE.containsKey(path)) {
                     CACHE.put(path, new UserDictionary(path));
                 }
             }

--- a/src/main/java/com/fwdekker/randomness/word/Dictionary.java
+++ b/src/main/java/com/fwdekker/randomness/word/Dictionary.java
@@ -242,6 +242,13 @@ public abstract class Dictionary {
             return CACHE.get(path);
         }
 
+        /**
+         * Clears the cache of stored dictionaries.
+         */
+        public static void clearCache() {
+            CACHE.clear();
+        }
+
 
         @Override
         public ValidationInfo validate() {
@@ -338,6 +345,13 @@ public abstract class Dictionary {
             }
 
             return CACHE.get(path);
+        }
+
+        /**
+         * Clears the cache of stored dictionaries.
+         */
+        public static void clearCache() {
+            CACHE.clear();
         }
 
 

--- a/src/main/java/com/fwdekker/randomness/word/WordSettingsDialog.java
+++ b/src/main/java/com/fwdekker/randomness/word/WordSettingsDialog.java
@@ -124,6 +124,8 @@ final class WordSettingsDialog extends SettingsDialog<WordSettings> {
                 .filter(Dictionary.BundledDictionary.class::isInstance)
                 .map(Dictionary::getUid)
                 .collect(Collectors.toSet()));
+        Dictionary.BundledDictionary.clearCache();
+
         settings.setUserDictionaries(dictionaries.getEntries().stream()
                 .filter(Dictionary.UserDictionary.class::isInstance)
                 .map(Dictionary::getUid)
@@ -132,6 +134,7 @@ final class WordSettingsDialog extends SettingsDialog<WordSettings> {
                 .filter(Dictionary.UserDictionary.class::isInstance)
                 .map(Dictionary::getUid)
                 .collect(Collectors.toSet()));
+        Dictionary.UserDictionary.clearCache();
     }
 
     @Override
@@ -179,7 +182,7 @@ final class WordSettingsDialog extends SettingsDialog<WordSettings> {
                 return;
             }
 
-            final Dictionary newDictionary = Dictionary.UserDictionary.get(files.get(0).getCanonicalPath());
+            final Dictionary newDictionary = Dictionary.UserDictionary.get(files.get(0).getCanonicalPath(), false);
             dictionaries.addEntry(newDictionary);
         });
     }

--- a/src/test/java/com/fwdekker/randomness/word/BundledDictionaryTest.java
+++ b/src/test/java/com/fwdekker/randomness/word/BundledDictionaryTest.java
@@ -32,7 +32,24 @@ final class BundledDictionaryTest {
         final Dictionary dictionaryA = Dictionary.BundledDictionary.get("dictionaries/varied.dic");
         final Dictionary dictionaryB = Dictionary.BundledDictionary.get("dictionaries/varied.dic");
 
-        assertThat(dictionaryA).isEqualTo(dictionaryB);
+        assertThat(dictionaryA).isSameAs(dictionaryB);
+    }
+
+    @Test
+    void testInitTwiceNoCacheEqualButNotSame() {
+        final Dictionary dictionaryA = Dictionary.BundledDictionary.get("dictionaries/simple.dic");
+        final Dictionary dictionaryB = Dictionary.BundledDictionary.get("dictionaries/simple.dic", false);
+
+        assertThat(dictionaryB).isEqualTo(dictionaryA);
+        assertThat(dictionaryB).isNotSameAs(dictionaryA);
+    }
+
+    @Test
+    void testInitNoCacheStoresAnyway() {
+        final Dictionary dictionaryA = Dictionary.BundledDictionary.get("dictionaries/simple.dic", false);
+        final Dictionary dictionaryB = Dictionary.BundledDictionary.get("dictionaries/simple.dic");
+
+        assertThat(dictionaryB).isSameAs(dictionaryA);
     }
 
 

--- a/src/test/java/com/fwdekker/randomness/word/DictionaryFileHelper.java
+++ b/src/test/java/com/fwdekker/randomness/word/DictionaryFileHelper.java
@@ -30,6 +30,20 @@ final class DictionaryFileHelper {
 
 
     /**
+     * Writes the given contents to the given file.
+     *
+     * @param target   the file to write to
+     * @param contents the contents to write to the file
+     */
+    void writeToFile(final File target, final String contents) {
+        try {
+            Files.write(target.toPath(), contents.getBytes(StandardCharsets.UTF_8));
+        } catch (IOException e) {
+            fail("Could not write to dictionary file.");
+        }
+    }
+
+    /**
      * Creates a temporary dictionary file with the given contents.
      * <p>
      * Because the created file is a temporary file, it does not have to be cleaned up afterwards.
@@ -42,7 +56,7 @@ final class DictionaryFileHelper {
 
         try {
             dictionaryFile = File.createTempFile("dictionary", ".dic");
-            Files.write(dictionaryFile.toPath(), contents.getBytes(StandardCharsets.UTF_8));
+            writeToFile(dictionaryFile, contents);
             files.add(dictionaryFile);
 
             return dictionaryFile;

--- a/src/test/java/com/fwdekker/randomness/word/UserDictionaryTest.java
+++ b/src/test/java/com/fwdekker/randomness/word/UserDictionaryTest.java
@@ -72,6 +72,20 @@ final class UserDictionaryTest {
         assertThat(dictionaryB).isSameAs(dictionaryA);
     }
 
+    @Test
+    void testInitAfterClearCache() {
+        final File dictionaryFile = FILE_HELPER.setUpDictionary("Melamin\nPetrol\nBruckled");
+        final Dictionary dictionaryBefore = Dictionary.UserDictionary.get(dictionaryFile.getAbsolutePath());
+
+        Dictionary.UserDictionary.clearCache();
+
+        FILE_HELPER.writeToFile(dictionaryFile, "Rutch\nDespin\nSweltry");
+        final Dictionary dictionaryAfter = Dictionary.UserDictionary.get(dictionaryFile.getAbsolutePath());
+
+        assertThat(dictionaryBefore.getWords()).containsExactlyInAnyOrder("Melamin", "Petrol", "Bruckled");
+        assertThat(dictionaryAfter.getWords()).containsExactlyInAnyOrder("Rutch", "Despin", "Sweltry");
+    }
+
 
     @Test
     void testValidateInstanceSuccess() {

--- a/src/test/java/com/fwdekker/randomness/word/UserDictionaryTest.java
+++ b/src/test/java/com/fwdekker/randomness/word/UserDictionaryTest.java
@@ -42,13 +42,34 @@ final class UserDictionaryTest {
     }
 
     @Test
-    void testInitTwiceEquals() {
+    void testInitTwiceSame() {
         final File dictionaryFile = FILE_HELPER.setUpDictionary("Fonded\nLustrum\nUpgale");
 
         final Dictionary dictionaryA = Dictionary.UserDictionary.get(dictionaryFile.getAbsolutePath());
         final Dictionary dictionaryB = Dictionary.UserDictionary.get(dictionaryFile.getAbsolutePath());
 
-        assertThat(dictionaryA).isEqualTo(dictionaryB);
+        assertThat(dictionaryA).isSameAs(dictionaryB);
+    }
+
+    @Test
+    void testInitTwiceNoCacheEqualButNotSame() {
+        final File dictionaryFile = FILE_HELPER.setUpDictionary("Dyers\nHexsub\nBookit");
+
+        final Dictionary dictionaryA = Dictionary.UserDictionary.get(dictionaryFile.getAbsolutePath());
+        final Dictionary dictionaryB = Dictionary.UserDictionary.get(dictionaryFile.getAbsolutePath(), false);
+
+        assertThat(dictionaryB).isEqualTo(dictionaryA);
+        assertThat(dictionaryB).isNotSameAs(dictionaryA);
+    }
+
+    @Test
+    void testInitNoCacheStoresAnyway() {
+        final File dictionaryFile = FILE_HELPER.setUpDictionary("Pecking\nAdinole\nFlashpan");
+
+        final Dictionary dictionaryA = Dictionary.UserDictionary.get(dictionaryFile.getAbsolutePath(), false);
+        final Dictionary dictionaryB = Dictionary.UserDictionary.get(dictionaryFile.getAbsolutePath());
+
+        assertThat(dictionaryB).isSameAs(dictionaryA);
     }
 
 


### PR DESCRIPTION
The contents of dictionaries are now refreshed each time the user saves the word settings.

Additionally, the cache is no longer used when a new dictionary is added. This will prevent the theoretical issue of a user trying to add an invalid dictionary, editing the source file, and then being unable to add the now-valid dictionary because the invalid version is still cached.
