### PR TITLE
Turn settings classes into data classes

### DIFF
--- a/.config/detekt/.detekt.yml
+++ b/.config/detekt/.detekt.yml
@@ -36,6 +36,9 @@ potential-bugs:
         active: false
 
 style:
+    # Those functions are added as conscious design decisions.
+    DataClassContainsFunctions:
+        active: false
     # No braces are easier to read.
     MandatoryBracesIfStatements:
         active: false

--- a/src/main/java/com/fwdekker/randomness/decimal/DecimalSettingsDialog.java
+++ b/src/main/java/com/fwdekker/randomness/decimal/DecimalSettingsDialog.java
@@ -92,14 +92,8 @@ public final class DecimalSettingsDialog extends SettingsDialog<DecimalSettings>
         settings.setMaxValue(maxValue.getValue());
         settings.setDecimalCount(decimalCount.getValue());
         settings.setShowTrailingZeroes(showTrailingZeroesCheckBox.isSelected());
-
-        final String groupingSeparator = ButtonGroupKt.getValue(groupingSeparatorGroup);
-        settings.setGroupingSeparator(groupingSeparator == null || groupingSeparator.isEmpty()
-            ? DecimalSettings.DEFAULT_GROUPING_SEPARATOR : groupingSeparator);
-
-        final String decimalSeparator = ButtonGroupKt.getValue(decimalSeparatorGroup);
-        settings.setDecimalSeparator(decimalSeparator == null || decimalSeparator.isEmpty()
-            ? DecimalSettings.DEFAULT_DECIMAL_SEPARATOR : decimalSeparator);
+        settings.safeSetGroupingSeparator(ButtonGroupKt.getValue(groupingSeparatorGroup));
+        settings.safeSetDecimalSeparator(ButtonGroupKt.getValue(decimalSeparatorGroup));
     }
 
     @Override

--- a/src/main/java/com/fwdekker/randomness/integer/IntegerSettingsDialog.java
+++ b/src/main/java/com/fwdekker/randomness/integer/IntegerSettingsDialog.java
@@ -95,10 +95,7 @@ public final class IntegerSettingsDialog extends SettingsDialog<IntegerSettings>
         settings.setMinValue(minValue.getValue());
         settings.setMaxValue(maxValue.getValue());
         settings.setBase(base.getValue());
-
-        final String groupingSeparator = ButtonGroupKt.getValue(groupingSeparatorGroup);
-        settings.setGroupingSeparator(groupingSeparator == null || groupingSeparator.isEmpty()
-            ? IntegerSettings.DEFAULT_GROUPING_SEPARATOR : groupingSeparator);
+        settings.safeSetGroupingSeparator(ButtonGroupKt.getValue(groupingSeparatorGroup));
     }
 
     @Override

--- a/src/main/kotlin/com/fwdekker/randomness/array/ArraySettings.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/array/ArraySettings.kt
@@ -10,10 +10,20 @@ import com.intellij.util.xmlb.XmlSerializerUtil
 /**
  * Contains settings for generating arrays of other types of random values.
  *
+ * @property count The number of elements to generate.
+ * @property brackets The brackets to surround arrays with.
+ * @property separator The string to place between generated elements.
+ * @property isSpaceAfterSeparator True iff a space should be placed after each separator.
+ *
  * @see com.fwdekker.randomness.DataInsertArrayAction
  */
 @State(name = "ArraySettings", storages = [Storage("\$APP_CONFIG\$/randomness.xml")])
