### PR TITLE
Exclude file lists from Codecov comments

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,6 @@
+comment:
+    layout: "reach, diff"
+
 coverage:
     status:
         project: off


### PR DESCRIPTION
Stops Codecov from including the list of affected files in PR comments. These lists are ugly and not very useful anyway.

![file list](https://user-images.githubusercontent.com/13442533/57051478-fa740800-6c81-11e9-9ae0-64eba3beb037.png)
