### PR TITLE
Improve backwards compatibility for settings

### DIFF
--- a/src/main/java/com/fwdekker/randomness/decimal/DecimalSettingsDialog.java
+++ b/src/main/java/com/fwdekker/randomness/decimal/DecimalSettingsDialog.java
@@ -90,8 +90,8 @@ public final class DecimalSettingsDialog extends SettingsDialog<DecimalSettings>
         minValue.setValue(settings.getMinValue());
         maxValue.setValue(settings.getMaxValue());
         decimalCount.setValue(settings.getDecimalCount());
-        ButtonGroupHelper.INSTANCE.setValue(groupingSeparatorGroup, String.valueOf(settings.getGroupingSeparator()));
-        ButtonGroupHelper.INSTANCE.setValue(decimalSeparatorGroup, String.valueOf(settings.getDecimalSeparator()));
+        ButtonGroupHelper.INSTANCE.setValue(groupingSeparatorGroup, settings.getGroupingSeparator());
+        ButtonGroupHelper.INSTANCE.setValue(decimalSeparatorGroup, settings.getDecimalSeparator());
     }
 
     @Override
@@ -102,10 +102,10 @@ public final class DecimalSettingsDialog extends SettingsDialog<DecimalSettings>
 
         final String groupingSeparator = ButtonGroupHelper.INSTANCE.getValue(groupingSeparatorGroup);
         settings.setGroupingSeparator(groupingSeparator == null || groupingSeparator.isEmpty()
-            ? '\0' : groupingSeparator.charAt(0));
+            ? DecimalSettings.DEFAULT_GROUPING_SEPARATOR : groupingSeparator);
 
         final String decimalSeparator = ButtonGroupHelper.INSTANCE.getValue(decimalSeparatorGroup);
         settings.setDecimalSeparator(decimalSeparator == null || decimalSeparator.isEmpty()
-            ? '\0' : decimalSeparator.charAt(0));
+            ? DecimalSettings.DEFAULT_DECIMAL_SEPARATOR : decimalSeparator);
     }
 }

--- a/src/main/java/com/fwdekker/randomness/integer/IntegerSettingsDialog.java
+++ b/src/main/java/com/fwdekker/randomness/integer/IntegerSettingsDialog.java
@@ -100,7 +100,7 @@ public final class IntegerSettingsDialog extends SettingsDialog<IntegerSettings>
         minValue.setValue(settings.getMinValue());
         maxValue.setValue(settings.getMaxValue());
         base.setValue((long) settings.getBase());
-        ButtonGroupHelper.INSTANCE.setValue(groupingSeparatorGroup, String.valueOf(settings.getGroupingSeparator()));
+        ButtonGroupHelper.INSTANCE.setValue(groupingSeparatorGroup, settings.getGroupingSeparator());
     }
 
     @Override
@@ -111,6 +111,6 @@ public final class IntegerSettingsDialog extends SettingsDialog<IntegerSettings>
 
         final String groupingSeparator = ButtonGroupHelper.INSTANCE.getValue(groupingSeparatorGroup);
         settings.setGroupingSeparator(groupingSeparator == null || groupingSeparator.isEmpty()
-            ? '\0' : groupingSeparator.charAt(0));
+            ? IntegerSettings.DEFAULT_GROUPING_SEPARATOR : groupingSeparator);
     }
 }

