### PR TITLE
Fix issue with missing bundled dictionaries

### DIFF
--- a/src/main/java/com/fwdekker/randomness/word/WordSettingsDialog.java
+++ b/src/main/java/com/fwdekker/randomness/word/WordSettingsDialog.java
@@ -117,7 +117,7 @@ public final class WordSettingsDialog extends SettingsDialog<WordSettings> {
             : CapitalizationMode.Companion.getMode(capitalization));
 
         settings.setBundledDictionaries(filterIsInstance(dictionaries.getEntries(), BundledDictionary.class));
-        settings.setBundledDictionaries(filterIsInstance(dictionaries.getActiveEntries(), BundledDictionary.class));
+        settings.setActiveBundledDictionaries(filterIsInstance(dictionaries.getActiveEntries(), BundledDictionary.class));
         BundledDictionary.Companion.getCache().clear();
 
         settings.setUserDictionaries(filterIsInstance(dictionaries.getEntries(), UserDictionary.class));


### PR DESCRIPTION
Because of a minor typo, saving word settings would result in the _available_ bundled dictionaries being overwritten by the _selected_ bundled dictionaries. This bug was able to slip by the tests because the tests supposed to cover this could not be written because of incompatibility between IntelliJ's file chooser and the UI test framework.