### PR TITLE
UI QoL

### DIFF
--- a/src/main/java/com/fwdekker/randomness/array/ArraySettingsDialog.form
+++ b/src/main/java/com/fwdekker/randomness/array/ArraySettingsDialog.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.fwdekker.randomness.array.ArraySettingsDialog">
-  <grid id="27dc6" binding="contentPane" layout-manager="GridLayoutManager" row-count="5" column-count="5" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="contentPane" layout-manager="GridLayoutManager" row-count="5" column-count="6" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="500" height="400"/>
@@ -120,6 +120,11 @@
           <text value="\n"/>
         </properties>
       </component>
+      <hspacer id="156a7">
+        <constraints>
+          <grid row="0" column="5" row-span="4" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+      </hspacer>
     </children>
   </grid>
   <buttonGroups>

--- a/src/main/java/com/fwdekker/randomness/decimal/DecimalSettingsDialog.form
+++ b/src/main/java/com/fwdekker/randomness/decimal/DecimalSettingsDialog.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.fwdekker.randomness.decimal.DecimalSettingsDialog">
-  <grid id="cbd77" binding="contentPane" layout-manager="GridLayoutManager" row-count="7" column-count="5" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="cbd77" binding="contentPane" layout-manager="GridLayoutManager" row-count="7" column-count="6" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="10" left="10" bottom="10" right="10"/>
     <constraints>
       <xy x="48" y="54" width="442" height="297"/>
@@ -150,6 +150,11 @@
           <grid row="6" column="0" row-span="1" col-span="5" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
+      <hspacer id="d11f">
+        <constraints>
+          <grid row="0" column="5" row-span="6" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+      </hspacer>
     </children>
   </grid>
   <buttonGroups>

--- a/src/main/java/com/fwdekker/randomness/decimal/DecimalSettingsDialog.form
+++ b/src/main/java/com/fwdekker/randomness/decimal/DecimalSettingsDialog.form
@@ -10,9 +10,7 @@
     <children>
       <component id="6a447" class="com.fwdekker.randomness.ui.JDoubleSpinner" binding="minValue" custom-create="true">
         <constraints>
-          <grid row="0" column="1" row-span="1" col-span="4" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
-            <minimum-size width="75" height="-1"/>
-          </grid>
+          <grid row="0" column="1" row-span="1" col-span="4" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <name value="minValue"/>
@@ -20,9 +18,7 @@
       </component>
       <component id="7daea" class="com.fwdekker.randomness.ui.JDoubleSpinner" binding="maxValue" custom-create="true">
         <constraints>
-          <grid row="1" column="1" row-span="1" col-span="4" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
-            <minimum-size width="75" height="-1"/>
-          </grid>
+          <grid row="1" column="1" row-span="1" col-span="4" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <name value="maxValue"/>
@@ -48,9 +44,7 @@
       </component>
       <component id="b93dd" class="com.fwdekker.randomness.ui.JIntSpinner" binding="decimalCount" custom-create="true">
         <constraints>
-          <grid row="2" column="1" row-span="1" col-span="4" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
-            <preferred-size width="52" height="-1"/>
-          </grid>
+          <grid row="2" column="1" row-span="1" col-span="4" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <name value="decimalCount"/>

--- a/src/main/java/com/fwdekker/randomness/integer/IntegerSettingsDialog.form
+++ b/src/main/java/com/fwdekker/randomness/integer/IntegerSettingsDialog.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.fwdekker.randomness.integer.IntegerSettingsDialog">
-  <grid id="cbd77" binding="contentPane" layout-manager="GridLayoutManager" row-count="5" column-count="5" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="cbd77" binding="contentPane" layout-manager="GridLayoutManager" row-count="5" column-count="6" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="10" left="10" bottom="10" right="10"/>
     <constraints>
       <xy x="48" y="54" width="541" height="297"/>
@@ -114,6 +114,11 @@
           <grid row="4" column="0" row-span="1" col-span="5" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
+      <hspacer id="460b1">
+        <constraints>
+          <grid row="0" column="5" row-span="4" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+      </hspacer>
     </children>
   </grid>
   <buttonGroups>

--- a/src/main/java/com/fwdekker/randomness/integer/IntegerSettingsDialog.form
+++ b/src/main/java/com/fwdekker/randomness/integer/IntegerSettingsDialog.form
@@ -28,9 +28,7 @@
       </component>
       <component id="44ac7" class="com.fwdekker.randomness.ui.JLongSpinner" binding="minValue" custom-create="true">
         <constraints>
-          <grid row="0" column="1" row-span="1" col-span="4" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
-            <minimum-size width="75" height="-1"/>
-          </grid>
+          <grid row="0" column="1" row-span="1" col-span="4" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <name value="minValue"/>
@@ -38,9 +36,7 @@
       </component>
       <component id="b9000" class="com.fwdekker.randomness.ui.JLongSpinner" binding="maxValue" custom-create="true">
         <constraints>
-          <grid row="1" column="1" row-span="1" col-span="4" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
-            <minimum-size width="75" height="-1"/>
-          </grid>
+          <grid row="1" column="1" row-span="1" col-span="4" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <name value="maxValue"/>
@@ -96,14 +92,13 @@
           <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
