### PR TITLE
Re-engineer JCheckBoxTable

### DIFF
--- a/.config/detekt/.detekt.yml
+++ b/.config/detekt/.detekt.yml
@@ -39,6 +39,9 @@ style:
     # Those functions are added as conscious design decisions.
     DataClassContainsFunctions:
         active: false
+    # Such comments are OK.
+    ForbiddenComment:
+        active: false
     # No braces are easier to read.
     MandatoryBracesIfStatements:
         active: false

--- a/src/main/java/com/fwdekker/randomness/string/StringSettingsComponent.java
+++ b/src/main/java/com/fwdekker/randomness/string/StringSettingsComponent.java
@@ -148,7 +148,7 @@ public final class StringSettingsComponent extends SettingsComponent<StringSetti
      * @return {@link Unit}
      */
     private Unit addSymbolSets(final List<? extends SymbolSet> symbolSets) {
-        symbolSetTable.addEntry(new SymbolSet("", ""));
+        symbolSetTable.addEntry(new SymbolSet("", ""), false);
         return Unit.INSTANCE;
     }
 

--- a/src/main/java/com/fwdekker/randomness/string/StringSettingsComponent.java
+++ b/src/main/java/com/fwdekker/randomness/string/StringSettingsComponent.java
@@ -71,12 +71,13 @@ public final class StringSettingsComponent extends SettingsComponent<StringSetti
         lengthRange = new JSpinnerRange(minLength, maxLength, Integer.MAX_VALUE, "length");
 
         symbolSetTable = new JCheckBoxTable<>(
-            2,
-            Arrays.asList(0, 1),
-            Arrays.asList("Name", "Symbols"),
-            it -> true,
+            Arrays.asList(
+                new JCheckBoxTable.Column("Name", true),
+                new JCheckBoxTable.Column("Symbols", true)
+            ),
             it -> new SymbolSet(it.get(0), it.get(1)),
-            it -> Arrays.asList(it.getName(), it.getSymbols())
+            it -> Arrays.asList(it.getName(), it.getSymbols()),
+            it -> true
         );
         symbolSetTable.setName("symbolSets");
 

--- a/src/main/java/com/fwdekker/randomness/string/StringSettingsComponent.java
+++ b/src/main/java/com/fwdekker/randomness/string/StringSettingsComponent.java
@@ -70,21 +70,22 @@ public final class StringSettingsComponent extends SettingsComponent<StringSetti
         maxLength = new JIntSpinner(1, 1);
         lengthRange = new JSpinnerRange(minLength, maxLength, Integer.MAX_VALUE, "length");
 
+        symbolSetTable = new JCheckBoxTable<>(
+            2,
+            Arrays.asList(0, 1),
+            Arrays.asList("Name", "Symbols"),
+            it -> true,
+            it -> new SymbolSet(it.get(0), it.get(1)),
+            it -> Arrays.asList(it.getName(), it.getSymbols())
+        );
+        symbolSetTable.setName("symbolSets");
+
         symbolSetPanel =
             new JDecoratedCheckBoxTablePanel<SymbolSet>(
-                new JCheckBoxTable<>(
-                    2,
-                    Arrays.asList(0, 1),
-                    Arrays.asList("Name", "Symbols"),
-                    it -> true,
-                    it -> new SymbolSet(it.get(0), it.get(1)),
-                    it -> Arrays.asList(it.getName(), it.getSymbols()),
-                    "symbolSets"
-                ),
+                symbolSetTable,
                 this::addSymbolSets, null, this::removeSymbolSets,
                 it -> true, it -> false, it -> !it.isEmpty()
             );
-        symbolSetTable = symbolSetPanel.getTable();
     }
 
 

--- a/src/main/java/com/fwdekker/randomness/word/WordSettingsComponent.java
+++ b/src/main/java/com/fwdekker/randomness/word/WordSettingsComponent.java
@@ -79,25 +79,25 @@ public final class WordSettingsComponent extends SettingsComponent<WordSettings>
         maxLength = new JIntSpinner(1, 1);
         lengthRange = new JSpinnerRange(minLength, maxLength, Integer.MAX_VALUE, "length");
 
-        dictionaryPanel =
-            new JDecoratedCheckBoxTablePanel<Dictionary>(
-                new JCheckBoxTable<>(
-                    2,
-                    Collections.emptyList(),
-                    Arrays.asList("Type", "Location"),
-                    UserDictionary.class::isInstance,
-                    it -> it.get(0).equals("bundled")
-                        ? BundledDictionary.Companion.getCache().get(it.get(1), true)
-                        : UserDictionary.Companion.getCache().get(it.get(1), true),
-                    it -> it instanceof BundledDictionary
-                        ? Arrays.asList("bundled", ((BundledDictionary) it).getFilename())
-                        : Arrays.asList("user", ((UserDictionary) it).getFilename()),
-                    "dictionaries"
-                ),
-                this::addDictionaries, null, this::removeDictionaries,
-                it -> true, it -> false, it -> it.stream().allMatch(UserDictionary.class::isInstance)
-            );
-        dictionaryTable = dictionaryPanel.getTable();
+        dictionaryTable = new JCheckBoxTable<>(
+            2,
+            Collections.emptyList(),
+            Arrays.asList("Type", "Location"),
+            UserDictionary.class::isInstance,
+            it -> it.get(0).equals("bundled")
+                ? BundledDictionary.Companion.getCache().get(it.get(1), true)
+                : UserDictionary.Companion.getCache().get(it.get(1), true),
+            it -> it instanceof BundledDictionary
+                ? Arrays.asList("bundled", ((BundledDictionary) it).getFilename())
+                : Arrays.asList("user", ((UserDictionary) it).getFilename())
+        );
+        dictionaryTable.setName("dictionaries");
+
+        dictionaryPanel = new JDecoratedCheckBoxTablePanel<Dictionary>(
+            dictionaryTable,
+            this::addDictionaries, null, this::removeDictionaries,
+            it -> true, it -> false, it -> it.stream().allMatch(UserDictionary.class::isInstance)
+        );
     }
 
 

--- a/src/main/java/com/fwdekker/randomness/word/WordSettingsComponent.java
+++ b/src/main/java/com/fwdekker/randomness/word/WordSettingsComponent.java
@@ -22,7 +22,6 @@ import org.jetbrains.annotations.Nullable;
 import javax.swing.ButtonGroup;
 import javax.swing.JPanel;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -80,16 +79,17 @@ public final class WordSettingsComponent extends SettingsComponent<WordSettings>
         lengthRange = new JSpinnerRange(minLength, maxLength, Integer.MAX_VALUE, "length");
 
         dictionaryTable = new JCheckBoxTable<>(
-            2,
-            Collections.emptyList(),
-            Arrays.asList("Type", "Location"),
-            UserDictionary.class::isInstance,
-            it -> it.get(0).equals("bundled")
+            Arrays.asList(
+                new JCheckBoxTable.Column("Type", false),
+                new JCheckBoxTable.Column("Location", false)
+            ),
+            it -> "bundled".equals(it.get(0))
                 ? BundledDictionary.Companion.getCache().get(it.get(1), true)
                 : UserDictionary.Companion.getCache().get(it.get(1), true),
             it -> it instanceof BundledDictionary
                 ? Arrays.asList("bundled", ((BundledDictionary) it).getFilename())
-                : Arrays.asList("user", ((UserDictionary) it).getFilename())
+                : Arrays.asList("user", ((UserDictionary) it).getFilename()),
+            UserDictionary.class::isInstance
         );
         dictionaryTable.setName("dictionaries");
 

