### PR TITLE
Remove ApplicationComponent interface

### DIFF
--- a/src/main/java/com/fwdekker/randomness/Settings.java
+++ b/src/main/java/com/fwdekker/randomness/Settings.java
@@ -1,26 +1,12 @@
 package com.fwdekker.randomness;
 
-import com.intellij.openapi.components.ApplicationComponent;
+import com.intellij.openapi.components.PersistentStateComponent;
 
 
 /**
  * Superclass for classes that will contain settings that should persist over IDE restarts.
+ *
+ * @param <S> the class of settings that should be persisted
  */
-public abstract class Settings implements ApplicationComponent {
-    @Override
-    @SuppressWarnings("PMD.EmptyMethodInAbstractClassShouldBeAbstract") // This method should not be overridden
-    public final void initComponent() {
-        // No interaction with other plugins
-    }
-
-    @Override
-    @SuppressWarnings("PMD.EmptyMethodInAbstractClassShouldBeAbstract") // This method should not be overridden
-    public final void disposeComponent() {
-        // No interaction with other plugins
-    }
-
-    @Override
-    public final String getComponentName() {
-        return getClass().getSimpleName();
-    }
+public interface Settings<S extends Settings> extends PersistentStateComponent<S> {
 }

--- a/src/main/java/com/fwdekker/randomness/array/ArraySettings.java
+++ b/src/main/java/com/fwdekker/randomness/array/ArraySettings.java
@@ -1,7 +1,6 @@
 package com.fwdekker.randomness.array;
 
 import com.fwdekker.randomness.Settings;
-import com.intellij.openapi.components.PersistentStateComponent;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.components.State;
 import com.intellij.openapi.components.Storage;
@@ -17,7 +16,7 @@ import java.util.Collection;
         name = "ArraySettings",
         storages = @Storage("$APP_CONFIG$/randomness.xml")
 )
