### PR TITLE
Fix #167

### DIFF
--- a/src/main/java/com/fwdekker/randomness/string/StringSettingsComponent.java
+++ b/src/main/java/com/fwdekker/randomness/string/StringSettingsComponent.java
@@ -32,6 +32,7 @@ public final class StringSettingsComponent extends SettingsComponent<StringSetti
     private JIntSpinner maxLength;
     private ButtonGroup enclosureGroup;
     private ButtonGroup capitalizationGroup;
+    @SuppressWarnings("unused") // Used by GUI builder
     private JDecoratedCheckBoxTablePanel<SymbolSet> symbolSetPanel;
     private JCheckBoxTable<SymbolSet> symbolSetTable;
 
@@ -72,8 +73,8 @@ public final class StringSettingsComponent extends SettingsComponent<StringSetti
 
         symbolSetTable = new JCheckBoxTable<>(
             Arrays.asList(
-                new JCheckBoxTable.Column("Name", true),
-                new JCheckBoxTable.Column("Symbols", true)
+                new JCheckBoxTable.Column("Name", true, null),
+                new JCheckBoxTable.Column("Symbols", true, null)
             ),
             it -> new SymbolSet(it.get(0), it.get(1)),
             it -> Arrays.asList(it.getName(), it.getSymbols()),

--- a/src/test/kotlin/com/fwdekker/randomness/ui/JCheckBoxTableTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/ui/JCheckBoxTableTest.kt
@@ -11,6 +11,8 @@ import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
 import java.util.NoSuchElementException
+import javax.swing.DefaultCellEditor
+import javax.swing.table.TableCellEditor
 
 
 /**
@@ -488,6 +490,38 @@ object JCheckBoxTableTest : Spek({
 
         it("returns true if both the column and the entry are editable") {
             assertThat(table.isCellEditable(1, 1)).isTrue()
+        }
+    }
+
+    describe("getCellEditor") {
+        lateinit var customEditor: TableCellEditor
+
+        beforeEachTest {
+            customEditor = mock {}
+            table = GuiActionRunner.execute<JCheckBoxTable<String>> {
+                JCheckBoxTable(
+                    listOf(JCheckBoxTable.Column(cellEditor = null), JCheckBoxTable.Column(cellEditor = customEditor)),
+                    { it.joinToString(",") },
+                    { it.split(",") }
+                )
+            }
+        }
+
+
+        fun getCellEditor(row: Int, col: Int) =
+            GuiActionRunner.execute<TableCellEditor> { table.getCellEditor(row, col) }
+
+
+        it("returns a default editor for the checkbox column") {
+            assertThat(getCellEditor(0, 0)).isInstanceOf(DefaultCellEditor::class.java)
+        }
+
+        it("returns a default editor for a column with a `null` editor") {
+            assertThat(getCellEditor(0, 1)).isInstanceOf(DefaultCellEditor::class.java)
+        }
+
+        it("returns the custom editor for a column with a custom editor") {
+            assertThat(getCellEditor(0, 2)).isEqualTo(customEditor)
         }
     }
 })


### PR DESCRIPTION
Fixes #167.

* Adds the option to add a custom `TableCellEditor` to a `Column` in `JCheckBoxTable`.
* Uses IntelliJ's `LocalPathCellEditor` to edit paths with.
* Moves validation from the `addDictionaries` method to the `doValidate` method.
* Validates all dictionaries instead of only active dictionaries.
* Fixes an issue where an exception is thrown if a row that is being edited is removed.