### PR TITLE
Bump dependencies

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,6 +5,6 @@ assertjVersion        = 3.8.0
 assertjSwingVersion   = 3.8.0
 equalsVerifierVersion = 2.4.6
 findbugsVersion       = 3.0.1
-intellijVersion       = 2017.3
+intellijVersion       = 2018.2.3
 junitVersion          = 5.3.0
 mockitoVersion        = 2.22.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,5 +6,5 @@ assertjSwingVersion   = 3.8.0
 equalsVerifierVersion = 2.4.6
 findbugsVersion       = 3.0.1
 intellijVersion       = 2017.3
-junitVersion          = 5.2.0
-mockitoVersion        = 2.18.3
+junitVersion          = 5.3.0
+mockitoVersion        = 2.22.0


### PR DESCRIPTION
AssertJ was not updated from 3.8.0 to 3.11.0 because the Swing core is still at 3.8.0, and I'm not sure what effects it has on the compatibility.