--- a/src/main/java/com/fwdekker/randomness/word/WordSettingsComponent.java
+++ b/src/main/java/com/fwdekker/randomness/word/WordSettingsComponent.java
@@ -22,6 +22,7 @@ import org.jetbrains.annotations.Nullable;
 import javax.swing.ButtonGroup;
 import javax.swing.JPanel;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -203,7 +204,7 @@ public final class WordSettingsComponent extends SettingsComponent<WordSettings>
                 return;
             }
 
-            dictionaryTable.addEntry(newDictionary);
+            dictionaryTable.addEntry(newDictionary, false);
         });
 
         return Unit.INSTANCE;
@@ -255,13 +256,13 @@ public final class WordSettingsComponent extends SettingsComponent<WordSettings>
     /**
      * Filters instances of {@code SUP} to only return instances of {@code SUB}.
      *
-     * @param list  a list of {@code SUP} elements
+     * @param list  a collection of {@code SUP} elements
      * @param cls   the class to filter by
      * @param <SUB> the subclass
      * @param <SUP> the super class
      * @return a list containing the values of {@code list} that are of class {@code cls}
      */
-    private static <SUB, SUP> Set<SUB> filterIsInstance(final List<SUP> list, final Class<SUB> cls) {
+    private static <SUB, SUP> Set<SUB> filterIsInstance(final Collection<SUP> list, final Class<SUB> cls) {
         return list.stream().filter(cls::isInstance).map(cls::cast).collect(Collectors.toSet());
     }
 }