--- a/src/main/kotlin/com/fwdekker/randomness/array/ArraySettings.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/array/ArraySettings.kt
@@ -50,7 +50,7 @@ class ArraySettings : Settings<ArraySettings> {
      */
     var brackets = DEFAULT_BRACKETS
     /**
-     * The separator to place between generated elements.
+     * The string to place between generated elements.
      */
     var separator = DEFAULT_SEPARATOR
     /**

--- a/src/main/kotlin/com/fwdekker/randomness/decimal/DecimalActions.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/decimal/DecimalActions.kt
@@ -49,11 +49,11 @@ class DecimalInsertAction(private val settings: DecimalSettings = DecimalSetting
      */
     private fun convertToString(decimal: Double): String {
         val format = DecimalFormat()
-        format.isGroupingUsed = settings.groupingSeparator != '\u0000'
+        format.isGroupingUsed = settings.groupingSeparator != "\u0000"
 
         val symbols = format.decimalFormatSymbols
-        symbols.groupingSeparator = settings.groupingSeparator
-        symbols.decimalSeparator = settings.decimalSeparator
+        symbols.groupingSeparator = settings.groupingSeparator[0]
+        symbols.decimalSeparator = settings.decimalSeparator[0]
         format.minimumFractionDigits = settings.decimalCount
         format.maximumFractionDigits = settings.decimalCount
         format.decimalFormatSymbols = symbols

--- a/src/main/kotlin/com/fwdekker/randomness/decimal/DecimalSettings.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/decimal/DecimalSettings.kt
@@ -33,11 +33,11 @@ class DecimalSettings : Settings<DecimalSettings> {
         /**
          * The default value of the [groupingSeparator][DecimalSettings.groupingSeparator] field.
          */
-        const val DEFAULT_GROUPING_SEPARATOR = '\u0000'
+        const val DEFAULT_GROUPING_SEPARATOR = "\u0000"
         /**
          * The default value of the [decimalSeparator][DecimalSettings.decimalSeparator] field.
          */
-        const val DEFAULT_DECIMAL_SEPARATOR = '.'
+        const val DEFAULT_DECIMAL_SEPARATOR = "."
 
 
         /**
@@ -63,11 +63,19 @@ class DecimalSettings : Settings<DecimalSettings> {
     /**
      * The character that should separate groups.
      */
+    // TODO Turn this field into a char field once supported by the settings serializer
     var groupingSeparator = DEFAULT_GROUPING_SEPARATOR
+        set(value) {
+            field = value.getOrElse(0) { DEFAULT_GROUPING_SEPARATOR[0] }.toString()
+        }
     /**
      * The character that should separate decimals.
      */
+    // TODO Turn this field into a char field once supported by the settings serializer
     var decimalSeparator = DEFAULT_DECIMAL_SEPARATOR
+        set(value) {
+            field = value.getOrElse(0) { DEFAULT_DECIMAL_SEPARATOR[0] }.toString()
+        }
 
 
     /**

--- a/src/main/kotlin/com/fwdekker/randomness/integer/IntegerActions.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/integer/IntegerActions.kt
@@ -52,10 +52,10 @@ class IntegerInsertAction(private val settings: IntegerSettings = IntegerSetting
             return value.toString(settings.base)
 
         val format = DecimalFormat()
-        format.isGroupingUsed = settings.groupingSeparator != '\u0000'
+        format.isGroupingUsed = settings.groupingSeparator != "\u0000"
 
         val symbols = format.decimalFormatSymbols
-        symbols.groupingSeparator = settings.groupingSeparator
+        symbols.groupingSeparator = settings.groupingSeparator[0]
         format.minimumFractionDigits = 0
         format.maximumFractionDigits = 0
         format.decimalFormatSymbols = symbols

--- a/src/main/kotlin/com/fwdekker/randomness/integer/IntegerSettings.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/integer/IntegerSettings.kt
@@ -45,7 +45,7 @@ class IntegerSettings : Settings<IntegerSettings> {
         /**
          * The default value of the [groupingSeparator][IntegerSettings.groupingSeparator] field.
          */
-        const val DEFAULT_GROUPING_SEPARATOR = '\u0000'
+        const val DEFAULT_GROUPING_SEPARATOR = "\u0000"
 
 
         /**
@@ -71,7 +71,11 @@ class IntegerSettings : Settings<IntegerSettings> {
     /**
      * The character that should separate groups.
      */
+    // TODO Turn this field into a char field once supported by the settings serializer
     var groupingSeparator = DEFAULT_GROUPING_SEPARATOR
+        set(value) {
+            field = value.getOrElse(0) { DEFAULT_GROUPING_SEPARATOR[0] }.toString()
+        }
 
 
     /**

--- a/src/main/kotlin/com/fwdekker/randomness/ui/JLongSpinner.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/ui/JLongSpinner.kt
@@ -61,6 +61,20 @@ class JLongSpinner(
     override fun getValue() = (super.getValue() as Number).toLong()
 
     /**
+     * Returns the previous value of the model, equal to [getValue] minus one or [minValue], whichever is larger.
+     *
+     * @return the previous value of the model, equal to [getValue] minus one or [minValue], whichever is larger
+     */
+    override fun getPreviousValue() = Math.max(value - 1, minValue)
+
+    /**
+     * Returns the next value of the model, equal to [getValue] plus one or [maxValue], whichever is smaller.
+     *
+     * @return the next value of the model, equal to [getValue] plus one or [maxValue], whichever is smaller
+     */
+    override fun getNextValue() = Math.min(value + 1, maxValue)
+
+    /**
      * Validates the current value.
      *
      * @return `null` if the current value is valid, or a `ValidationInfo` object explaining why the current value is

--- a/src/test/kotlin/com/fwdekker/randomness/decimal/DecimalInsertActionSymbolTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/decimal/DecimalInsertActionSymbolTest.kt
@@ -13,15 +13,15 @@ class DecimalInsertActionSymbolTest {
         @JvmStatic
         private fun provider() =
             listOf(
-                arrayOf(4.2, 2, '.', '.', "4.20"),
-                arrayOf(4.2, 2, '.', ',', "4,20"),
-                arrayOf(4.2, 2, ',', '.', "4.20"),
-                arrayOf(4.2, 2, ',', ',', "4,20"),
-                arrayOf(67575.845, 3, '\u0000', '.', "67575.845"),
-                arrayOf(67575.845, 3, '.', '.', "67.575.845"),
-                arrayOf(67575.845, 3, '.', ',', "67.575,845"),
-                arrayOf(67575.845, 3, ',', '.', "67,575.845"),
-                arrayOf(67575.845, 3, ',', ',', "67,575,845")
+                arrayOf(4.2, 2, ".", ".", "4.20"),
+                arrayOf(4.2, 2, ".", ",", "4,20"),
+                arrayOf(4.2, 2, ",", ".", "4.20"),
+                arrayOf(4.2, 2, ",", ",", "4,20"),
+                arrayOf(67575.845, 3, "\u0000", ".", "67575.845"),
+                arrayOf(67575.845, 3, ".", ".", "67.575.845"),
+                arrayOf(67575.845, 3, ".", ",", "67.575,845"),
+                arrayOf(67575.845, 3, ",", ".", "67,575.845"),
+                arrayOf(67575.845, 3, ",", ",", "67,575,845")
             )
     }
 
@@ -29,8 +29,8 @@ class DecimalInsertActionSymbolTest {
     @ParameterizedTest
     @MethodSource("provider")
     fun testValue(
-        value: Double, decimalCount: Int, groupingSeparator: Char,
-        decimalSeparator: Char, expectedString: String
+        value: Double, decimalCount: Int, groupingSeparator: String,
+        decimalSeparator: String, expectedString: String
     ) {
         val decimalSettings = DecimalSettings()
         decimalSettings.minValue = value

--- a/src/test/kotlin/com/fwdekker/randomness/decimal/DecimalSettingsDialogTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/decimal/DecimalSettingsDialogTest.kt
@@ -164,8 +164,8 @@ object DecimalSettingsDialogTest : Spek({
             assertThat(decimalSettings.minValue).isEqualTo(112.54)
             assertThat(decimalSettings.maxValue).isEqualTo(644.74)
             assertThat(decimalSettings.decimalCount).isEqualTo(485)
-            assertThat(decimalSettings.groupingSeparator).isEqualTo('_')
-            assertThat(decimalSettings.decimalSeparator).isEqualTo(',')
+            assertThat(decimalSettings.groupingSeparator).isEqualTo("_")
+            assertThat(decimalSettings.decimalSeparator).isEqualTo(",")
         }
     }
 })

--- a/src/test/kotlin/com/fwdekker/randomness/decimal/DecimalSettingsTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/decimal/DecimalSettingsTest.kt
@@ -32,4 +32,34 @@ object DecimalSettingsTest : Spek({
             assertThat(newDecimalSettings.decimalCount).isEqualTo(205)
         }
     }
+
+    describe("input handling") {
+        describe("grouping separator") {
+            it("uses the default separator if an empty string is set") {
+                decimalSettings.groupingSeparator = ""
+
+                assertThat(decimalSettings.groupingSeparator).isEqualTo(DecimalSettings.DEFAULT_GROUPING_SEPARATOR)
+            }
+
+            it("uses only the first character if a multi-character string is given") {
+                decimalSettings.groupingSeparator = "drummer"
+
+                assertThat(decimalSettings.groupingSeparator).isEqualTo("d")
+            }
+        }
+
+        describe("decimal separator") {
+            it("uses the default separator if an empty string is set") {
+                decimalSettings.decimalSeparator = ""
+
+                assertThat(decimalSettings.decimalSeparator).isEqualTo(DecimalSettings.DEFAULT_DECIMAL_SEPARATOR)
+            }
+
+            it("uses only the first character if a multi-character string is given") {
+                decimalSettings.decimalSeparator = "foolish"
+
+                assertThat(decimalSettings.decimalSeparator).isEqualTo("f")
+            }
+        }
+    }
 })

--- a/src/test/kotlin/com/fwdekker/randomness/integer/IntegerInsertActionBaseTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/integer/IntegerInsertActionBaseTest.kt
@@ -13,16 +13,16 @@ class IntegerInsertActionBaseTest {
         @JvmStatic
         fun provider() =
             listOf(
-                arrayOf(33360, 10, '.', "33.360"),
-                arrayOf(48345, 10, '.', "48.345"),
-                arrayOf(48345, 11, '.', "33360")
+                arrayOf(33360, 10, ".", "33.360"),
+                arrayOf(48345, 10, ".", "48.345"),
+                arrayOf(48345, 11, ".", "33360")
             )
     }
 
 
     @ParameterizedTest
     @MethodSource("provider")
-    fun testValue(value: Long, base: Int, groupingSeparator: Char, expectedString: String) {
+    fun testValue(value: Long, base: Int, groupingSeparator: String, expectedString: String) {
         val integerSettings = IntegerSettings()
         integerSettings.minValue = value
         integerSettings.maxValue = value

--- a/src/test/kotlin/com/fwdekker/randomness/integer/IntegerInsertActionSymbolTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/integer/IntegerInsertActionSymbolTest.kt
@@ -13,16 +13,16 @@ class IntegerInsertActionSymbolTest {
         @JvmStatic
         fun provider() =
             listOf(
-                arrayOf(95713, '\u0000', "95713"),
-                arrayOf(163583, '.', "163.583"),
-                arrayOf(351426, ',', "351,426")
+                arrayOf(95713, "\u0000", "95713"),
+                arrayOf(163583, ".", "163.583"),
+                arrayOf(351426, ",", "351,426")
             )
     }
 
 
     @ParameterizedTest
     @MethodSource("provider")
-    fun testValue(value: Long, groupingSeparator: Char, expectedString: String) {
+    fun testValue(value: Long, groupingSeparator: String, expectedString: String) {
         val integerSettings = IntegerSettings()
         integerSettings.minValue = value
         integerSettings.maxValue = value

--- a/src/test/kotlin/com/fwdekker/randomness/integer/IntegerSettingsTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/integer/IntegerSettingsTest.kt
@@ -32,4 +32,20 @@ object IntegerSettingsTest : Spek({
             assertThat(newIntegerSettings.base).isEqualTo(12)
         }
     }
+
+    describe("input handling") {
+        describe("grouping separator") {
+            it("uses the default separator if an empty string is set") {
+                integerSettings.groupingSeparator = ""
+
+                assertThat(integerSettings.groupingSeparator).isEqualTo(IntegerSettings.DEFAULT_GROUPING_SEPARATOR)
+            }
+
+            it("uses only the first character if a multi-character string is given") {
+                integerSettings.groupingSeparator = "recited"
+
+                assertThat(integerSettings.groupingSeparator).isEqualTo("r")
+            }
+        }
+    }
 })

--- a/src/test/kotlin/com/fwdekker/randomness/ui/JLongSpinnerTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/ui/JLongSpinnerTest.kt
@@ -76,6 +76,36 @@ object JLongSpinnerTest : Spek({
         }
     }
 
+    describe("getting surrounding values") {
+        describe("previous value") {
+            it("returns the previous value") {
+                val spinner = GuiActionRunner.execute<JLongSpinner> { JLongSpinner(56L) }
+
+                assertThat(spinner.previousValue).isEqualTo(55L)
+            }
+
+            it("returns the minimum value if the current value is already at the minimum") {
+                val spinner = GuiActionRunner.execute<JLongSpinner> { JLongSpinner(203L, minValue = 203L) }
+
+                assertThat(spinner.previousValue).isEqualTo(203L)
+            }
+        }
+
+        describe("next value") {
+            it("returns the next value") {
+                val spinner = GuiActionRunner.execute<JLongSpinner> { JLongSpinner(112L) }
+
+                assertThat(spinner.nextValue).isEqualTo(113L)
+            }
+
+            it("returns the maximum value if the current value is already at the maximum") {
+                val spinner = GuiActionRunner.execute<JLongSpinner> { JLongSpinner(119L, minValue = 119L) }
+
+                assertThat(spinner.previousValue).isEqualTo(119L)
+            }
+        }
+    }
+
     describe("validation") {
         it("should fail when the value is below the set range") {
             val spinner = GuiActionRunner.execute<JLongSpinner> { JLongSpinner(-665, -950, -559) }


### PR DESCRIPTION
IntelliJ would fail to read a setting into a `Char` field. Therefore, all `Char` fields have been converted to `String` fields. Where the length of a field must be exactly one, a check is added to the setter.