### PR TITLE
Improve error messages to refer to components

### DIFF
--- a/src/main/java/com/fwdekker/randomness/decimal/DecimalSettingsComponent.java
+++ b/src/main/java/com/fwdekker/randomness/decimal/DecimalSettingsComponent.java
@@ -64,7 +64,7 @@ public final class DecimalSettingsComponent extends SettingsComponent<DecimalSet
     private void createUIComponents() {
         minValue = new JDoubleSpinner();
         maxValue = new JDoubleSpinner();
-        valueRange = new JSpinnerRange(minValue, maxValue);
+        valueRange = new JSpinnerRange(minValue, maxValue, "value");
         decimalCount = new JIntSpinner(0, 0);
 
         decimalCount.addChangeListener(event -> {

--- a/src/main/java/com/fwdekker/randomness/integer/IntegerSettingsComponent.java
+++ b/src/main/java/com/fwdekker/randomness/integer/IntegerSettingsComponent.java
@@ -63,7 +63,7 @@ public final class IntegerSettingsComponent extends SettingsComponent<IntegerSet
         minValue = new JLongSpinner();
         maxValue = new JLongSpinner();
         base = new JIntSpinner(IntegerSettings.DECIMAL_BASE, IntegerSettings.MIN_BASE, IntegerSettings.MAX_BASE);
-        valueRange = new JSpinnerRange(minValue, maxValue, Long.MAX_VALUE);
+        valueRange = new JSpinnerRange(minValue, maxValue, Long.MAX_VALUE, "value");
 
         base.addChangeListener(event -> {
             final int value = ((JIntSpinner) event.getSource()).getValue();

--- a/src/main/java/com/fwdekker/randomness/string/StringSettingsComponent.java
+++ b/src/main/java/com/fwdekker/randomness/string/StringSettingsComponent.java
@@ -65,7 +65,7 @@ public final class StringSettingsComponent extends SettingsComponent<StringSetti
     private void createUIComponents() {
         minLength = new JIntSpinner(1, 1);
         maxLength = new JIntSpinner(1, 1);
-        lengthRange = new JSpinnerRange(minLength, maxLength, Integer.MAX_VALUE);
+        lengthRange = new JSpinnerRange(minLength, maxLength, Integer.MAX_VALUE, "length");
 
         alphabetList = new JList<>(Alphabet.values());
         alphabetList.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
@@ -108,7 +108,7 @@ public final class StringSettingsComponent extends SettingsComponent<StringSetti
     @Nullable
     public ValidationInfo doValidate() {
         if (alphabetList.getSelectedValuesList().isEmpty())
-            return new ValidationInfo("Please select at least one alphabet.", alphabetList);
+            return new ValidationInfo("Please select at least one symbol set.", alphabetList);
 
         return JavaHelperKt.firstNonNull(
             minLength.validateValue(),

--- a/src/main/java/com/fwdekker/randomness/string/StringSettingsComponent.java
+++ b/src/main/java/com/fwdekker/randomness/string/StringSettingsComponent.java
@@ -108,7 +108,7 @@ public final class StringSettingsComponent extends SettingsComponent<StringSetti
     @Nullable
     public ValidationInfo doValidate() {
         if (alphabetList.getSelectedValuesList().isEmpty())
-            return new ValidationInfo("Please select at least one symbol set.", alphabetList);
+            return new ValidationInfo("Select at least one symbol set.", alphabetList);
 
         return JavaHelperKt.firstNonNull(
             minLength.validateValue(),

--- a/src/main/java/com/fwdekker/randomness/string/StringSettingsDialog.form
+++ b/src/main/java/com/fwdekker/randomness/string/StringSettingsDialog.form
@@ -93,7 +93,7 @@
         </constraints>
         <properties>
           <labelFor value="9ade9"/>
-          <text value="Symbols"/>
+          <text value="Symbol sets"/>
         </properties>
       </component>
       <scrollpane id="9ade9">

--- a/src/main/java/com/fwdekker/randomness/word/WordSettingsComponent.java
+++ b/src/main/java/com/fwdekker/randomness/word/WordSettingsComponent.java
@@ -76,7 +76,7 @@ public final class WordSettingsComponent extends SettingsComponent<WordSettings>
     private void createUIComponents() {
         minLength = new JIntSpinner(1, 1);
         maxLength = new JIntSpinner(1, 1);
-        lengthRange = new JSpinnerRange(minLength, maxLength, Integer.MAX_VALUE);
+        lengthRange = new JSpinnerRange(minLength, maxLength, Integer.MAX_VALUE, "length");
 
         dictionaries = new JEditableList<>();
         dictionaries.getSelectionModel().addListSelectionListener(this::onDictionaryHighlightChange);
@@ -220,8 +220,8 @@ public final class WordSettingsComponent extends SettingsComponent<WordSettings>
         final int maxWordLength = WordSettingsComponentHelperKt.maxLength(words);
         if (minLength.getValue() > maxWordLength) {
             return new ValidationInfo("" +
-                "Enter a value less than or equal to " + maxWordLength + ", " +
-                "the length of the longest word in the selected dictionaries.",
+                "The longest word in the selected dictionaries is " + maxWordLength + " characters. " +
+                "Set the minimum length to a value less than or equal to " + maxWordLength + ".",
                 minLength
             );
         }
@@ -229,8 +229,8 @@ public final class WordSettingsComponent extends SettingsComponent<WordSettings>
         final int minWordLength = WordSettingsComponentHelperKt.minLength(words);
         if (maxLength.getValue() < minWordLength) {
             return new ValidationInfo("" +
-                "Enter a value greater than or equal to " + minWordLength + ", " +
-                "the length of the shortest word in the selected dictionaries.",
+                "The shortest word in the selected dictionaries is " + minWordLength + " characters. " +
+                "Set the maximum length to a value less than or equal to " + minWordLength + ".",
                 maxLength
             );
         }

--- a/src/main/kotlin/com/fwdekker/randomness/DataActions.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/DataActions.kt
@@ -141,7 +141,7 @@ abstract class DataInsertAction : AnAction() {
                     """
                         Randomness was unable to generate random data.
                         ${if (!e.message.isNullOrBlank()) "The following error was encountered: ${e.message}\n" else ""}
-                        Please check your Randomness settings and try again.
+                        Check your Randomness settings and try again.
                     """.trimIndent()
                 )
                 return

--- a/src/main/kotlin/com/fwdekker/randomness/ui/JNumberSpinners.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/ui/JNumberSpinners.kt
@@ -86,8 +86,8 @@ abstract class JNumberSpinner<T>(value: T, minValue: T, maxValue: T, stepSize: T
      */
     fun validateValue() =
         when {
-            value < minValue -> ValidationInfo("Please enter a value greater than or equal to $minValue.", this)
-            value > maxValue -> ValidationInfo("Please enter a value less than or equal to $maxValue.", this)
+            value < minValue -> ValidationInfo("Enter a value greater than or equal to $minValue.", this)
+            value > maxValue -> ValidationInfo("Enter a value less than or equal to $maxValue.", this)
             else -> null
         }
 }

--- a/src/main/kotlin/com/fwdekker/randomness/ui/JSpinnerRange.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/ui/JSpinnerRange.kt
@@ -41,6 +41,12 @@ class JSpinnerRange @JvmOverloads constructor(
         get() = (this.max.value as Number).toDouble()
 
 
+    /**
+     * A container for two [JSpinner]s that indicate a range of values, using a default range.
+     *
+     * Used for compatibility with Java.
+     */
+    // TODO Remove this after migrating UI to Kotlin.
     constructor(min: JSpinner, max: JSpinner, name: String?) : this(min, max, DEFAULT_MAX_RANGE, name)
 
     init {

--- a/src/main/kotlin/com/fwdekker/randomness/ui/JSpinnerRange.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/ui/JSpinnerRange.kt
@@ -10,11 +10,13 @@ import javax.swing.JSpinner
  * @param min the `JSpinner` that represents the minimum value
  * @param max the `JSpinner` that represents the maximum value
  * @param maxRange the maximum difference between `min` and `max`
+ * @param name the name used in error messages
  */
 class JSpinnerRange @JvmOverloads constructor(
     private val min: JSpinner,
     private val max: JSpinner,
-    private val maxRange: Double = DEFAULT_MAX_RANGE
+    private val maxRange: Double = DEFAULT_MAX_RANGE,
+    name: String? = null
 ) {
     companion object {
         /**
@@ -23,6 +25,10 @@ class JSpinnerRange @JvmOverloads constructor(
         private const val DEFAULT_MAX_RANGE = 1E53
     }
 
+    /**
+     * The `name` parameter preceded by a whitespace if it was not null, or an empty string otherwise.
+     */
+    val name = if (name != null) " $name" else ""
     /**
      * The current minimum value of the range.
      */
@@ -34,6 +40,8 @@ class JSpinnerRange @JvmOverloads constructor(
     val maxValue: Double
         get() = (this.max.value as Number).toDouble()
 
+
+    constructor(min: JSpinner, max: JSpinner, name: String?) : this(min, max, DEFAULT_MAX_RANGE, name)
 
     init {
         if (maxRange < 0)
@@ -49,8 +57,11 @@ class JSpinnerRange @JvmOverloads constructor(
      */
     fun validateValue() =
         when {
-            minValue > maxValue -> ValidationInfo("The maximum should not be smaller than the minimum.", max)
-            maxValue - minValue > maxRange -> ValidationInfo("The range should not exceed $maxRange.", max)
-            else -> null
+            minValue > maxValue ->
+                ValidationInfo("The maximum$name should not be smaller than the minimum$name.", max)
+            maxValue - minValue > maxRange ->
+                ValidationInfo("The range should not exceed $maxRange.", max)
+            else ->
+                null
         }
 }

--- a/src/test/kotlin/com/fwdekker/randomness/array/ArraySettingsComponentTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/array/ArraySettingsComponentTest.kt
@@ -90,7 +90,7 @@ object ArraySettingsComponentTest : Spek({
 
                 assertThat(validationInfo).isNotNull()
                 assertThat(validationInfo?.component).isEqualTo(frame.spinner("count").target())
-                assertThat(validationInfo?.message).isEqualTo("Please enter a value greater than or equal to 1.")
+                assertThat(validationInfo?.message).isEqualTo("Enter a value greater than or equal to 1.")
             }
 
             it("passes for a count of 1") {
@@ -106,7 +106,7 @@ object ArraySettingsComponentTest : Spek({
 
                 assertThat(validationInfo).isNotNull()
                 assertThat(validationInfo?.component).isEqualTo(frame.spinner("count").target())
-                assertThat(validationInfo?.message).isEqualTo("Please enter a value greater than or equal to 1.")
+                assertThat(validationInfo?.message).isEqualTo("Enter a value greater than or equal to 1.")
             }
         }
     }

--- a/src/test/kotlin/com/fwdekker/randomness/decimal/DecimalSettingsComponentTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/decimal/DecimalSettingsComponentTest.kt
@@ -102,7 +102,8 @@ object DecimalSettingsComponentTest : Spek({
 
                 assertThat(validationInfo).isNotNull()
                 assertThat(validationInfo?.component).isEqualTo(frame.spinner("maxValue").target())
-                assertThat(validationInfo?.message).isEqualTo("The maximum should not be smaller than the minimum.")
+                assertThat(validationInfo?.message)
+                    .isEqualTo("The maximum value should not be smaller than the minimum value.")
             }
 
             it("fails if the range size overflows") {

--- a/src/test/kotlin/com/fwdekker/randomness/decimal/DecimalSettingsComponentTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/decimal/DecimalSettingsComponentTest.kt
@@ -134,7 +134,7 @@ object DecimalSettingsComponentTest : Spek({
 
                 assertThat(validationInfo).isNotNull()
                 assertThat(validationInfo?.component).isEqualTo(frame.spinner("decimalCount").target())
-                assertThat(validationInfo?.message).isEqualTo("Please enter a value greater than or equal to 0.")
+                assertThat(validationInfo?.message).isEqualTo("Enter a value greater than or equal to 0.")
             }
         }
     }

--- a/src/test/kotlin/com/fwdekker/randomness/integer/IntegerSettingsComponentTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/integer/IntegerSettingsComponentTest.kt
@@ -129,7 +129,8 @@ object IntegerSettingsComponentTest : Spek({
 
                 assertThat(validationInfo).isNotNull()
                 assertThat(validationInfo?.component).isEqualTo(frame.spinner("maxValue").target())
-                assertThat(validationInfo?.message).isEqualTo("The maximum should not be smaller than the minimum.")
+                assertThat(validationInfo?.message)
+                    .isEqualTo("The maximum value should not be smaller than the minimum value.")
             }
 
             it("fails if the range size overflows") {

--- a/src/test/kotlin/com/fwdekker/randomness/integer/IntegerSettingsComponentTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/integer/IntegerSettingsComponentTest.kt
@@ -155,7 +155,7 @@ object IntegerSettingsComponentTest : Spek({
 
                 assertThat(validationInfo).isNotNull()
                 assertThat(validationInfo?.component).isEqualTo(frame.spinner("base").target())
-                assertThat(validationInfo?.message).isEqualTo("Please enter a value greater than or equal to 2.")
+                assertThat(validationInfo?.message).isEqualTo("Enter a value greater than or equal to 2.")
             }
 
             it("fails if the base is 0") {
@@ -165,7 +165,7 @@ object IntegerSettingsComponentTest : Spek({
 
                 assertThat(validationInfo).isNotNull()
                 assertThat(validationInfo?.component).isEqualTo(frame.spinner("base").target())
-                assertThat(validationInfo?.message).isEqualTo("Please enter a value greater than or equal to 2.")
+                assertThat(validationInfo?.message).isEqualTo("Enter a value greater than or equal to 2.")
             }
 
             it("fails if the base is 1") {
@@ -175,7 +175,7 @@ object IntegerSettingsComponentTest : Spek({
 
                 assertThat(validationInfo).isNotNull()
                 assertThat(validationInfo?.component).isEqualTo(frame.spinner("base").target())
-                assertThat(validationInfo?.message).isEqualTo("Please enter a value greater than or equal to 2.")
+                assertThat(validationInfo?.message).isEqualTo("Enter a value greater than or equal to 2.")
             }
 
             it("fails if the base is greater than 36") {
@@ -185,7 +185,7 @@ object IntegerSettingsComponentTest : Spek({
 
                 assertThat(validationInfo).isNotNull()
                 assertThat(validationInfo?.component).isEqualTo(frame.spinner("base").target())
-                assertThat(validationInfo?.message).isEqualTo("Please enter a value less than or equal to 36.")
+                assertThat(validationInfo?.message).isEqualTo("Enter a value less than or equal to 36.")
             }
         }
     }

--- a/src/test/kotlin/com/fwdekker/randomness/string/StringSettingsComponentTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/string/StringSettingsComponentTest.kt
@@ -116,7 +116,8 @@ object StringSettingsComponentTest : Spek({
 
                 assertThat(validationInfo).isNotNull()
                 assertThat(validationInfo?.component).isEqualTo(frame.spinner("maxLength").target())
-                assertThat(validationInfo?.message).isEqualTo("The maximum should not be smaller than the minimum.")
+                assertThat(validationInfo?.message)
+                    .isEqualTo("The maximum length should not be smaller than the minimum length.")
             }
         }
 
@@ -128,7 +129,7 @@ object StringSettingsComponentTest : Spek({
 
                 assertThat(validationInfo).isNotNull()
                 assertThat(validationInfo?.component).isEqualTo(frame.list("alphabets").target())
-                assertThat(validationInfo?.message).isEqualTo("Please select at least one alphabet.")
+                assertThat(validationInfo?.message).isEqualTo("Please select at least one symbol set.")
             }
         }
     }

--- a/src/test/kotlin/com/fwdekker/randomness/string/StringSettingsComponentTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/string/StringSettingsComponentTest.kt
@@ -103,7 +103,7 @@ object StringSettingsComponentTest : Spek({
 
                 assertThat(validationInfo).isNotNull()
                 assertThat(validationInfo?.component).isEqualTo(frame.spinner("minLength").target())
-                assertThat(validationInfo?.message).isEqualTo("Please enter a value greater than or equal to 1.")
+                assertThat(validationInfo?.message).isEqualTo("Enter a value greater than or equal to 1.")
             }
 
             it("fails if the minimum length is greater than the maximum length") {
@@ -129,7 +129,7 @@ object StringSettingsComponentTest : Spek({
 
                 assertThat(validationInfo).isNotNull()
                 assertThat(validationInfo?.component).isEqualTo(frame.list("alphabets").target())
-                assertThat(validationInfo?.message).isEqualTo("Please select at least one symbol set.")
+                assertThat(validationInfo?.message).isEqualTo("Select at least one symbol set.")
             }
         }
     }

--- a/src/test/kotlin/com/fwdekker/randomness/ui/JNumberSpinnerTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/ui/JNumberSpinnerTest.kt
@@ -70,7 +70,7 @@ object JNumberSpinnerTest : Spek({
 
             val info = spinner.validateValue()
             assertThat(info).isNotNull()
-            assertThat(info?.message).isEqualTo("Please enter a value greater than or equal to -24.8.")
+            assertThat(info?.message).isEqualTo("Enter a value greater than or equal to -24.8.")
         }
 
         it("should fail if the value is higher than the maximum value") {
@@ -80,7 +80,7 @@ object JNumberSpinnerTest : Spek({
 
             val info = spinner.validateValue()
             assertThat(info).isNotNull()
-            assertThat(info?.message).isEqualTo("Please enter a value less than or equal to 32.03.")
+            assertThat(info?.message).isEqualTo("Enter a value less than or equal to 32.03.")
         }
 
         it("should pass if the minimum value was adjusted") {

--- a/src/test/kotlin/com/fwdekker/randomness/ui/JSpinnerRangeTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/ui/JSpinnerRangeTest.kt
@@ -12,6 +12,13 @@ import javax.swing.JSpinner
  */
 class JSpinnerRangeTest {
     @Test
+    fun testValidRange() {
+        val range = JSpinnerRange(createJSpinner(287.01), createJSpinner(448.50), 758.34)
+
+        assertThat(range.validateValue()).isNull()
+    }
+
+    @Test
     fun testIllegalMaxRange() {
         assertThatThrownBy { JSpinnerRange(createJSpinner(), createJSpinner(), -37.20) }
             .isInstanceOf(IllegalArgumentException::class.java)
@@ -44,6 +51,15 @@ class JSpinnerRangeTest {
         val info = range.validateValue()
         assertThat(info).isNotNull()
         assertThat(info?.message).isEqualTo("The range should not exceed 793.31.")
+    }
+
+    @Test
+    fun testName() {
+        val range = JSpinnerRange(createJSpinner(459.18), createJSpinner(214.93), "name")
+
+        val info = range.validateValue()
+        assertThat(info).isNotNull()
+        assertThat(info?.message).isEqualTo("The maximum name should not be smaller than the minimum name.")
     }
 }
 

--- a/src/test/kotlin/com/fwdekker/randomness/word/WordSettingsComponentTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/word/WordSettingsComponentTest.kt
@@ -165,7 +165,7 @@ object WordSettingsComponentTest : Spek({
 
                 assertThat(validationInfo).isNotNull()
                 assertThat(validationInfo?.component).isEqualTo(frame.spinner("minLength").target())
-                assertThat(validationInfo?.message).isEqualTo("Please enter a value greater than or equal to 1.")
+                assertThat(validationInfo?.message).isEqualTo("Enter a value greater than or equal to 1.")
             }
 
             it("fails if the minimum length is greater than the maximum length") {

--- a/src/test/kotlin/com/fwdekker/randomness/word/WordSettingsComponentTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/word/WordSettingsComponentTest.kt
@@ -177,7 +177,8 @@ object WordSettingsComponentTest : Spek({
 
                 assertThat(validationInfo).isNotNull()
                 assertThat(validationInfo?.component).isEqualTo(frame.spinner("maxLength").target())
-                assertThat(validationInfo?.message).isEqualTo("The maximum should not be smaller than the minimum.")
+                assertThat(validationInfo?.message)
+                    .isEqualTo("The maximum length should not be smaller than the minimum length.")
             }
 
             it("fails if the length range ends too low to match any words") {
@@ -189,8 +190,8 @@ object WordSettingsComponentTest : Spek({
                 assertThat(validationInfo).isNotNull()
                 assertThat(validationInfo?.component).isEqualTo(frame.spinner("maxLength").target())
                 assertThat(validationInfo?.message).isEqualTo("" +
-                    "Enter a value greater than or equal to 1, " +
-                    "the length of the shortest word in the selected dictionaries."
+                    "The shortest word in the selected dictionaries is 1 characters. " +
+                    "Set the maximum length to a value less than or equal to 1."
                 )
             }
 
@@ -203,8 +204,9 @@ object WordSettingsComponentTest : Spek({
                 assertThat(validationInfo).isNotNull()
                 assertThat(validationInfo?.component).isEqualTo(frame.spinner("minLength").target())
                 assertThat(validationInfo?.message).isEqualTo("" +
-                    "Enter a value less than or equal to 31, " +
-                    "the length of the longest word in the selected dictionaries.")
+                    "The longest word in the selected dictionaries is 31 characters. " +
+                    "Set the minimum length to a value less than or equal to 31."
+                )
             }
         }
 


### PR DESCRIPTION
* Changes error messages for ranges to say "The minimum length should be larger than ..." rather than "The minimum should be larger than ...".
* Makes word length range error messages easier to read.
* Renames "alphabets" to "symbol sets" in the user interface.
* Adds a test (`testValidRange`) for `JSpinnerRange` that should have been there in the first place.
* Removes "please" from error messages because a) it was done inconsistently, and b) it's more concise.