### PR TITLE
Address Detekt violations

### DIFF
--- a/.config/detekt/.detekt.yml
+++ b/.config/detekt/.detekt.yml
@@ -1,8 +1,5 @@
 autoCorrect: false
 
-console-reports:
-    active: false
-
 
 comments:
     # Nothing wrong with documenting private methods.
@@ -16,6 +13,9 @@ complexity:
     # Static analysis is not good at estimating this.
     TooManyFunctions:
         thresholdInClasses: 20
+    # Acceptable if used sparingly
+    LabeledExpression:
+        active: false
 
 formatting:
     # That's part of my code style.
@@ -25,6 +25,9 @@ formatting:
 naming:
     # Static analysis is not good at estimating this.
     FunctionMaxLength:
+        active: false
+    # Cannot be suppressed in case of false positives
+    MatchingDeclarationName:
         active: false
 
 potential-bugs:

--- a/src/main/kotlin/com/fwdekker/randomness/DataActions.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/DataActions.kt
@@ -124,6 +124,7 @@ abstract class DataInsertAction : AnAction() {
      *
      * @param event carries information on the invocation place
      */
+    @Suppress("ReturnCount") // Result of null checks at start
     override fun actionPerformed(event: AnActionEvent) {
         val editor = event.getData(CommonDataKeys.EDITOR)
             ?: return

--- a/src/main/kotlin/com/fwdekker/randomness/ui/JBPopupHelper.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/ui/JBPopupHelper.kt
@@ -51,7 +51,8 @@ fun ListPopupImpl.registerModifierActions(
         }
     )
 
-    (1..9).forEach { key ->
+    @Suppress("MagicNumber") // Not worth a constant
+    for (key in 1..9) {
         registerAction(
             "${modifierKey.shortName.toLowerCase()}Invoke$key",
             KeyStroke.getKeyStroke("${modifierKey.longName.toLowerCase()} $key"),

--- a/src/main/kotlin/com/fwdekker/randomness/ui/JNumberSpinners.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/ui/JNumberSpinners.kt
@@ -14,10 +14,17 @@ import javax.swing.SpinnerNumberModel
  * @param minValue the smallest number that may be represented
  * @param maxValue the largest number that may be represented
  * @param stepSize the default value to increment and decrement by
- * @property numberToT converts a [Number] to a [T]
  */
 abstract class JNumberSpinner<T>(value: T, minValue: T, maxValue: T, stepSize: T) :
     JSpinner(SpinnerNumberModel(value, minValue, maxValue, stepSize)) where T : Number, T : Comparable<T> {
+    companion object {
+        /**
+         * The default width of a number spinner.
+         */
+        const val DEFAULT_WIDTH = 52
+    }
+
+
     /**
      * Transforms a [Number] into a [T].
      */
@@ -103,8 +110,8 @@ class JDoubleSpinner @JvmOverloads constructor(
     init {
         this.name = name
         this.editor = NumberEditor(this, "#")
-        this.minimumSize = Dimension(52, minimumSize.height)
-        this.preferredSize = Dimension(52, preferredSize.height)
+        this.minimumSize = Dimension(DEFAULT_WIDTH, minimumSize.height)
+        this.preferredSize = Dimension(DEFAULT_WIDTH, preferredSize.height)
     }
 }
 
@@ -132,8 +139,8 @@ class JLongSpinner @JvmOverloads constructor(
     init {
         this.name = name
         this.editor = NumberEditor(this, "#")
-        this.minimumSize = Dimension(52, minimumSize.height)
-        this.preferredSize = Dimension(52, preferredSize.height)
+        this.minimumSize = Dimension(DEFAULT_WIDTH, minimumSize.height)
+        this.preferredSize = Dimension(DEFAULT_WIDTH, preferredSize.height)
     }
 }
 
@@ -161,7 +168,7 @@ class JIntSpinner @JvmOverloads constructor(
     init {
         this.name = name
         this.editor = NumberEditor(this, "#")
-        this.minimumSize = Dimension(52, minimumSize.height)
-        this.preferredSize = Dimension(52, preferredSize.height)
+        this.minimumSize = Dimension(DEFAULT_WIDTH, minimumSize.height)
+        this.preferredSize = Dimension(DEFAULT_WIDTH, preferredSize.height)
     }
 }


### PR DESCRIPTION
Fixes some Detekt violations that remained in the code. Detekt did not fail the build because the `console-reports` option apparently disables the check entirely instead of just disabling console output. Strange.