-class ArraySettings : Settings<ArraySettings> {
+data class ArraySettings(
+    var count: Int = DEFAULT_COUNT,
+    var brackets: String = DEFAULT_BRACKETS,
+    var separator: String = DEFAULT_SEPARATOR,
+    var isSpaceAfterSeparator: Boolean = DEFAULT_SPACE_AFTER_SEPARATOR
+) : Settings<ArraySettings> {
     companion object {
         /**
          * The default value of the [count][ArraySettings.count] field.
@@ -39,24 +49,6 @@ class ArraySettings : Settings<ArraySettings> {
         val default: ArraySettings
             get() = ServiceManager.getService(ArraySettings::class.java)
     }
-
-
-    /**
-     * The number of elements to generate.
-     */
-    var count = DEFAULT_COUNT
-    /**
-     * The brackets to surround arrays with.
-     */
-    var brackets = DEFAULT_BRACKETS
-    /**
-     * The string to place between generated elements.
-     */
-    var separator = DEFAULT_SEPARATOR
-    /**
-     * True iff a space should be placed after each separator.
-     */
-    var isSpaceAfterSeparator = DEFAULT_SPACE_AFTER_SEPARATOR
 
 
     /**

--- a/src/main/kotlin/com/fwdekker/randomness/decimal/DecimalSettings.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/decimal/DecimalSettings.kt
@@ -11,12 +11,27 @@ import com.intellij.util.xmlb.XmlSerializerUtil
 /**
  * Contains settings for generating random decimals.
  *
+ * @property minValue The minimum value to be generated, inclusive.
+ * @property maxValue The maximum value to be generated, inclusive.
+ * @property decimalCount The number of decimals to display.
+ * @property showTrailingZeroes Whether to include trailing zeroes in the decimals.
+ * @property groupingSeparator The character that should separate groups.
+ * @property decimalSeparator The character that should separate decimals.
+ *
  * @see DecimalInsertAction
  * @see DecimalSettingsAction
  * @see DecimalSettingsDialog
  */
+// TODO Turn separator properties into char properties once supported by the settings serializer
 @State(name = "DecimalSettings", storages = [Storage("\$APP_CONFIG\$/randomness.xml")])
-class DecimalSettings : Settings<DecimalSettings> {
+data class DecimalSettings(
+    var minValue: Double = DEFAULT_MIN_VALUE,
+    var maxValue: Double = DEFAULT_MAX_VALUE,
+    var decimalCount: Int = DEFAULT_DECIMAL_COUNT,
+    var showTrailingZeroes: Boolean = DEFAULT_SHOW_TRAILING_ZEROES,
+    var groupingSeparator: String = DEFAULT_GROUPING_SEPARATOR,
+    var decimalSeparator: String = DEFAULT_DECIMAL_SEPARATOR
+) : Settings<DecimalSettings> {
     companion object {
         /**
          * The default value of the [minValue][DecimalSettings.minValue] field.
@@ -53,37 +68,26 @@ class DecimalSettings : Settings<DecimalSettings> {
 
 
     /**
-     * The minimum value to be generated, inclusive.
+     * Sets the grouping separator safely to ensure that exactly one character is set.
+     *
+     * @param groupingSeparator the possibly-unsafe grouping separator string
      */
-    var minValue = DEFAULT_MIN_VALUE
+    fun safeSetGroupingSeparator(groupingSeparator: String?) =
+        if (groupingSeparator == null || groupingSeparator.isEmpty())
+            this.groupingSeparator = DEFAULT_GROUPING_SEPARATOR
+        else
+            this.groupingSeparator = groupingSeparator.substring(0, 1)
+
     /**
-     * The maximum value to be generated, inclusive.
+     * Sets the decimal separator safely to ensure that exactly one character is set.
+     *
+     * @param decimalSeparator the possibly-unsafe decimal separator string
      */
-    var maxValue = DEFAULT_MAX_VALUE
-    /**
-     * The number of decimals to display.
-     */
-    var decimalCount = DEFAULT_DECIMAL_COUNT
-    /**
-     * Whether to include trailing zeroes in the decimals.
-     */
-    var showTrailingZeroes = DEFAULT_SHOW_TRAILING_ZEROES
-    /**
-     * The character that should separate groups.
-     */
-    // TODO Turn this field into a char field once supported by the settings serializer
-    var groupingSeparator = DEFAULT_GROUPING_SEPARATOR
-        set(value) {
-            field = if (value.isNotEmpty()) value.substring(0, 1) else DEFAULT_GROUPING_SEPARATOR
-        }
-    /**
-     * The character that should separate decimals.
-     */
-    // TODO Turn this field into a char field once supported by the settings serializer
-    var decimalSeparator = DEFAULT_DECIMAL_SEPARATOR
-        set(value) {
-            field = if (value.isNotEmpty()) value.substring(0, 1) else DEFAULT_DECIMAL_SEPARATOR
-        }
+    fun safeSetDecimalSeparator(decimalSeparator: String?) =
+        if (decimalSeparator == null || decimalSeparator.isEmpty())
+            this.decimalSeparator = DEFAULT_DECIMAL_SEPARATOR
+        else
+            this.decimalSeparator = decimalSeparator.substring(0, 1)
 
 
     /**

--- a/src/main/kotlin/com/fwdekker/randomness/integer/IntegerSettings.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/integer/IntegerSettings.kt
@@ -10,12 +10,23 @@ import com.intellij.util.xmlb.XmlSerializerUtil
 /**
  * Contains settings for generating random integers.
  *
+ * @property minValue The minimum value to be generated, inclusive.
+ * @property maxValue The maximum value to be generated, inclusive.
+ * @property base The base the generated value should be displayed in.
+ * @property groupingSeparator The character that should separate groups.
+ *
  * @see IntegerInsertAction
  * @see IntegerSettingsAction
  * @see IntegerSettingsDialog
  */
+// TODO Turn the separator property into a char property once supported by the settings serializer
 @State(name = "IntegerSettings", storages = [Storage("\$APP_CONFIG\$/randomness.xml")])
-class IntegerSettings : Settings<IntegerSettings> {
+data class IntegerSettings(
+    var minValue: Long = DEFAULT_MIN_VALUE,
+    var maxValue: Long = DEFAULT_MAX_VALUE,
+    var base: Int = DEFAULT_BASE,
+    var groupingSeparator: String = DEFAULT_GROUPING_SEPARATOR
+) : Settings<IntegerSettings> {
     companion object {
         /**
          * The minimum value of the [base][IntegerSettings.base] field.
@@ -57,25 +68,16 @@ class IntegerSettings : Settings<IntegerSettings> {
 
 
     /**
-     * The minimum value to be generated, inclusive.
+     * Sets the grouping separator safely to ensure that exactly one character is set.
+     *
+     * @param groupingSeparator the possibly-unsafe grouping separator string
      */
-    var minValue = DEFAULT_MIN_VALUE
-    /**
-     * The maximum value to be generated, inclusive.
-     */
-    var maxValue = DEFAULT_MAX_VALUE
-    /**
-     * The base the generated value should be displayed in.
-     */
-    var base = DEFAULT_BASE
-    /**
-     * The character that should separate groups.
-     */
-    // TODO Turn this field into a char field once supported by the settings serializer
-    var groupingSeparator = DEFAULT_GROUPING_SEPARATOR
-        set(value) {
-            field = if (value.isNotEmpty()) value.substring(0, 1) else DEFAULT_GROUPING_SEPARATOR
-        }
+    fun safeSetGroupingSeparator(groupingSeparator: String?) {
+        if (groupingSeparator == null || groupingSeparator.isEmpty())
+            this.groupingSeparator = DEFAULT_GROUPING_SEPARATOR
+        else
+            this.groupingSeparator = groupingSeparator.substring(0, 1)
+    }
 
 
     /**

--- a/src/main/kotlin/com/fwdekker/randomness/string/StringSettings.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/string/StringSettings.kt
@@ -11,12 +11,24 @@ import com.intellij.util.xmlb.XmlSerializerUtil
 /**
  * Contains settings for generating random strings.
  *
+ * @property minLength The minimum length of the generated string, inclusive.
+ * @property maxLength The maximum length of the generated string, inclusive.
+ * @property enclosure The string that encloses the generated string on both sides.
+ * @property capitalization The capitalization mode of the generated string.
+ * @property alphabets The alphabets to be used for generating strings.
+ *
  * @see StringInsertAction
  * @see StringSettingsAction
  * @see StringSettingsDialog
  */
 @State(name = "StringSettings", storages = [Storage("\$APP_CONFIG\$/randomness.xml")])
-class StringSettings : Settings<StringSettings> {
+data class StringSettings(
+    var minLength: Int = DEFAULT_MIN_LENGTH,
+    var maxLength: Int = DEFAULT_MAX_LENGTH,
+    var enclosure: String = DEFAULT_ENCLOSURE,
+    var capitalization: CapitalizationMode = DEFAULT_CAPITALIZATION,
+    var alphabets: MutableSet<Alphabet> = mutableSetOf(Alphabet.ALPHABET, Alphabet.DIGITS)
+) : Settings<StringSettings> {
     companion object {
         /**
          * The default value of the [minLength][StringSettings.minLength] field.
@@ -42,28 +54,6 @@ class StringSettings : Settings<StringSettings> {
         val default: StringSettings
             get() = ServiceManager.getService(StringSettings::class.java)
     }
-
-
-    /**
-     * The minimum length of the generated string, inclusive.
-     */
-    var minLength = DEFAULT_MIN_LENGTH
-    /**
-     * The maximum length of the generated string, inclusive.
-     */
-    var maxLength = DEFAULT_MAX_LENGTH
-    /**
-     * The string that encloses the generated string on both sides.
-     */
-    var enclosure = DEFAULT_ENCLOSURE
-    /**
-     * The capitalization mode of the generated string.
-     */
-    var capitalization = DEFAULT_CAPITALIZATION
-    /**
-     * The alphabets to be used for generating strings.
-     */
-    var alphabets = mutableSetOf(Alphabet.ALPHABET, Alphabet.DIGITS)
 
 
     /**

--- a/src/main/kotlin/com/fwdekker/randomness/uuid/UuidSettings.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/uuid/UuidSettings.kt
@@ -10,12 +10,14 @@ import com.intellij.util.xmlb.XmlSerializerUtil
 /**
  * Contains settings for generating random UUIDs.
  *
+ * @property enclosure The string that encloses the generated UUID on both sides.
+ *
  * @see UuidInsertAction
  * @see UuidSettingsAction
  * @see UuidSettingsDialog
  */
 @State(name = "UuidSettings", storages = [Storage("\$APP_CONFIG\$/randomness.xml")])
-class UuidSettings : Settings<UuidSettings> {
+data class UuidSettings(var enclosure: String = DEFAULT_ENCLOSURE) : Settings<UuidSettings> {
     companion object {
         /**
          * The default value of the [enclosure][UuidSettings.enclosure] field.
@@ -29,12 +31,6 @@ class UuidSettings : Settings<UuidSettings> {
         val default: UuidSettings
             get() = ServiceManager.getService(UuidSettings::class.java)
     }
-
-
-    /**
-     * The string that encloses the generated UUID on both sides.
-     */
-    var enclosure = DEFAULT_ENCLOSURE
 
 
     /**

--- a/src/main/kotlin/com/fwdekker/randomness/word/WordSettings.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/word/WordSettings.kt
@@ -12,12 +12,36 @@ import com.intellij.util.xmlb.annotations.Transient
 /**
  * Contains settings for generating random words.
  *
+ * @property minLength The minimum length of the generated word, inclusive.
+ * @property maxLength The maximum length of the generated word, inclusive.
+ * @property enclosure The string that encloses the generated word on both sides.
+ * @property capitalization The way in which the generated word should be capitalized.
+ * @property bundledDictionaryFiles The list of all dictionary files provided by the plugin.
+ * @property userDictionaryFiles The list of all dictionary files registered by the user.
+ * @property activeBundledDictionaryFiles The list of bundled dictionary files that are currently active; a subset of
+ * [bundledDictionaryFiles].
+ * @property activeUserDictionaryFiles The list of user dictionary files that are currently active; a subset of
+ * [userDictionaryFiles].
+ *
  * @see WordInsertAction
  * @see WordSettingsAction
  * @see WordSettingsDialog
  */
 @State(name = "WordSettings", storages = [Storage("\$APP_CONFIG\$/randomness.xml")])
-class WordSettings : Settings<WordSettings> {
+data class WordSettings(
+    var minLength: Int = DEFAULT_MIN_LENGTH,
+    var maxLength: Int = DEFAULT_MAX_LENGTH,
+    var enclosure: String = DEFAULT_ENCLOSURE,
+    var capitalization: CapitalizationMode = DEFAULT_CAPITALIZATION,
+    var bundledDictionaryFiles: MutableSet<String> =
+        mutableSetOf(BundledDictionary.SIMPLE_DICTIONARY, BundledDictionary.EXTENDED_DICTIONARY),
+    var userDictionaryFiles: MutableSet<String> =
+        mutableSetOf(),
+    var activeBundledDictionaryFiles: MutableSet<String> =
+        mutableSetOf(BundledDictionary.SIMPLE_DICTIONARY),
+    var activeUserDictionaryFiles: MutableSet<String> =
+        mutableSetOf()
+) : Settings<WordSettings> {
     companion object {
         /**
          * The default value of the [minLength][WordSettings.minLength] field.
@@ -45,43 +69,6 @@ class WordSettings : Settings<WordSettings> {
     }
 
 
-    /**
-     * The minimum length of the generated word, inclusive.
-     */
-    var minLength = DEFAULT_MIN_LENGTH
-    /**
-     * The maximum length of the generated word, inclusive.
-     */
-    var maxLength = DEFAULT_MAX_LENGTH
-    /**
-     * The string that encloses the generated word on both sides.
-     */
-    var enclosure = DEFAULT_ENCLOSURE
-    /**
-     * The way in which the generated word should be capitalized.
-     */
-    var capitalization = DEFAULT_CAPITALIZATION
-    /**
-     * The list of all dictionary files provided by the plugin.
-     */
-    var bundledDictionaryFiles =
-        mutableSetOf(BundledDictionary.SIMPLE_DICTIONARY, BundledDictionary.EXTENDED_DICTIONARY)
-    /**
-     * The list of all dictionary files registered by the user.
-     */
-    var userDictionaryFiles: MutableSet<String> = mutableSetOf()
-    /**
-     * The list of bundled dictionary files that are currently active.
-     *
-     * This is a subset of [bundledDictionaryFiles].
-     */
-    var activeBundledDictionaryFiles = mutableSetOf(BundledDictionary.SIMPLE_DICTIONARY)
-    /**
-     * The list of user dictionary files that are currently active.
-     *
-     * This is a subset of [userDictionaries].
-     */
-    var activeUserDictionaryFiles: MutableSet<String> = mutableSetOf()
     /**
      * A mutable view of the filenames of the files in [bundledDictionaryFiles].
      */

--- a/src/test/kotlin/com/fwdekker/randomness/decimal/DecimalSettingsTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/decimal/DecimalSettingsTest.kt
@@ -41,7 +41,7 @@ object DecimalSettingsTest : Spek({
 
     describe("input handling") {
         describe("grouping separator") {
-            it("uses the default separator if an empty string is set") {
+            it("uses the default separator if null is set") {
                 decimalSettings.safeSetGroupingSeparator(null)
 
                 assertThat(decimalSettings.groupingSeparator).isEqualTo(DecimalSettings.DEFAULT_GROUPING_SEPARATOR)
@@ -61,7 +61,7 @@ object DecimalSettingsTest : Spek({
         }
 
         describe("decimal separator") {
-            it("uses the default separator if a null string is set") {
+            it("uses the default separator if null is set") {
                 decimalSettings.safeSetDecimalSeparator(null)
 
                 assertThat(decimalSettings.decimalSeparator).isEqualTo(DecimalSettings.DEFAULT_DECIMAL_SEPARATOR)

--- a/src/test/kotlin/com/fwdekker/randomness/decimal/DecimalSettingsTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/decimal/DecimalSettingsTest.kt
@@ -42,27 +42,39 @@ object DecimalSettingsTest : Spek({
     describe("input handling") {
         describe("grouping separator") {
             it("uses the default separator if an empty string is set") {
-                decimalSettings.groupingSeparator = ""
+                decimalSettings.safeSetGroupingSeparator(null)
+
+                assertThat(decimalSettings.groupingSeparator).isEqualTo(DecimalSettings.DEFAULT_GROUPING_SEPARATOR)
+            }
+
+            it("uses the default separator if an empty string is set") {
+                decimalSettings.safeSetGroupingSeparator("")
 
                 assertThat(decimalSettings.groupingSeparator).isEqualTo(DecimalSettings.DEFAULT_GROUPING_SEPARATOR)
             }
 
             it("uses only the first character if a multi-character string is given") {
-                decimalSettings.groupingSeparator = "drummer"
+                decimalSettings.safeSetGroupingSeparator("drummer")
 
                 assertThat(decimalSettings.groupingSeparator).isEqualTo("d")
             }
         }
 
         describe("decimal separator") {
+            it("uses the default separator if a null string is set") {
+                decimalSettings.safeSetDecimalSeparator(null)
+
+                assertThat(decimalSettings.decimalSeparator).isEqualTo(DecimalSettings.DEFAULT_DECIMAL_SEPARATOR)
+            }
+
             it("uses the default separator if an empty string is set") {
-                decimalSettings.decimalSeparator = ""
+                decimalSettings.safeSetDecimalSeparator("")
 
                 assertThat(decimalSettings.decimalSeparator).isEqualTo(DecimalSettings.DEFAULT_DECIMAL_SEPARATOR)
             }
 
             it("uses only the first character if a multi-character string is given") {
-                decimalSettings.decimalSeparator = "foolish"
+                decimalSettings.safeSetDecimalSeparator("foolish")
 
                 assertThat(decimalSettings.decimalSeparator).isEqualTo("f")
             }

--- a/src/test/kotlin/com/fwdekker/randomness/integer/IntegerSettingsDialogTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/integer/IntegerSettingsDialogTest.kt
@@ -87,7 +87,7 @@ object IntegerSettingsDialogTest : Spek({
         }
 
         describe("grouping separator") {
-            it("uses the default separator if an empty string is set") {
+            it("uses the default separator if null is set") {
                 integerSettings.safeSetGroupingSeparator(null)
 
                 assertThat(integerSettings.groupingSeparator).isEqualTo(IntegerSettings.DEFAULT_GROUPING_SEPARATOR)

--- a/src/test/kotlin/com/fwdekker/randomness/integer/IntegerSettingsDialogTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/integer/IntegerSettingsDialogTest.kt
@@ -62,22 +62,48 @@ object IntegerSettingsDialogTest : Spek({
     }
 
     describe("input handling") {
-        it("truncates decimals in the base") {
-            GuiActionRunner.execute { frame.spinner("base").target().value = 22.62f }
+        describe("base") {
+            it("truncates decimals in the base") {
+                GuiActionRunner.execute { frame.spinner("base").target().value = 22.62f }
 
-            frame.spinner("base").requireValue(22)
+                frame.spinner("base").requireValue(22)
+            }
         }
 
-        it("truncates decimals in the minimum value") {
-            GuiActionRunner.execute { frame.spinner("minValue").target().value = 285.21f }
+        describe("minimum value") {
+            it("truncates decimals in the minimum value") {
+                GuiActionRunner.execute { frame.spinner("minValue").target().value = 285.21f }
 
-            frame.spinner("minValue").requireValue(285L)
+                frame.spinner("minValue").requireValue(285L)
+            }
         }
 
-        it("truncates decimals in the maximum value") {
-            GuiActionRunner.execute { frame.spinner("maxValue").target().value = 490.34f }
+        describe("maximum value") {
+            it("truncates decimals in the maximum value") {
+                GuiActionRunner.execute { frame.spinner("maxValue").target().value = 490.34f }
 
-            frame.spinner("maxValue").requireValue(490L)
+                frame.spinner("maxValue").requireValue(490L)
+            }
+        }
+
+        describe("grouping separator") {
+            it("uses the default separator if an empty string is set") {
+                integerSettings.safeSetGroupingSeparator(null)
+
+                assertThat(integerSettings.groupingSeparator).isEqualTo(IntegerSettings.DEFAULT_GROUPING_SEPARATOR)
+            }
+
+            it("uses the default separator if an empty string is set") {
+                integerSettings.safeSetGroupingSeparator("")
+
+                assertThat(integerSettings.groupingSeparator).isEqualTo(IntegerSettings.DEFAULT_GROUPING_SEPARATOR)
+            }
+
+            it("uses only the first character if a multi-character string is given") {
+                integerSettings.safeSetGroupingSeparator("mention")
+
+                assertThat(integerSettings.groupingSeparator).isEqualTo("m")
+            }
         }
     }
 

--- a/src/test/kotlin/com/fwdekker/randomness/integer/IntegerSettingsTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/integer/IntegerSettingsTest.kt
@@ -35,14 +35,20 @@ object IntegerSettingsTest : Spek({
 
     describe("input handling") {
         describe("grouping separator") {
+            it("uses the default separator if null is set") {
+                integerSettings.safeSetGroupingSeparator(null)
+
+                assertThat(integerSettings.groupingSeparator).isEqualTo(IntegerSettings.DEFAULT_GROUPING_SEPARATOR)
+            }
+
             it("uses the default separator if an empty string is set") {
-                integerSettings.groupingSeparator = ""
+                integerSettings.safeSetGroupingSeparator("")
 
                 assertThat(integerSettings.groupingSeparator).isEqualTo(IntegerSettings.DEFAULT_GROUPING_SEPARATOR)
             }
 
             it("uses only the first character if a multi-character string is given") {
-                integerSettings.groupingSeparator = "recited"
+                integerSettings.safeSetGroupingSeparator("recited")
 
                 assertThat(integerSettings.groupingSeparator).isEqualTo("r")
             }


### PR DESCRIPTION
Moves settings class properties to the constructor and makes the classes into data classes. This allows for easier comparison between settings instances. Because the settings serialiser currently cannot handle chars, `safeSet` methods have been added to check for the theoretical edge cases where a non-character-like string is set.