### PR TITLE
Fix error where checked entries are not unchecked

### DIFF
--- a/src/main/kotlin/com/fwdekker/randomness/ui/JEditableList.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/ui/JEditableList.kt
@@ -181,8 +181,7 @@ class JEditableList<T>(name: String? = null) : JTable() {
      *
      * @param entries exactly those entries of which the checkboxes should be checked
      */
-    fun setActiveEntries(entries: Collection<T>) =
-        entries.filter { hasEntry(it) }.forEach { entry -> setActive(entry, entries.contains(entry)) }
+    fun setActiveEntries(entries: Collection<T>) = this.entries.forEach { setActive(it, entries.contains(it)) }
 
     /**
      * Adds a listener that is called when a row's activity is changed by the user.

--- a/src/test/kotlin/com/fwdekker/randomness/ui/JEditableListTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/ui/JEditableListTest.kt
@@ -193,6 +193,16 @@ object JEditableListTest : Spek({
 
             assertThat(list.activeEntries).containsExactly("forte")
         }
+
+        it("unchecks previously checked entries") {
+            val entries = listOf("rot", "possible", "harbor")
+            GuiActionRunner.execute { list.setEntries(entries) }
+            GuiActionRunner.execute { list.setActiveEntries(entries) }
+
+            GuiActionRunner.execute { list.setActiveEntries(listOf("rot", "harbor")) }
+
+            assertThat(list.activeEntries).containsExactly("rot", "harbor")
+        }
     }
 
     describe("isActive") {


### PR DESCRIPTION
When calling `setActiveEntries`, only those entries that are given should be checked afterwards. The old implementation would only check the given entries without considering the state of the other entries.