--- a/src/main/kotlin/com/fwdekker/randomness/ui/JCheckBoxTable.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/ui/JCheckBoxTable.kt
@@ -195,8 +195,8 @@ class JCheckBoxTable<T>(
     /**
      * Returns the name of the [column]th column.
      *
-     * The index uses the model's indexing rather than the indexing of [columns]. Therefore, an index of `0` refers to
-     * the checkbox column.
+     * The index uses the model's indexing rather than the indexing of the user-supplied columns. Therefore, an index of
+     * `0` refers to the checkbox column.
      *
      * @param column the index of the column to return the name of
      */

--- a/src/main/kotlin/com/fwdekker/randomness/ui/JCheckBoxTable.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/ui/JCheckBoxTable.kt
@@ -30,8 +30,7 @@ class JCheckBoxTable<T>(
     columnNames: Collection<String> = emptyList(),
     val isEntryEditable: ((T) -> Boolean) = { false },
     val listToEntry: ((List<String>) -> T),
-    val entryToList: ((T) -> List<String>),
-    name: String? = null
+    val entryToList: ((T) -> List<String>)
 ) : JBTable() {
     companion object {
         /**
@@ -80,7 +79,6 @@ class JCheckBoxTable<T>(
     init {
         require(columnCount >= 1) { "`columnCount` must be at least 1." }
 
-        setName(name)
         setModel(model)
 
         setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION)
@@ -260,7 +258,7 @@ class JCheckBoxTable<T>(
  * be enabled
  */
 class JDecoratedCheckBoxTablePanel<T>(
-    val table: JCheckBoxTable<T>,
+    table: JCheckBoxTable<T>,
     addAction: ((List<T>) -> Unit)? = null,
     editAction: ((List<T>) -> Unit)? = null,
     removeAction: ((List<T>) -> Unit)? = null,

--- a/src/test/kotlin/com/fwdekker/randomness/string/StringSettingsComponentTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/string/StringSettingsComponentTest.kt
@@ -259,6 +259,39 @@ object StringSettingsComponentTest : Spek({
         }
 
         describe("symbol sets") {
+            it("fails if a symbol set does not have a name") {
+                GuiActionRunner.execute { componentSymbolSets.entries = listOf(SymbolSet("", "abc")) }
+
+                val validationInfo = stringSettingsComponent.doValidate()
+
+                assertThat(validationInfo).isNotNull()
+                assertThat(validationInfo?.component).isEqualTo(frame.table("symbolSets").target())
+                assertThat(validationInfo?.message).isEqualTo("All symbol sets must have a name.")
+            }
+
+            it("fails if two symbol sets have the same name") {
+                GuiActionRunner.execute {
+                    componentSymbolSets.entries = listOf(SymbolSet("name1", "abc"), SymbolSet("name2", "abc"))
+                    componentSymbolSets.setValueAt("name1", 1, 1)
+                }
+
+                val validationInfo = stringSettingsComponent.doValidate()
+
+                assertThat(validationInfo).isNotNull()
+                assertThat(validationInfo?.component).isEqualTo(frame.table("symbolSets").target())
+                assertThat(validationInfo?.message).isEqualTo("Symbol sets must have unique names.")
+            }
+
+            it("fails if a symbol set does not have symbols") {
+                GuiActionRunner.execute { componentSymbolSets.entries = listOf(SymbolSet("name", "")) }
+
+                val validationInfo = stringSettingsComponent.doValidate()
+
+                assertThat(validationInfo).isNotNull()
+                assertThat(validationInfo?.component).isEqualTo(frame.table("symbolSets").target())
+                assertThat(validationInfo?.message).isEqualTo("Symbol sets must have at least one symbol each.")
+            }
+
             it("fails if no symbol sets are selected") {
                 GuiActionRunner.execute { componentSymbolSets.activeEntries = emptyList() }
 

--- a/src/test/kotlin/com/fwdekker/randomness/string/StringSettingsComponentTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/string/StringSettingsComponentTest.kt
@@ -147,7 +147,7 @@ object StringSettingsComponentTest : Spek({
                         symbols = "old symbols"
                     }
 
-                    GuiActionRunner.execute { frame.table("symbolSets").target().addRowSelectionInterval(0, 0)}
+                    GuiActionRunner.execute { frame.table("symbolSets").target().addRowSelectionInterval(0, 0) }
                     frame.button("symbolSetEdit").click()
 
                     val fixture = WindowFinder.findDialog(subDialogMatcher).using(frame.robot())

--- a/src/test/kotlin/com/fwdekker/randomness/string/StringSettingsComponentTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/string/StringSettingsComponentTest.kt
@@ -260,7 +260,7 @@ object StringSettingsComponentTest : Spek({
 
         describe("symbol sets") {
             it("fails if no symbol sets are selected") {
-                GuiActionRunner.execute { componentSymbolSets.setActiveEntries(emptyList()) }
+                GuiActionRunner.execute { componentSymbolSets.activeEntries = emptyList() }
 
                 val validationInfo = stringSettingsComponent.doValidate()
 
@@ -278,8 +278,8 @@ object StringSettingsComponentTest : Spek({
                 frame.spinner("maxLength").target().value = 803
                 frame.radioButton("enclosureBacktick").target().isSelected = true
                 frame.radioButton("capitalizationUpper").target().isSelected = true
-                componentSymbolSets.setEntries(listOf(SymbolSet.BRACKETS, SymbolSet.MINUS))
-                componentSymbolSets.setActiveEntries(listOf(SymbolSet.MINUS))
+                componentSymbolSets.entries = listOf(SymbolSet.BRACKETS, SymbolSet.MINUS)
+                componentSymbolSets.activeEntries = listOf(SymbolSet.MINUS)
             }
 
             stringSettingsComponent.saveSettings()
@@ -352,7 +352,7 @@ object StringSettingsComponentTest : Spek({
                     frame.spinner("maxLength").target().value = 102
                     frame.radioButton("enclosureSingle").target().isSelected = true
                     frame.radioButton("capitalizationLower").target().isSelected = true
-                    componentSymbolSets.setActiveEntries(newSymbolSets)
+                    componentSymbolSets.activeEntries = newSymbolSets
 
                     stringSettingsComponentConfigurable.reset()
                 }

--- a/src/test/kotlin/com/fwdekker/randomness/ui/JCheckBoxTableTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/ui/JCheckBoxTableTest.kt
@@ -16,20 +16,29 @@ import java.util.NoSuchElementException
  * Unit tests for [JCheckBoxTable].
  */
 object JCheckBoxTableTest : Spek({
+    val defaultColumns = listOf(JCheckBoxTable.Column(), JCheckBoxTable.Column("name"))
+
     lateinit var table: JCheckBoxTable<String>
 
 
     beforeEachTest {
         table = GuiActionRunner.execute<JCheckBoxTable<String>> {
-            JCheckBoxTable(
-                listOf(JCheckBoxTable.Column(null, true), JCheckBoxTable.Column(null, true)),
-                listToEntry = { it.joinToString(",") },
-                entryToList = { it.split(",") },
-                isEntryEditable = { true }
-            )
+            JCheckBoxTable(defaultColumns, { it.joinToString(",") }, { it.split(",") })
         }
     }
 
+
+    describe("entryCount") {
+        it("returns 0 for an empty list") {
+            assertThat(table.entryCount).isEqualTo(0)
+        }
+
+        it("returns 2 for a list with 2 elements") {
+            GuiActionRunner.execute { table.entries = listOf("mercy,supply", "wrong,light") }
+
+            assertThat(table.entryCount).isEqualTo(2)
+        }
+    }
 
     describe("getEntries") {
         it("returns nothing if no entries are added") {
@@ -39,96 +48,210 @@ object JCheckBoxTableTest : Spek({
 
     describe("addEntry") {
         it("adds a given entry") {
-            GuiActionRunner.execute { table.addEntry("manscape,bicycle") }
+            GuiActionRunner.execute { table.addEntry("bank,bicycle") }
 
-            assertThat(table.entries).containsExactly("manscape,bicycle")
+            assertThat(table.entries).containsExactly("bank,bicycle")
+        }
+
+        it("sets the activity of the new entry as desired") {
+            GuiActionRunner.execute {
+                table.addEntry("meantime,treasury", true)
+                table.addEntry("praise,edge", false)
+            }
+
+            assertThat(table.isActive("meantime,treasury")).isTrue()
+            assertThat(table.isActive("praise,edge")).isFalse()
+        }
+
+        it("splits the entry into separate columns") {
+            GuiActionRunner.execute { table.addEntry("memory,bicycle") }
+
+            assertThat(table.getValueAt(0, 1)).isEqualTo("memory")
+            assertThat(table.getValueAt(0, 2)).isEqualTo("bicycle")
         }
 
         it("adds two given entries") {
             GuiActionRunner.execute {
-                table.addEntry("osteomas,quart")
-                table.addEntry("imido,basic")
+                table.addEntry("discover,quart")
+                table.addEntry("prison,basic")
             }
 
-            assertThat(table.entries).containsExactly("osteomas,quart", "imido,basic")
+            assertThat(table.entries).containsExactly("discover,quart", "prison,basic")
         }
 
         it("does not add a given entry twice") {
+            GuiActionRunner.execute { table.addEntry("bloomed,dull") }
+
+            assertThatThrownBy { table.addEntry("bloomed,dull") }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessage("Cannot add duplicate entry.")
+        }
+    }
+
+    describe("setEntry") {
+        it("updates a given entry") {
+            GuiActionRunner.execute { table.entries = listOf("although,stocking", "governor,pay") }
+
+            GuiActionRunner.execute { table.setEntry(1, "violent,failure") }
+
+            assertThat(table.entries).containsExactly("although,stocking", "violent,failure")
+        }
+
+        it("updates a given entry to itself") {
+            GuiActionRunner.execute { table.entries = listOf("bribe,straight", "health,stuff") }
+
+            GuiActionRunner.execute { table.setEntry(1, "health,stuff") }
+
+            assertThat(table.entries).containsExactly("bribe,straight", "health,stuff")
+        }
+
+        it("does not set negative out-of-bounds indices") {
+            assertThatThrownBy { table.setEntry(-4, "splendid,lift") }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessage("Index out of bounds. rows=0, index=-4.")
+        }
+
+        it("does not set positive out-of-bounds indices") {
+            GuiActionRunner.execute { table.addEntry("misery,laugh") }
+
+            assertThatThrownBy { table.setEntry(1, "hat,bowl") }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessage("Index out of bounds. rows=1, index=1.")
+        }
+
+        it("does not cause duplicate entries") {
+            GuiActionRunner.execute { table.entries = listOf("whip,actor", "wine,sympathy") }
+
+            assertThatThrownBy { GuiActionRunner.execute { table.setEntry(1, "whip,actor") } }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessage("Cannot add duplicate entry.")
+        }
+
+        it("does not change activity if null is passed") {
             GuiActionRunner.execute {
-                table.addEntry("bloomed,dull")
-                table.addEntry("bloomed,dull")
+                table.entries = listOf("stretch,ready", "egg,return")
+                table.activeEntries = listOf("stretch,ready")
             }
 
-            assertThat(table.entries).containsExactly("bloomed,dull")
+            GuiActionRunner.execute { table.setEntry(0, "swear,loyal", null) }
+
+            assertThat(table.isActive("swear,loyal")).isTrue()
+        }
+
+        it("changes the entry's activity as desired") {
+            GuiActionRunner.execute {
+                table.entries = listOf("elastic,name", "shake,gradual")
+                table.activeEntries = listOf("shake,gradual")
+            }
+
+            GuiActionRunner.execute {
+                table.setEntry(0, "property,barber", false)
+                table.setEntry(1, "weekday,farm", true)
+            }
+
+            assertThat(table.isActive("property,barber")).isFalse()
+            assertThat(table.isActive("weekday,farm")).isTrue()
         }
     }
 
     describe("setEntries") {
         it("empties an empty list") {
-            GuiActionRunner.execute { table.setEntries(emptyList()) }
+            GuiActionRunner.execute { table.entries = emptyList() }
 
             assertThat(table.entries).isEmpty()
         }
 
         it("adds two entries to an empty list") {
-            GuiActionRunner.execute { table.setEntries(listOf("gladding,which", "flecky,arch")) }
+            GuiActionRunner.execute { table.entries = listOf("ripen,which", "luck,arch") }
 
-            assertThat(table.entries).containsExactly("gladding,which", "flecky,arch")
+            assertThat(table.entries).containsExactly("ripen,which", "luck,arch")
         }
 
         it("does not add duplicate entries to a list") {
-            GuiActionRunner.execute { table.setEntries(listOf("orrery,northern", "orrery,northern")) }
+            assertThatThrownBy { table.entries = listOf("soap,northern", "soap,northern") }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessage("Cannot add duplicate entry.")
+        }
 
-            assertThat(table.entries).containsExactly("orrery,northern")
+        it("successfully adds an entry that was in the list before") {
+            GuiActionRunner.execute {
+                table.addEntry("border,cake")
+                table.addEntry("protect,shore")
+            }
+
+            GuiActionRunner.execute { table.entries = listOf("border,cake") }
+
+            assertThat(table.entries).containsExactly("border,cake")
         }
 
         it("empties a non-empty list") {
-            GuiActionRunner.execute {
-                table.addEntry("prefeast,sock")
-                table.addEntry("strip,hurt")
-            }
+            GuiActionRunner.execute { table.entries = listOf("prefeast,sock", "strip,hurt") }
 
-            GuiActionRunner.execute { table.setEntries(emptyList()) }
+            GuiActionRunner.execute { table.entries = emptyList() }
 
             assertThat(table.entries).isEmpty()
         }
 
         it("replaces the entries in a non-empty list") {
-            GuiActionRunner.execute {
-                table.addEntry("pirates,scatter")
-                table.addEntry("underbit,country")
-                table.addEntry("flexured,shape")
-            }
+            GuiActionRunner.execute { table.entries = listOf("pirates,scatter", "underbit,country", "flexured,shape") }
 
-            GuiActionRunner.execute { table.setEntries(listOf("steevely,scatter", "qual,country", "wheaties,shape")) }
+            GuiActionRunner.execute { table.entries = listOf("shirt,scatter", "detail,country", "wheaties,shape") }
 
-            assertThat(table.entries).containsExactly("steevely,scatter", "qual,country", "wheaties,shape")
+            assertThat(table.entries).containsExactly("shirt,scatter", "detail,country", "wheaties,shape")
+        }
+    }
+
+    describe("hasEntry") {
+        it("returns false if the entry is not present") {
+            GuiActionRunner.execute { table.entries = listOf("remind,foot") }
+
+            assertThat(table.hasEntry("either,crime")).isFalse()
+        }
+
+        it("returns true if the entry is present") {
+            GuiActionRunner.execute { table.entries = listOf("thus,victory") }
+
+            assertThat(table.hasEntry("thus,victory")).isTrue()
+        }
+    }
+
+    describe("getEntry") {
+        it("returns the entry in the given row") {
+            GuiActionRunner.execute { table.entries = listOf("commerce,arch", "whom,square") }
+
+            assertThat(table.getEntry(0)).isEqualTo("commerce,arch")
+        }
+
+        it("does not return negative out-of-bounds entries") {
+            assertThatThrownBy { table.getEntry(-1) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessage("Index out of bounds. rows=0, index=-1.")
+        }
+
+        it("does not return positive out-of-bounds entries") {
+            GuiActionRunner.execute { table.addEntry("float,cousin") }
+
+            assertThatThrownBy { table.getEntry(1) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessage("Index out of bounds. rows=1, index=1.")
         }
     }
 
     describe("removeEntry") {
         it("removes the given entry") {
-            GuiActionRunner.execute {
-                table.addEntry("giftwrap,delicate")
-                table.addEntry("backbite,heaven")
-                table.addEntry("landwhin,patient")
-            }
+            GuiActionRunner.execute { table.entries = listOf("lessen,delicate", "backbite,heaven", "pump,patient") }
 
             GuiActionRunner.execute { table.removeEntry("backbite,heaven") }
 
-            assertThat(table.entries).containsExactly("giftwrap,delicate", "landwhin,patient")
+            assertThat(table.entries).containsExactly("lessen,delicate", "pump,patient")
         }
 
         it("throws an exception if the element to be removed cannot be found") {
-            GuiActionRunner.execute {
-                table.addEntry("tracheid,dear")
-                table.addEntry("cocomat,youth")
-                table.addEntry("videotex,clear")
-            }
+            GuiActionRunner.execute { table.entries = listOf("heighten,dear", "videotex,clear") }
 
-            assertThatThrownBy { table.removeEntry("unshowed,general") }
+            assertThatThrownBy { table.removeEntry("strict,general") }
                 .isInstanceOf(NoSuchElementException::class.java)
-                .hasMessage("No row with entry `unshowed,general` found.")
+                .hasMessage("No row with entry `strict,general` found.")
                 .hasNoCause()
         }
     }
@@ -141,10 +264,7 @@ object JCheckBoxTableTest : Spek({
         }
 
         it("clears a non-empty list") {
-            GuiActionRunner.execute {
-                table.addEntry("lathered,terrible")
-                table.addEntry("aquench,hold")
-            }
+            GuiActionRunner.execute { table.entries = listOf("lathered,terrible", "wonder,hold") }
 
             GuiActionRunner.execute { table.clear() }
 
@@ -152,20 +272,6 @@ object JCheckBoxTableTest : Spek({
         }
     }
 
-    describe("entryCount") {
-        it("counts 0 elements for an empty list") {
-            assertThat(table.entryCount).isEqualTo(0)
-        }
-
-        it("counts 2 elements for a list with 2 elements") {
-            GuiActionRunner.execute {
-                table.addEntry("musmon,supply")
-                table.addEntry("topepo,light")
-            }
-
-            assertThat(table.entryCount).isEqualTo(2)
-        }
-    }
 
     describe("activeEntries") {
         it("has no active entries in an empty list") {
@@ -173,89 +279,156 @@ object JCheckBoxTableTest : Spek({
         }
 
         it("has no active entries by default") {
-            GuiActionRunner.execute { table.setEntries(listOf("otxi,for", "chamorro,spin", "scarab,rank")) }
+            GuiActionRunner.execute { table.entries = listOf("proposal,for", "mouse,spin", "scarab,rank") }
 
             assertThat(table.activeEntries).isEmpty()
         }
 
-        it("can enable one entry") {
-            GuiActionRunner.execute { table.setEntries(listOf("disbury,another", "curet,minute", "sunhat,observe")) }
+        it("returns the currently-active entries") {
+            GuiActionRunner.execute { table.addEntry("widen,forest", true) }
 
-            GuiActionRunner.execute { table.setActiveEntries(listOf("curet,minute")) }
+            assertThat(table.activeEntries).containsExactly("widen,forest")
+        }
+    }
 
-            assertThat(table.activeEntries).containsExactly("curet,minute")
+    describe("isActive") {
+        it("returns true iff an element is active") {
+            GuiActionRunner.execute {
+                table.entries = listOf("upright,compete", "set,industry")
+                table.activeEntries = listOf("set,industry")
+            }
+
+            assertThat(table.isActive("upright,compete")).isFalse()
+            assertThat(table.isActive("set,industry")).isTrue()
+        }
+
+        it("throws an exception if an element is not in the list") {
+            assertThatThrownBy { table.isActive("space,pardon") }
+                .isInstanceOf(NoSuchElementException::class.java)
+                .hasMessage("No row with entry `space,pardon` found.")
+                .hasNoCause()
+        }
+    }
+
+    describe("setActive") {
+        it("updates the activity of the given entry") {
+            GuiActionRunner.execute { table.entries = listOf("wax,fellow") }
+
+            GuiActionRunner.execute { table.setActive("wax,fellow", true) }
+
+            assertThat(table.isActive("wax,fellow")).isTrue()
+        }
+
+        it("throws an exception if the entry does not exist") {
+            assertThatThrownBy { GuiActionRunner.execute { table.setActive("pardon,crop", false) } }
+                .isInstanceOf(NoSuchElementException::class.java)
+                .hasMessage("No row with entry `pardon,crop` found.")
+        }
+    }
+
+    describe("setActiveEntries") {
+        it("can enable a given entry") {
+            GuiActionRunner.execute { table.entries = listOf("toe,another", "cause,minute", "sunhat,observe") }
+
+            GuiActionRunner.execute { table.activeEntries = listOf("cause,minute") }
+
+            assertThat(table.activeEntries).containsExactly("cause,minute")
         }
 
         it("can enable all entries") {
-            val entries = listOf("big,chance", "coumaric,head", "hooray,sit")
-            GuiActionRunner.execute { table.setEntries(entries) }
+            val entries = listOf("big,chance", "cruel,head", "hooray,sit")
+            GuiActionRunner.execute { table.entries = entries }
 
-            GuiActionRunner.execute { table.setActiveEntries(entries) }
+            GuiActionRunner.execute { table.activeEntries = entries }
 
             assertThat(table.activeEntries).containsExactlyElementsOf(entries)
         }
 
         it("ignores when a non-existing element is enabled") {
             val entries = listOf("forte,dine", "blarneys,lead")
-            GuiActionRunner.execute { table.setEntries(entries) }
+            GuiActionRunner.execute { table.entries = entries }
 
-            GuiActionRunner.execute { table.setActiveEntries(listOf("forte,dine", "pittings,being")) }
+            GuiActionRunner.execute { table.activeEntries = listOf("forte,dine", "lamp,being") }
 
             assertThat(table.activeEntries).containsExactly("forte,dine")
         }
 
-        it("unchecks previously checked entries") {
+        it("unchecks previously-checked entries") {
             val entries = listOf("rot,victory", "possible,umbrella", "harbor,heavenly")
-            GuiActionRunner.execute { table.setEntries(entries) }
-            GuiActionRunner.execute { table.setActiveEntries(entries) }
+            GuiActionRunner.execute { table.entries = entries }
+            GuiActionRunner.execute { table.activeEntries = entries }
 
-            GuiActionRunner.execute { table.setActiveEntries(listOf("rot,victory", "harbor,heavenly")) }
+            GuiActionRunner.execute { table.activeEntries = listOf("rot,victory", "harbor,heavenly") }
 
             assertThat(table.activeEntries).containsExactly("rot,victory", "harbor,heavenly")
         }
     }
 
-    describe("isActive") {
-        it("returns true iff an element is active") {
-            GuiActionRunner.execute { table.setEntries(listOf("upright,compete", "hasten,chicken", "set,industry")) }
 
-            GuiActionRunner.execute { table.setActive("upright,compete", true) }
-
-            assertThat(table.isActive("upright,compete")).isTrue()
-            assertThat(table.isActive("hasten,chicken")).isFalse()
-            assertThat(table.isActive("set,industry")).isFalse()
-        }
-
-        it("throws an exception if an element is not in the list") {
-            assertThatThrownBy { table.isActive("nanism,pardon") }
-                .isInstanceOf(NoSuchElementException::class.java)
-                .hasMessage("No row with entry `nanism,pardon` found.")
-                .hasNoCause()
-        }
-    }
-
-    describe("getHighlightedEntry") {
-        it("returns null when no entry is highlighted") {
+    describe("getHighlightedEntries") {
+        it("returns an empty list when no entries are highlighted") {
             assertThat(table.highlightedEntries).isEmpty()
         }
 
-        it("returns the single highlighted entry") {
+        it("returns only the highlighted entries") {
             GuiActionRunner.execute {
-                table.setEntries(listOf("bahay,leave", "woodyard,oil", "hussies,coast"))
-                table.addRowSelectionInterval(0, 0)
-            }
-
-            assertThat(table.highlightedEntries).containsExactly("bahay,leave")
-        }
-
-        it("returns all highlighted entries") {
-            GuiActionRunner.execute {
-                table.setEntries(listOf("shutoffs,terrible", "dentine,glass", "scutel,afford"))
+                table.entries = listOf("shutoffs,terrible", "pound,glass", "size,afford")
                 table.addRowSelectionInterval(0, 0)
                 table.addRowSelectionInterval(2, 2)
             }
 
-            assertThat(table.highlightedEntries).containsExactly("shutoffs,terrible", "scutel,afford")
+            assertThat(table.highlightedEntries).containsExactly("shutoffs,terrible", "size,afford")
+        }
+    }
+
+    describe("setHighlightedEntries") {
+        it("unhighlights the current entries") {
+            GuiActionRunner.execute {
+                table.entries = listOf("waste,remain", "clever,moment")
+                table.addRowSelectionInterval(0, 1)
+            }
+
+            GuiActionRunner.execute { table.highlightedEntries = emptyList() }
+
+            assertThat(table.highlightedEntries).isEmpty()
+        }
+
+        it("moves the highlight to a different entry") {
+            GuiActionRunner.execute {
+                table.entries = listOf("copper,bury", "country,study")
+                table.addRowSelectionInterval(0, 0)
+            }
+
+            GuiActionRunner.execute { table.highlightedEntries = listOf("country,study") }
+
+            assertThat(table.highlightedEntries).containsExactly("country,study")
+        }
+    }
+
+
+    describe("getColumnName") {
+        it("returns the checkbox column's name") {
+            assertThat(table.getColumnName(0)).isEqualTo("")
+        }
+
+        it("returns null if the column's name is null") {
+            assertThat(table.getColumnName(1)).isNull()
+        }
+
+        it("returns the column's name if it is not null") {
+            assertThat(table.getColumnName(2)).isEqualTo("name")
+        }
+
+        it("throws an exception for a negative out-of-bounds column") {
+            assertThatThrownBy { table.getColumnName(-1) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessage("Index out of bounds. columns=3, index=-1.")
+        }
+
+        it("throws an exception for a positive out-of-bounds column") {
+            assertThatThrownBy { table.getColumnName(3) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessage("Index out of bounds. columns=3, index=3.")
         }
     }
 
@@ -266,37 +439,54 @@ object JCheckBoxTableTest : Spek({
             assertThat(table.getColumnClass(1)).isEqualTo(java.lang.String::class.java)
         }
 
-        it("throws an exception if a negative column index is requested") {
+        it("throws an exception if a negative out-of-bounds column is requested") {
             assertThatThrownBy { table.getColumnClass(-1) }
-                .isInstanceOf(IndexOutOfBoundsException::class.java)
-                .hasMessage("columns=3, index=-1")
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessage("Index out of bounds. columns=3, index=-1.")
                 .hasNoCause()
         }
 
-        it("throws an exception if column index that is too high is requested") {
+        it("throws an exception if a positive out-of-bounds column is requested") {
             assertThatThrownBy { table.getColumnClass(3) }
-                .isInstanceOf(IndexOutOfBoundsException::class.java)
-                .hasMessage("columns=3, index=3")
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessage("Index out of bounds. columns=3, index=3.")
                 .hasNoCause()
         }
     }
 
     describe("isCellEditable") {
-        // TODO Update these tests for configurable editability
-        xit("returns true iff the column is 0") {
-            GuiActionRunner.execute {
-                table.addEntry("threaten,future")
-                table.addEntry("pleasure,frequent")
-                table.addEntry("gate,name")
+        beforeEachTest {
+            table = GuiActionRunner.execute<JCheckBoxTable<String>> {
+                JCheckBoxTable(
+                    listOf(JCheckBoxTable.Column(null, true), JCheckBoxTable.Column(null, false)),
+                    { it.joinToString(",") },
+                    { it.split(",") },
+                    { it.startsWith("_") }
+                )
             }
 
-            assertThat(table.isCellEditable(0, 0)).isTrue()
-            assertThat(table.isCellEditable(1, 0)).isTrue()
-            assertThat(table.isCellEditable(2, 0)).isTrue()
+            GuiActionRunner.execute { table.entries = listOf("forth,thief", "_cheese,mail") }
+        }
 
-            assertThat(table.isCellEditable(0, 2)).isFalse()
-            assertThat(table.isCellEditable(1, 1)).isFalse()
-            assertThat(table.isCellEditable(2, 2)).isFalse()
+
+        it("return true for the checkbox column, even if the entry is not editable") {
+            assertThat(table.isCellEditable(0, 0)).isTrue()
+        }
+
+        it("returns true for the checkbox column when the entry is editable") {
+            assertThat(table.isCellEditable(1, 0)).isTrue()
+        }
+
+        it("returns false if the column is not editable even if the entry is") {
+            assertThat(table.isCellEditable(1, 2)).isFalse()
+        }
+
+        it("returns false if the entry is not editable even if the column is") {
+            assertThat(table.isCellEditable(0, 1)).isFalse()
+        }
+
+        it("returns true if both the column and the entry are editable") {
+            assertThat(table.isCellEditable(1, 1)).isTrue()
         }
     }
 })

--- a/src/test/kotlin/com/fwdekker/randomness/ui/JCheckBoxTableTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/ui/JCheckBoxTableTest.kt
@@ -318,33 +318,23 @@ object JDecoratedCheckBoxTablePanelTest : Spek({
     }
 
 
-    fun createTablePanel(query: () -> JDecoratedCheckBoxTablePanel<String>) = GuiActionRunner.execute(query)
+    fun createTable(query: () -> JCheckBoxTable<String>) = GuiActionRunner.execute(query)
+
+    fun createPanel(query: () -> JDecoratedCheckBoxTablePanel<String>) = GuiActionRunner.execute(query)
 
 
     describe("appearance") {
-        it("assigns the given name to the inner list") {
-            val table = createTablePanel {
-                JDecoratedCheckBoxTablePanel(JCheckBoxTable(
-                    columnCount = 2,
-                    listToEntry = { it.joinToString(",") },
-                    entryToList = { it.split(",") },
-                    name = "thirst"
-                ))
-            }
-
-            assertThat(table.table.name).isEqualTo("thirst")
-        }
-
         it("does not add any buttons by default") {
-            val table = createTablePanel {
-                JDecoratedCheckBoxTablePanel(JCheckBoxTable(
+            val table = createTable {
+                JCheckBoxTable(
                     columnCount = 2,
                     listToEntry = { it.joinToString(",") },
                     entryToList = { it.split(",") }
-                ))
+                )
             }
+            val panel = createPanel { JDecoratedCheckBoxTablePanel(table) }
 
-            assertThat(table.actionsPanel.actionMap.size()).isZero()
+            assertThat(panel.actionsPanel.actionMap.size()).isZero()
         }
     }
 
@@ -355,24 +345,22 @@ object JDecoratedCheckBoxTablePanelTest : Spek({
 
         it("executes the add function if the add button is clicked") {
             var addedEntries: List<String> = emptyList()
-            val table = createTablePanel {
-                JDecoratedCheckBoxTablePanel(
-                    JCheckBoxTable(
-                        columnCount = 2,
-                        listToEntry = { it.joinToString(",") },
-                        entryToList = { it.split(",") }
-                    ),
-                    addAction = { addedEntries = it }
+            val table = createTable {
+                JCheckBoxTable(
+                    columnCount = 2,
+                    listToEntry = { it.joinToString(",") },
+                    entryToList = { it.split(",") }
                 )
             }
+            val panel = createPanel { JDecoratedCheckBoxTablePanel(table, addAction = { addedEntries = it }) }
             GuiActionRunner.execute {
-                table.table.addEntry("debt,promise")
-                table.table.addEntry("common,gallon")
+                table.addEntry("debt,promise")
+                table.addEntry("common,gallon")
             }
 
             GuiActionRunner.execute {
-                table.table.addRowSelectionInterval(0, 1)
-                table.pressButton(CommonActionsPanel.Buttons.ADD)
+                table.addRowSelectionInterval(0, 1)
+                panel.pressButton(CommonActionsPanel.Buttons.ADD)
             }
 
             assertThat(addedEntries).containsExactly("debt,promise", "common,gallon")
@@ -380,24 +368,22 @@ object JDecoratedCheckBoxTablePanelTest : Spek({
 
         it("executes the edit function if the edit button is clicked") {
             var editedEntries: List<String> = emptyList()
-            val table = createTablePanel {
-                JDecoratedCheckBoxTablePanel(
-                    JCheckBoxTable(
-                        columnCount = 2,
-                        listToEntry = { it.joinToString(",") },
-                        entryToList = { it.split(",") }
-                    ),
-                    editAction = { editedEntries = it }
+            val table = createTable {
+                JCheckBoxTable(
+                    columnCount = 2,
+                    listToEntry = { it.joinToString(",") },
+                    entryToList = { it.split(",") }
                 )
             }
+            val panel = createPanel { JDecoratedCheckBoxTablePanel(table, editAction = { editedEntries = it }) }
             GuiActionRunner.execute {
-                table.table.addEntry("collar,lend")
-                table.table.addEntry("neck,language")
+                table.addEntry("collar,lend")
+                table.addEntry("neck,language")
             }
 
             GuiActionRunner.execute {
-                table.table.addRowSelectionInterval(0, 1)
-                table.pressButton(CommonActionsPanel.Buttons.EDIT)
+                table.addRowSelectionInterval(0, 1)
+                panel.pressButton(CommonActionsPanel.Buttons.EDIT)
             }
 
             assertThat(editedEntries).containsExactly("collar,lend", "neck,language")
@@ -405,21 +391,19 @@ object JDecoratedCheckBoxTablePanelTest : Spek({
 
         it("does nothing if the edit button is clicked but no entry is highlighted") {
             var editedEntries: List<String> = emptyList()
-            val table = createTablePanel {
-                JDecoratedCheckBoxTablePanel(
-                    JCheckBoxTable(
-                        columnCount = 2,
-                        listToEntry = { it.joinToString(",") },
-                        entryToList = { it.split(",") }
-                    ),
-                    editAction = { editedEntries = it }
+            val table = createTable {
+                JCheckBoxTable(
+                    columnCount = 2,
+                    listToEntry = { it.joinToString(",") },
+                    entryToList = { it.split(",") }
                 )
             }
-            GuiActionRunner.execute { table.table.addEntry("water,least") }
+            val panel = createPanel { JDecoratedCheckBoxTablePanel(table, editAction = { editedEntries = it }) }
+            GuiActionRunner.execute { table.addEntry("water,least") }
 
             GuiActionRunner.execute {
-                table.table.clearSelection()
-                table.pressButton(CommonActionsPanel.Buttons.EDIT)
+                table.clearSelection()
+                panel.pressButton(CommonActionsPanel.Buttons.EDIT)
             }
 
             assertThat(editedEntries).isEmpty()
@@ -427,21 +411,19 @@ object JDecoratedCheckBoxTablePanelTest : Spek({
 
         it("executes the remove function if the remove button is clicked") {
             var removedEntries: List<String> = emptyList()
-            val table = createTablePanel {
-                JDecoratedCheckBoxTablePanel(
-                    JCheckBoxTable(
-                        columnCount = 2,
-                        listToEntry = { it.joinToString(",") },
-                        entryToList = { it.split(",") }
-                    ),
-                    removeAction = { removedEntries = it }
+            val table = createTable {
+                JCheckBoxTable(
+                    columnCount = 2,
+                    listToEntry = { it.joinToString(",") },
+                    entryToList = { it.split(",") }
                 )
             }
-            GuiActionRunner.execute { table.table.addEntry("dip,duck") }
+            val panel = createPanel { JDecoratedCheckBoxTablePanel(table, removeAction = { removedEntries = it }) }
+            GuiActionRunner.execute { table.addEntry("dip,duck") }
 
             GuiActionRunner.execute {
-                table.table.addRowSelectionInterval(0, 0)
-                table.pressButton(CommonActionsPanel.Buttons.REMOVE)
+                table.addRowSelectionInterval(0, 0)
+                panel.pressButton(CommonActionsPanel.Buttons.REMOVE)
             }
 
             assertThat(removedEntries).containsExactly("dip,duck")
@@ -449,21 +431,19 @@ object JDecoratedCheckBoxTablePanelTest : Spek({
 
         it("does nothing if the remove button is clicked but no entry is highlighted") {
             var removedEntries: List<String> = emptyList()
-            val table = createTablePanel {
-                JDecoratedCheckBoxTablePanel(
-                    JCheckBoxTable(
-                        columnCount = 2,
-                        listToEntry = { it.joinToString(",") },
-                        entryToList = { it.split(",") }
-                    ),
-                    removeAction = { removedEntries = it }
+            val table = createTable {
+                JCheckBoxTable(
+                    columnCount = 2,
+                    listToEntry = { it.joinToString(",") },
+                    entryToList = { it.split(",") }
                 )
             }
-            GuiActionRunner.execute { table.table.addEntry("tax,applause") }
+            val panel = createPanel { JDecoratedCheckBoxTablePanel(table, removeAction = { removedEntries = it }) }
+            GuiActionRunner.execute { table.addEntry("tax,applause") }
 
             GuiActionRunner.execute {
-                table.table.clearSelection()
-                table.pressButton(CommonActionsPanel.Buttons.REMOVE)
+                table.clearSelection()
+                panel.pressButton(CommonActionsPanel.Buttons.REMOVE)
             }
 
             assertThat(removedEntries).isEmpty()
@@ -472,34 +452,29 @@ object JDecoratedCheckBoxTablePanelTest : Spek({
 
     describe("getting buttons") {
         it("returns null if the button was not added") {
-            val table = createTablePanel {
-                JDecoratedCheckBoxTablePanel(
-                    JCheckBoxTable(
-                        columnCount = 2,
-                        listToEntry = { it.joinToString(",") },
-                        entryToList = { it.split(",") }
-                    ),
-                    editAction = {}
+            val table = createTable {
+                JCheckBoxTable(
+                    columnCount = 2,
+                    listToEntry = { it.joinToString(",") },
+                    entryToList = { it.split(",") }
                 )
             }
+            val panel = createPanel { JDecoratedCheckBoxTablePanel(table, editAction = {}) }
 
-            assertThat(table.getButton(CommonActionsPanel.Buttons.ADD)).isNull()
+            assertThat(panel.getButton(CommonActionsPanel.Buttons.ADD)).isNull()
         }
 
         it("returns the appropriate button") {
-            val table = createTablePanel {
-                JDecoratedCheckBoxTablePanel(
-                    JCheckBoxTable(
-                        columnCount = 2,
-                        listToEntry = { it.joinToString(",") },
-                        entryToList = { it.split(",") }
-                    ),
-                    addAction = {},
-                    removeAction = {}
+            val table = createTable {
+                JCheckBoxTable(
+                    columnCount = 2,
+                    listToEntry = { it.joinToString(",") },
+                    entryToList = { it.split(",") }
                 )
             }
+            val panel = createPanel { JDecoratedCheckBoxTablePanel(table, addAction = {}, removeAction = {}) }
 
-            assertThat(table.getButton(CommonActionsPanel.Buttons.ADD)).isNotNull()
+            assertThat(panel.getButton(CommonActionsPanel.Buttons.ADD)).isNotNull()
         }
     }
 })

--- a/src/test/kotlin/com/fwdekker/randomness/ui/JCheckBoxTableTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/ui/JCheckBoxTableTest.kt
@@ -22,7 +22,7 @@ object JCheckBoxTableTest : Spek({
     beforeEachTest {
         table = GuiActionRunner.execute<JCheckBoxTable<String>> {
             JCheckBoxTable(
-                columnCount = 2,
+                listOf(JCheckBoxTable.Column(null, true), JCheckBoxTable.Column(null, true)),
                 listToEntry = { it.joinToString(",") },
                 entryToList = { it.split(",") },
                 isEntryEditable = { true }
@@ -219,7 +219,7 @@ object JCheckBoxTableTest : Spek({
         it("returns true iff an element is active") {
             GuiActionRunner.execute { table.setEntries(listOf("upright,compete", "hasten,chicken", "set,industry")) }
 
-            GuiActionRunner.execute { table.setEntryActivity("upright,compete", true) }
+            GuiActionRunner.execute { table.setActive("upright,compete", true) }
 
             assertThat(table.isActive("upright,compete")).isTrue()
             assertThat(table.isActive("hasten,chicken")).isFalse()
@@ -268,21 +268,22 @@ object JCheckBoxTableTest : Spek({
 
         it("throws an exception if a negative column index is requested") {
             assertThatThrownBy { table.getColumnClass(-1) }
-                .isInstanceOf(IllegalArgumentException::class.java)
-                .hasMessage("JEditableList has only two columns.")
+                .isInstanceOf(IndexOutOfBoundsException::class.java)
+                .hasMessage("columns=3, index=-1")
                 .hasNoCause()
         }
 
         it("throws an exception if column index that is too high is requested") {
             assertThatThrownBy { table.getColumnClass(3) }
-                .isInstanceOf(IllegalArgumentException::class.java)
-                .hasMessage("JEditableList has only two columns.")
+                .isInstanceOf(IndexOutOfBoundsException::class.java)
+                .hasMessage("columns=3, index=3")
                 .hasNoCause()
         }
     }
 
     describe("isCellEditable") {
-        it("returns true iff the column is 0") {
+        // TODO Update these tests for configurable editability
+        xit("returns true iff the column is 0") {
             GuiActionRunner.execute {
                 table.addEntry("threaten,future")
                 table.addEntry("pleasure,frequent")
@@ -293,8 +294,8 @@ object JCheckBoxTableTest : Spek({
             assertThat(table.isCellEditable(1, 0)).isTrue()
             assertThat(table.isCellEditable(2, 0)).isTrue()
 
-            assertThat(table.isCellEditable(0, 5)).isFalse()
-            assertThat(table.isCellEditable(1, 10)).isFalse()
+            assertThat(table.isCellEditable(0, 2)).isFalse()
+            assertThat(table.isCellEditable(1, 1)).isFalse()
             assertThat(table.isCellEditable(2, 2)).isFalse()
         }
     }
@@ -327,7 +328,7 @@ object JDecoratedCheckBoxTablePanelTest : Spek({
         it("does not add any buttons by default") {
             val table = createTable {
                 JCheckBoxTable(
-                    columnCount = 2,
+                    listOf(JCheckBoxTable.Column(null, true), JCheckBoxTable.Column(null, true)),
                     listToEntry = { it.joinToString(",") },
                     entryToList = { it.split(",") }
                 )
@@ -347,7 +348,7 @@ object JDecoratedCheckBoxTablePanelTest : Spek({
             var addedEntries: List<String> = emptyList()
             val table = createTable {
                 JCheckBoxTable(
-                    columnCount = 2,
+                    listOf(JCheckBoxTable.Column(null, true), JCheckBoxTable.Column(null, true)),
                     listToEntry = { it.joinToString(",") },
                     entryToList = { it.split(",") }
                 )
@@ -370,7 +371,7 @@ object JDecoratedCheckBoxTablePanelTest : Spek({
             var editedEntries: List<String> = emptyList()
             val table = createTable {
                 JCheckBoxTable(
-                    columnCount = 2,
+                    listOf(JCheckBoxTable.Column(null, true), JCheckBoxTable.Column(null, true)),
                     listToEntry = { it.joinToString(",") },
                     entryToList = { it.split(",") }
                 )
@@ -393,7 +394,7 @@ object JDecoratedCheckBoxTablePanelTest : Spek({
             var editedEntries: List<String> = emptyList()
             val table = createTable {
                 JCheckBoxTable(
-                    columnCount = 2,
+                    listOf(JCheckBoxTable.Column(null, true), JCheckBoxTable.Column(null, true)),
                     listToEntry = { it.joinToString(",") },
                     entryToList = { it.split(",") }
                 )
@@ -413,7 +414,7 @@ object JDecoratedCheckBoxTablePanelTest : Spek({
             var removedEntries: List<String> = emptyList()
             val table = createTable {
                 JCheckBoxTable(
-                    columnCount = 2,
+                    listOf(JCheckBoxTable.Column(null, true), JCheckBoxTable.Column(null, true)),
                     listToEntry = { it.joinToString(",") },
                     entryToList = { it.split(",") }
                 )
@@ -433,7 +434,7 @@ object JDecoratedCheckBoxTablePanelTest : Spek({
             var removedEntries: List<String> = emptyList()
             val table = createTable {
                 JCheckBoxTable(
-                    columnCount = 2,
+                    listOf(JCheckBoxTable.Column(null, true), JCheckBoxTable.Column(null, true)),
                     listToEntry = { it.joinToString(",") },
                     entryToList = { it.split(",") }
                 )
@@ -454,7 +455,7 @@ object JDecoratedCheckBoxTablePanelTest : Spek({
         it("returns null if the button was not added") {
             val table = createTable {
                 JCheckBoxTable(
-                    columnCount = 2,
+                    listOf(JCheckBoxTable.Column(null, true), JCheckBoxTable.Column(null, true)),
                     listToEntry = { it.joinToString(",") },
                     entryToList = { it.split(",") }
                 )
@@ -467,7 +468,7 @@ object JDecoratedCheckBoxTablePanelTest : Spek({
         it("returns the appropriate button") {
             val table = createTable {
                 JCheckBoxTable(
-                    columnCount = 2,
+                    listOf(JCheckBoxTable.Column(null, true), JCheckBoxTable.Column(null, true)),
                     listToEntry = { it.joinToString(",") },
                     entryToList = { it.split(",") }
                 )

--- a/src/test/kotlin/com/fwdekker/randomness/ui/JCheckBoxTableTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/ui/JCheckBoxTableTest.kt
@@ -82,7 +82,7 @@ object JCheckBoxTableTest : Spek({
         it("does not add a given entry twice") {
             GuiActionRunner.execute { table.addEntry("bloomed,dull") }
 
-            assertThatThrownBy { table.addEntry("bloomed,dull") }
+            assertThatThrownBy { GuiActionRunner.execute { table.addEntry("bloomed,dull") } }
                 .isInstanceOf(IllegalArgumentException::class.java)
                 .hasMessage("Cannot add duplicate entry.")
         }
@@ -106,13 +106,13 @@ object JCheckBoxTableTest : Spek({
         }
 
         it("does not set negative out-of-bounds indices") {
-            assertThatThrownBy { table.setEntry(-4, "splendid,lift") }
+            assertThatThrownBy { GuiActionRunner.execute { table.setEntry(-4, "splendid,lift") } }
                 .isInstanceOf(IllegalArgumentException::class.java)
                 .hasMessage("Index out of bounds. rows=0, index=-4.")
         }
 
         it("does not set positive out-of-bounds indices") {
-            GuiActionRunner.execute { table.addEntry("misery,laugh") }
+            GuiActionRunner.execute { GuiActionRunner.execute { table.addEntry("misery,laugh") } }
 
             assertThatThrownBy { table.setEntry(1, "hat,bowl") }
                 .isInstanceOf(IllegalArgumentException::class.java)
@@ -120,7 +120,7 @@ object JCheckBoxTableTest : Spek({
         }
 
         it("does not cause duplicate entries") {
-            GuiActionRunner.execute { table.entries = listOf("whip,actor", "wine,sympathy") }
+            GuiActionRunner.execute { GuiActionRunner.execute { table.entries = listOf("whip,actor", "wine,advise") } }
 
             assertThatThrownBy { GuiActionRunner.execute { table.setEntry(1, "whip,actor") } }
                 .isInstanceOf(IllegalArgumentException::class.java)
@@ -133,7 +133,7 @@ object JCheckBoxTableTest : Spek({
                 table.activeEntries = listOf("stretch,ready")
             }
 
-            GuiActionRunner.execute { table.setEntry(0, "swear,loyal", null) }
+            GuiActionRunner.execute { GuiActionRunner.execute { table.setEntry(0, "swear,loyal", null) } }
 
             assertThat(table.isActive("swear,loyal")).isTrue()
         }
@@ -168,7 +168,7 @@ object JCheckBoxTableTest : Spek({
         }
 
         it("does not add duplicate entries to a list") {
-            assertThatThrownBy { table.entries = listOf("soap,northern", "soap,northern") }
+            assertThatThrownBy { GuiActionRunner.execute { table.entries = listOf("soap,northern", "soap,northern") } }
                 .isInstanceOf(IllegalArgumentException::class.java)
                 .hasMessage("Cannot add duplicate entry.")
         }
@@ -249,7 +249,7 @@ object JCheckBoxTableTest : Spek({
         it("throws an exception if the element to be removed cannot be found") {
             GuiActionRunner.execute { table.entries = listOf("heighten,dear", "videotex,clear") }
 
-            assertThatThrownBy { table.removeEntry("strict,general") }
+            assertThatThrownBy { GuiActionRunner.execute { table.removeEntry("strict,general") } }
                 .isInstanceOf(NoSuchElementException::class.java)
                 .hasMessage("No row with entry `strict,general` found.")
                 .hasNoCause()
@@ -345,8 +345,7 @@ object JCheckBoxTableTest : Spek({
         }
 
         it("ignores when a non-existing element is enabled") {
-            val entries = listOf("forte,dine", "blarneys,lead")
-            GuiActionRunner.execute { table.entries = entries }
+            GuiActionRunner.execute { table.entries = listOf("forte,dine", "blarneys,lead") }
 
             GuiActionRunner.execute { table.activeEntries = listOf("forte,dine", "lamp,being") }
 
@@ -354,9 +353,10 @@ object JCheckBoxTableTest : Spek({
         }
 
         it("unchecks previously-checked entries") {
-            val entries = listOf("rot,victory", "possible,umbrella", "harbor,heavenly")
-            GuiActionRunner.execute { table.entries = entries }
-            GuiActionRunner.execute { table.activeEntries = entries }
+            GuiActionRunner.execute {
+                table.entries = listOf("rot,victory", "possible,umbrella", "harbor,heavenly")
+                table.activeEntries = table.entries
+            }
 
             GuiActionRunner.execute { table.activeEntries = listOf("rot,victory", "harbor,heavenly") }
 

--- a/src/test/kotlin/com/fwdekker/randomness/word/WordSettingsComponentTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/word/WordSettingsComponentTest.kt
@@ -239,8 +239,8 @@ object WordSettingsComponentTest : Spek({
                     fail("Failed to delete file as part of test.")
 
                 GuiActionRunner.execute {
-                    dictionaries.addEntry(dictionary)
-                    dictionaries.setActiveEntries(listOf<Dictionary>(dictionary))
+                    dictionaries.entries = listOf(dictionary)
+                    dictionaries.activeEntries = listOf(dictionary)
                 }
 
                 val validationInfo = wordSettingsComponent.doValidate()


### PR DESCRIPTION
* Removes the `name` constructor parameter from `JCheckBoxTable`.
* Adds `Column` objects to configure options per column in `JCheckBoxTable`.
* Adds tests for `JCheckBoxTable` and `StringSettingsComponent`.