+          <labelFor value="ad1d8"/>
           <text value="Base"/>
         </properties>
       </component>
       <component id="ad1d8" class="com.fwdekker.randomness.ui.JIntSpinner" binding="base" custom-create="true">
         <constraints>
-          <grid row="2" column="1" row-span="1" col-span="4" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
-            <minimum-size width="75" height="-1"/>
-          </grid>
+          <grid row="2" column="1" row-span="1" col-span="4" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <name value="base"/>

--- a/src/main/java/com/fwdekker/randomness/string/StringSettingsDialog.form
+++ b/src/main/java/com/fwdekker/randomness/string/StringSettingsDialog.form
@@ -28,9 +28,7 @@
       </component>
       <component id="1885f" class="com.fwdekker.randomness.ui.JIntSpinner" binding="minLength" custom-create="true">
         <constraints>
-          <grid row="0" column="1" row-span="1" col-span="4" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
-            <minimum-size width="75" height="-1"/>
-          </grid>
+          <grid row="0" column="1" row-span="1" col-span="4" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <name value="minLength"/>
@@ -38,9 +36,7 @@
       </component>
       <component id="ae252" class="com.fwdekker.randomness.ui.JIntSpinner" binding="maxLength" custom-create="true">
         <constraints>
-          <grid row="1" column="1" row-span="1" col-span="4" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
-            <minimum-size width="75" height="-1"/>
-          </grid>
+          <grid row="1" column="1" row-span="1" col-span="4" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <name value="maxLength"/>

--- a/src/main/java/com/fwdekker/randomness/string/StringSettingsDialog.form
+++ b/src/main/java/com/fwdekker/randomness/string/StringSettingsDialog.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.fwdekker.randomness.string.StringSettingsDialog">
-  <grid id="cbd77" binding="contentPane" layout-manager="GridLayoutManager" row-count="7" column-count="5" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="cbd77" binding="contentPane" layout-manager="GridLayoutManager" row-count="7" column-count="6" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="10" left="10" bottom="10" right="10"/>
     <constraints>
       <xy x="48" y="54" width="460" height="297"/>
@@ -162,6 +162,11 @@
           <grid row="6" column="0" row-span="1" col-span="5" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
+      <hspacer id="8848f">
+        <constraints>
+          <grid row="0" column="5" row-span="6" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+      </hspacer>
     </children>
   </grid>
   <buttonGroups>

--- a/src/main/java/com/fwdekker/randomness/uuid/UuidSettingsDialog.form
+++ b/src/main/java/com/fwdekker/randomness/uuid/UuidSettingsDialog.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.fwdekker.randomness.uuid.UuidSettingsDialog">
-  <grid id="cbd77" binding="contentPane" layout-manager="GridLayoutManager" row-count="2" column-count="5" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="cbd77" binding="contentPane" layout-manager="GridLayoutManager" row-count="2" column-count="6" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="10" left="10" bottom="10" right="10"/>
     <constraints>
       <xy x="48" y="54" width="436" height="297"/>
@@ -58,6 +58,11 @@
           <grid row="1" column="0" row-span="1" col-span="5" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
+      <hspacer id="2ea0a">
+        <constraints>
+          <grid row="0" column="5" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+      </hspacer>
     </children>
   </grid>
   <buttonGroups>

--- a/src/main/java/com/fwdekker/randomness/word/WordSettingsDialog.form
+++ b/src/main/java/com/fwdekker/randomness/word/WordSettingsDialog.form
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.fwdekker.randomness.word.WordSettingsDialog">
-  <grid id="27dc6" binding="contentPane" layout-manager="GridLayoutManager" row-count="8" column-count="6" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="contentPane" layout-manager="GridLayoutManager" row-count="8" column-count="7" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="547" height="400"/>
+      <xy x="20" y="20" width="567" height="400"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -207,6 +207,11 @@
           <grid row="5" column="0" row-span="2" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
+      <hspacer id="3da9">
+        <constraints>
+          <grid row="0" column="6" row-span="7" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+      </hspacer>
     </children>
   </grid>
   <buttonGroups>

--- a/src/main/java/com/fwdekker/randomness/word/WordSettingsDialog.form
+++ b/src/main/java/com/fwdekker/randomness/word/WordSettingsDialog.form
@@ -19,9 +19,7 @@
       </component>
       <component id="8a66f" class="com.fwdekker.randomness.ui.JIntSpinner" binding="minLength" custom-create="true">
         <constraints>
-          <grid row="0" column="1" row-span="1" col-span="5" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
-            <minimum-size width="75" height="-1"/>
-          </grid>
+          <grid row="0" column="1" row-span="1" col-span="5" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <name value="minLength"/>
@@ -38,9 +36,7 @@
       </component>
       <component id="2e2f" class="com.fwdekker.randomness.ui.JIntSpinner" binding="maxLength" custom-create="true">
         <constraints>
-          <grid row="1" column="1" row-span="1" col-span="5" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
-            <minimum-size width="75" height="-1"/>
-          </grid>
+          <grid row="1" column="1" row-span="1" col-span="5" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <name value="maxLength"/>


### PR DESCRIPTION
* Prevent components from spreading horizontally; instead let there be empty space on the right. This is more consistent with IntelliJ's own settings layouts.
* Ensures that labels are assigned to inputs where appropriate.
* Removes unnecessary size restrictions on inputs; let IntelliJ do the work.