### PR TITLE
Improve data generation error dialog

### DIFF
--- a/src/main/kotlin/com/fwdekker/randomness/ui/JBPopupHelper.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/ui/JBPopupHelper.kt
@@ -1,6 +1,5 @@
 package com.fwdekker.randomness.ui
 
-import com.intellij.openapi.ui.popup.JBPopupFactory
 import com.intellij.ui.popup.list.ListPopupImpl
 import java.awt.event.ActionEvent
 import java.awt.event.KeyEvent
@@ -119,24 +118,6 @@ object JBPopupHelper {
                 )
         }
     }
-
-    /**
-     * Displays a popup with a title and two messages.
-     *
-     * @param title the title of the popup
-     * @param messageA the first message
-     * @param messageB the second message
-     */
-    fun showMessagePopup(title: String, messageA: String, messageB: String) =
-        JBPopupFactory.getInstance()
-            .createConfirmation(
-                title,
-                messageA,
-                messageB,
-                {},
-                1
-            )
-            .showInFocusCenter()
 
 
     /**

--- a/src/main/kotlin/com/fwdekker/randomness/word/WordActions.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/word/WordActions.kt
@@ -47,7 +47,7 @@ class WordInsertAction(private val settings: WordSettings = WordSettings.default
             } catch (e: InvalidDictionaryException) {
                 throw DataGenerationException(e.message, e)
             }
-                .ifEmpty { throw DataGenerationException("All dictionaries are empty.") }
+                .ifEmpty { throw DataGenerationException("All active dictionaries are empty.") }
                 .filter { it.length in settings.minLength..settings.maxLength }
                 .toSet()
                 .ifEmpty { throw DataGenerationException("There are no words within the configured length range.") }

--- a/src/test/kotlin/com/fwdekker/randomness/word/WordInsertActionTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/word/WordInsertActionTest.kt
@@ -3,7 +3,9 @@ package com.fwdekker.randomness.word
 import com.fwdekker.randomness.DataGenerationException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.junit.jupiter.api.Test
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.it
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 
@@ -11,7 +13,7 @@ import org.junit.jupiter.params.provider.MethodSource
 /**
  * Parameterized unit tests for [WordInsertAction].
  */
-class WordInsertActionTest {
+class WordInsertActionParamTest {
     companion object {
         @JvmStatic
         fun provider() =
@@ -44,17 +46,82 @@ class WordInsertActionTest {
             .isGreaterThanOrEqualTo(minLength + 2 * enclosure.length)
             .isLessThanOrEqualTo(maxLength + 2 * enclosure.length)
     }
-
-    @Test
-    fun testNoValidWords() {
-        val wordSettings = WordSettings()
-        wordSettings.activeBundledDictionaries = emptySet()
-
-        val insertRandomWord = WordInsertAction(wordSettings)
-
-        assertThatThrownBy { insertRandomWord.generateString() }
-            .isInstanceOf(DataGenerationException::class.java)
-            .hasMessage("There are no words compatible with the current settings.")
-            .hasNoCause()
-    }
 }
+
+
+/**
+ * Unit tests for [WordInsertAction].
+ */
+class WordInsertActionTest : Spek({
+    val tempFileHelper = TempFileHelper()
+
+
+    afterGroup {
+        tempFileHelper.cleanUp()
+    }
+
+
+    describe("error handling") {
+        it("throws an exception if there are no active dictionaries") {
+            val wordSettings = WordSettings()
+            wordSettings.activeBundledDictionaries = emptySet()
+
+            val insertRandomWord = WordInsertAction(wordSettings)
+
+            assertThatThrownBy { insertRandomWord.generateString() }
+                .isInstanceOf(DataGenerationException::class.java)
+                .hasMessage("There are no active dictionaries.")
+                .hasNoCause()
+        }
+
+        it("throws an exception if an active dictionary no longer exists") {
+            val dictionaryFile = tempFileHelper.createFile("", ".dic")
+            val dictionary = UserDictionary.cache.get(dictionaryFile.absolutePath, false)
+            dictionaryFile.delete()
+
+            val wordSettings = WordSettings()
+            wordSettings.activeBundledDictionaries = emptySet()
+            wordSettings.activeUserDictionaries = setOf(dictionary)
+
+            val insertRandomWord = WordInsertAction(wordSettings)
+
+            assertThatThrownBy { insertRandomWord.generateString() }
+                .isInstanceOf(DataGenerationException::class.java)
+                .hasMessage("Failed to read user dictionary into memory.")
+                .hasCauseInstanceOf(InvalidDictionaryException::class.java)
+        }
+
+        it("throws an exception if all active dictionaries are empty") {
+            val dictionaryFile = tempFileHelper.createFile("", ".dic")
+            val dictionary = UserDictionary.cache.get(dictionaryFile.absolutePath, false)
+
+            val wordSettings = WordSettings()
+            wordSettings.activeBundledDictionaries = emptySet()
+            wordSettings.activeUserDictionaries = setOf(dictionary)
+
+            val insertRandomWord = WordInsertAction(wordSettings)
+
+            assertThatThrownBy { insertRandomWord.generateString() }
+                .isInstanceOf(DataGenerationException::class.java)
+                .hasMessage("All dictionaries are empty.")
+                .hasNoCause()
+        }
+
+        it("throws an exception if there are no words in the configured range") {
+            val dictionaryFile = tempFileHelper.createFile("a", ".dic")
+            val dictionary = UserDictionary.cache.get(dictionaryFile.absolutePath, false)
+
+            val wordSettings = WordSettings()
+            wordSettings.minLength = 2
+            wordSettings.activeBundledDictionaries = emptySet()
+            wordSettings.activeUserDictionaries = setOf(dictionary)
+
+            val insertRandomWord = WordInsertAction(wordSettings)
+
+            assertThatThrownBy { insertRandomWord.generateString() }
+                .isInstanceOf(DataGenerationException::class.java)
+                .hasMessage("There are no words within the configured length range.")
+                .hasNoCause()
+        }
+    }
+})

--- a/src/test/kotlin/com/fwdekker/randomness/word/WordInsertActionTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/word/WordInsertActionTest.kt
@@ -103,7 +103,7 @@ class WordInsertActionTest : Spek({
 
             assertThatThrownBy { insertRandomWord.generateString() }
                 .isInstanceOf(DataGenerationException::class.java)
-                .hasMessage("All dictionaries are empty.")
+                .hasMessage("All active dictionaries are empty.")
                 .hasNoCause()
         }
 


### PR DESCRIPTION
Improves the error dialog that is shown when no data could be generated. Rather than using a JetBrains popup, it now uses a modal dialog. Additionally, the dialog now shows more descriptive errors for when no words could be generated.

| Before | After |
|---|---|
| ![before](https://user-images.githubusercontent.com/13442533/57095961-630bc500-6d14-11e9-8d79-3dd72ba28d8e.png) | ![after](https://user-images.githubusercontent.com/13442533/57095964-669f4c00-6d14-11e9-8962-578db61bed8a.PNG) |