### PR TITLE
Make access modifiers consistent

### DIFF
--- a/src/main/java/com/fwdekker/randomness/array/ArraySettingsDialog.java
+++ b/src/main/java/com/fwdekker/randomness/array/ArraySettingsDialog.java
@@ -22,7 +22,7 @@ import javax.swing.JPanel;
         value = {"NP_NULL_ON_SOME_PATH"},
         justification = "Initialized by UI framework"
 )
-final class ArraySettingsDialog extends SettingsDialog<ArraySettings> {
+public final class ArraySettingsDialog extends SettingsDialog<ArraySettings> {
     private JPanel contentPane;
     private JLongSpinner countSpinner;
     private ButtonGroup bracketsGroup;

--- a/src/main/java/com/fwdekker/randomness/decimal/DecimalSettingsDialog.java
+++ b/src/main/java/com/fwdekker/randomness/decimal/DecimalSettingsDialog.java
@@ -19,7 +19,7 @@ import javax.swing.JPanel;
 /**
  * Dialog for settings of random decimal generation.
  */
-final class DecimalSettingsDialog extends SettingsDialog<DecimalSettings> {
+public final class DecimalSettingsDialog extends SettingsDialog<DecimalSettings> {
     private JPanel contentPane;
     private JSpinnerRange valueRange;
     private JDoubleSpinner minValue;

--- a/src/main/java/com/fwdekker/randomness/integer/IntegerSettingsDialog.java
+++ b/src/main/java/com/fwdekker/randomness/integer/IntegerSettingsDialog.java
@@ -18,7 +18,7 @@ import javax.swing.JPanel;
 /**
  * Dialog for settings of random integer generation.
  */
-final class IntegerSettingsDialog extends SettingsDialog<IntegerSettings> {
+public final class IntegerSettingsDialog extends SettingsDialog<IntegerSettings> {
     private JPanel contentPane;
     private JSpinnerRange valueRange;
     private JLongSpinner minValue;

--- a/src/main/java/com/fwdekker/randomness/string/StringSettingsDialog.java
+++ b/src/main/java/com/fwdekker/randomness/string/StringSettingsDialog.java
@@ -26,7 +26,7 @@ import java.util.HashSet;
         value = {"UWF_UNWRITTEN_FIELD", "NP_UNWRITTEN_FIELD"},
         justification = "Initialized by UI framework"
 )
-final class StringSettingsDialog extends SettingsDialog<StringSettings> {
+public final class StringSettingsDialog extends SettingsDialog<StringSettings> {
     private JPanel contentPane;
     private JSpinnerRange lengthRange;
     private JLongSpinner minLength;

--- a/src/main/java/com/fwdekker/randomness/word/WordSettingsDialog.java
+++ b/src/main/java/com/fwdekker/randomness/word/WordSettingsDialog.java
@@ -36,7 +36,7 @@ import java.util.stream.Collectors;
         value = {"UWF_UNWRITTEN_FIELD", "NP_UNWRITTEN_FIELD"},
         justification = "Initialized by UI framework"
 )
-final class WordSettingsDialog extends SettingsDialog<WordSettings> {
+public final class WordSettingsDialog extends SettingsDialog<WordSettings> {
     private JPanel contentPane;
     private JSpinnerRange lengthRange;
     private JLongSpinner minLength;


### PR DESCRIPTION
Makes all `SettingsDialog` classes public; before, only `UuidSettingsDialog` was public.