-public final class ArraySettings extends Settings implements PersistentStateComponent<ArraySettings> {
+public final class ArraySettings implements Settings<ArraySettings> {
     private static final int DEFAULT_COUNT = 5;
     private static final String DEFAULT_BRACKETS = "[]";
     private static final String DEFAULT_SEPARATOR = ",";

--- a/src/main/java/com/fwdekker/randomness/decimal/DecimalSettings.java
+++ b/src/main/java/com/fwdekker/randomness/decimal/DecimalSettings.java
@@ -1,7 +1,6 @@
 package com.fwdekker.randomness.decimal;
 
 import com.fwdekker.randomness.Settings;
-import com.intellij.openapi.components.PersistentStateComponent;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.components.State;
 import com.intellij.openapi.components.Storage;
@@ -15,7 +14,7 @@ import com.intellij.util.xmlb.XmlSerializerUtil;
         name = "DecimalSettings",
         storages = @Storage("$APP_CONFIG$/randomness.xml")
 )
-public final class DecimalSettings extends Settings implements PersistentStateComponent<DecimalSettings> {
+public final class DecimalSettings implements Settings<DecimalSettings> {
     private static final double DEFAULT_MIN_VALUE = 0.0;
     private static final double DEFAULT_MAX_VALUE = 1000.0;
     private static final int DEFAULT_DECIMAL_COUNT = 2;

--- a/src/main/java/com/fwdekker/randomness/integer/IntegerSettings.java
+++ b/src/main/java/com/fwdekker/randomness/integer/IntegerSettings.java
@@ -1,7 +1,6 @@
 package com.fwdekker.randomness.integer;
 
 import com.fwdekker.randomness.Settings;
-import com.intellij.openapi.components.PersistentStateComponent;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.components.State;
 import com.intellij.openapi.components.Storage;
@@ -16,7 +15,7 @@ import org.jetbrains.annotations.NotNull;
         name = "IntegerSettings",
         storages = @Storage("$APP_CONFIG$/randomness.xml")
 )
-public final class IntegerSettings extends Settings implements PersistentStateComponent<IntegerSettings> {
+public final class IntegerSettings implements Settings<IntegerSettings> {
     public static final int MIN_BASE = 2;
     public static final int DECIMAL_BASE = 10;
     public static final int MAX_BASE = 36;

--- a/src/main/java/com/fwdekker/randomness/string/StringSettings.java
+++ b/src/main/java/com/fwdekker/randomness/string/StringSettings.java
@@ -1,8 +1,7 @@
 package com.fwdekker.randomness.string;
 
-import com.fwdekker.randomness.Settings;
 import com.fwdekker.randomness.CapitalizationMode;
-import com.intellij.openapi.components.PersistentStateComponent;
+import com.fwdekker.randomness.Settings;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.components.State;
 import com.intellij.openapi.components.Storage;
@@ -21,7 +20,7 @@ import java.util.Set;
         name = "StringSettings",
         storages = @Storage("$APP_CONFIG$/randomness.xml")
 )
-public final class StringSettings extends Settings implements PersistentStateComponent<StringSettings> {
+public final class StringSettings implements Settings<StringSettings> {
     private static final int DEFAULT_MIN_LENGTH = 3;
     private static final int DEFAULT_MAX_LENGTH = 8;
 

--- a/src/main/java/com/fwdekker/randomness/uuid/UuidSettings.java
+++ b/src/main/java/com/fwdekker/randomness/uuid/UuidSettings.java
@@ -1,7 +1,6 @@
 package com.fwdekker.randomness.uuid;
 
 import com.fwdekker.randomness.Settings;
-import com.intellij.openapi.components.PersistentStateComponent;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.components.State;
 import com.intellij.openapi.components.Storage;
@@ -16,7 +15,7 @@ import org.jetbrains.annotations.NotNull;
         name = "UuidSettings",
         storages = @Storage("$APP_CONFIG$/randomness.xml")
 )
-public final class UuidSettings extends Settings implements PersistentStateComponent<UuidSettings> {
+public final class UuidSettings implements Settings<UuidSettings> {
     /**
      * The string that encloses the generated UUID on both sides.
      */

--- a/src/main/java/com/fwdekker/randomness/word/WordSettings.java
+++ b/src/main/java/com/fwdekker/randomness/word/WordSettings.java
@@ -2,7 +2,6 @@ package com.fwdekker.randomness.word;
 
 import com.fwdekker.randomness.CapitalizationMode;
 import com.fwdekker.randomness.Settings;
-import com.intellij.openapi.components.PersistentStateComponent;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.components.State;
 import com.intellij.openapi.components.Storage;
@@ -27,7 +26,7 @@ import java.util.stream.Collectors;
         name = "WordSettings",
         storages = @Storage("$APP_CONFIG$/randomness.xml")
 )
-public final class WordSettings extends Settings implements PersistentStateComponent<WordSettings> {
+public final class WordSettings implements Settings<WordSettings> {
     private static final int DEFAULT_MIN_LENGTH = 3;
     private static final int DEFAULT_MAX_LENGTH = 8;
 

--- a/src/test/java/com/fwdekker/randomness/array/ArraySettingsTest.java
+++ b/src/test/java/com/fwdekker/randomness/array/ArraySettingsTest.java
@@ -23,11 +23,6 @@ final class ArraySettingsTest {
 
 
     @Test
-    void testGetComponentName() {
-        assertThat(arraySettings.getComponentName()).isEqualTo("ArraySettings");
-    }
-
-    @Test
     void testGetLoadState() {
         arraySettings.setCount(997);
         arraySettings.setBrackets("0fWx<i6jTJ");

--- a/src/test/java/com/fwdekker/randomness/decimal/DecimalSettingsTest.java
+++ b/src/test/java/com/fwdekker/randomness/decimal/DecimalSettingsTest.java
@@ -20,11 +20,6 @@ final class DecimalSettingsTest {
 
 
     @Test
-    void testGetComponentName() {
-        assertThat(decimalSettings.getComponentName()).isEqualTo("DecimalSettings");
-    }
-
-    @Test
     void testGetLoadState() {
         decimalSettings.setMinValue(399.75);
         decimalSettings.setMaxValue(928.22);

--- a/src/test/java/com/fwdekker/randomness/integer/IntegerSettingsTest.java
+++ b/src/test/java/com/fwdekker/randomness/integer/IntegerSettingsTest.java
@@ -20,11 +20,6 @@ final class IntegerSettingsTest {
 
 
     @Test
-    void testGetComponentName() {
-        assertThat(integerSettings.getComponentName()).isEqualTo("IntegerSettings");
-    }
-
-    @Test
     void testGetLoadState() {
         integerSettings.setMinValue(742);
         integerSettings.setMaxValue(908);

--- a/src/test/java/com/fwdekker/randomness/string/StringSettingsTest.java
+++ b/src/test/java/com/fwdekker/randomness/string/StringSettingsTest.java
@@ -25,11 +25,6 @@ final class StringSettingsTest {
 
 
     @Test
-    void testGetComponentName() {
-        assertThat(stringSettings.getComponentName()).isEqualTo("StringSettings");
-    }
-
-    @Test
     void testGetLoadState() {
         final HashSet<Alphabet> alphabets = new HashSet<>(Collections.emptyList());
 

--- a/src/test/java/com/fwdekker/randomness/uuid/UuidSettingsTest.java
+++ b/src/test/java/com/fwdekker/randomness/uuid/UuidSettingsTest.java
@@ -20,11 +20,6 @@ public final class UuidSettingsTest {
 
 
     @Test
-    void testGetComponentName() {
-        assertThat(uuidSettings.getComponentName()).isEqualTo("UuidSettings");
-    }
-
-    @Test
     void testGetLoadState() {
         uuidSettings.setEnclosure("nvpB");
 

--- a/src/test/java/com/fwdekker/randomness/word/WordSettingsTest.java
+++ b/src/test/java/com/fwdekker/randomness/word/WordSettingsTest.java
@@ -36,11 +36,6 @@ final class WordSettingsTest {
 
 
     @Test
-    void testGetComponentName() {
-        assertThat(wordSettings.getComponentName()).isEqualTo("WordSettings");
-    }
-
-    @Test
     void testGetLoadState() {
         wordSettings.setMinLength(502);
         wordSettings.setMaxLength(812);


### PR DESCRIPTION
Every `*Settings` class extended `Settings` and implemented `PersistentStateComponent`. In turn, `Settings` implemented `ApplicationComponent`. As a result, all `*Settings` classes were two types of components at once, even though the `ApplicationComponent` functionalities were not being used (and they were not even registered as application components in the `plugin.xml`).

This PR removes code related to `ApplicationComponent` because this plugin does not use application components.