### PR TITLE
Add input validation back in

### DIFF
--- a/src/main/kotlin/com/fwdekker/randomness/SettingsConfigurable.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/SettingsConfigurable.kt
@@ -1,6 +1,7 @@
 package com.fwdekker.randomness
 
 import com.intellij.openapi.options.Configurable
+import com.intellij.openapi.options.ConfigurationException
 import javax.swing.JComponent
 import javax.swing.JPanel
 
@@ -69,7 +70,13 @@ abstract class SettingsConfigurable<S : Settings<S>> : Configurable {
     /**
      * Saves the changes in the settings component to the default settings object.
      */
-    override fun apply() = component.saveSettings()
+    override fun apply() {
+        val validationInfo = component.doValidate()
+        if (validationInfo != null)
+            throw ConfigurationException(validationInfo.message, "Failed to save settings")
+
+        component.saveSettings()
+    }
 
     /**
      * Discards unsaved changes in the settings component.

--- a/src/test/kotlin/com/fwdekker/randomness/array/ArraySettingsComponentTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/array/ArraySettingsComponentTest.kt
@@ -1,6 +1,8 @@
 package com.fwdekker.randomness.array
 
+import com.intellij.openapi.options.ConfigurationException
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.swing.edt.FailOnThreadViolationRepaintManager
 import org.assertj.swing.edt.GuiActionRunner
 import org.assertj.swing.fixture.Containers.showInFrame
@@ -130,6 +132,23 @@ object ArraySettingsComponentTest : Spek({
     describe("configurable") {
         it("returns the correct display name") {
             assertThat(arraySettingsComponentConfigurable.displayName).isEqualTo("Arrays")
+        }
+
+        describe("saving modifications") {
+            it("accepts correct settings") {
+                GuiActionRunner.execute { frame.spinner("count").target().value = 39 }
+
+                arraySettingsComponentConfigurable.apply()
+
+                assertThat(arraySettings.count).isEqualTo(39)
+            }
+
+            it("rejects incorrect settings") {
+                GuiActionRunner.execute { frame.spinner("count").target().value = -3 }
+
+                assertThatThrownBy { arraySettingsComponentConfigurable.apply() }
+                    .isInstanceOf(ConfigurationException::class.java)
+            }
         }
 
         describe("modification detection") {

--- a/src/test/kotlin/com/fwdekker/randomness/decimal/DecimalSettingsComponentTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/decimal/DecimalSettingsComponentTest.kt
@@ -1,5 +1,7 @@
 package com.fwdekker.randomness.decimal
 
+import com.intellij.openapi.options.ConfigurationException
+import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.swing.edt.FailOnThreadViolationRepaintManager
 import org.assertj.swing.edt.GuiActionRunner
@@ -163,6 +165,23 @@ object DecimalSettingsComponentTest : Spek({
             assertThat(decimalSettingsComponentConfigurable.displayName).isEqualTo("Decimals")
         }
 
+        describe("saving modifications") {
+            it("accepts correct settings") {
+                GuiActionRunner.execute { frame.spinner("decimalCount").target().value = 89 }
+
+                decimalSettingsComponentConfigurable.apply()
+
+                assertThat(decimalSettings.decimalCount).isEqualTo(89)
+            }
+
+            it("rejects incorrect settings") {
+                GuiActionRunner.execute { frame.spinner("decimalCount").target().value = -13 }
+
+                Assertions.assertThatThrownBy { decimalSettingsComponentConfigurable.apply() }
+                    .isInstanceOf(ConfigurationException::class.java)
+            }
+        }
+
         describe("modification detection") {
             it("is initially unmodified") {
                 assertThat(decimalSettingsComponentConfigurable.isModified).isFalse()
@@ -193,8 +212,8 @@ object DecimalSettingsComponentTest : Spek({
         describe("resets") {
             it("resets all fields properly") {
                 GuiActionRunner.execute {
-                    frame.spinner("minValue").target().value = 970.53
-                    frame.spinner("maxValue").target().value = 206.90
+                    frame.spinner("minValue").target().value = 206.90
+                    frame.spinner("maxValue").target().value = 970.53
                     frame.spinner("decimalCount").target().value = 130
                     frame.checkBox("showTrailingZeroes").target().isSelected = true
                     frame.radioButton("groupingSeparatorPeriod").target().isSelected = true

--- a/src/test/kotlin/com/fwdekker/randomness/uuid/UuidSettingsComponentTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/uuid/UuidSettingsComponentTest.kt
@@ -70,6 +70,16 @@ object UuidSettingsComponentTest : Spek({
             assertThat(uuidSettingsComponentConfigurable.displayName).isEqualTo("UUIDs")
         }
 
+        describe("saving modifications") {
+            it("accepts correct settings") {
+                GuiActionRunner.execute { frame.radioButton("enclosureBacktick").target().isSelected = true }
+
+                uuidSettingsComponentConfigurable.apply()
+
+                assertThat(uuidSettings.enclosure).isEqualTo("`")
+            }
+        }
+
         describe("modification detection") {
             it("is initially unmodified") {
                 assertThat(uuidSettingsComponentConfigurable.isModified).isFalse()


### PR DESCRIPTION
#149 had the unintended side effect of removing input validation from the interface. This PR puts it back in.

(Oh, and it also renames `WordSettingsDialogTest` to `WordSettingsComponentTest` because apparently that didn't happen in #151.)