### PR TITLE
Guarantee entry order

### DIFF
--- a/src/main/java/com/fwdekker/randomness/string/StringSettingsComponent.java
+++ b/src/main/java/com/fwdekker/randomness/string/StringSettingsComponent.java
@@ -19,6 +19,7 @@ import javax.swing.JPanel;
  *
  * @see StringSettings
  * @see StringSettingsAction
+ * @see SymbolSetTable
  */
 public final class StringSettingsComponent extends SettingsComponent<StringSettings> {
     private JPanel contentPane;

--- a/src/main/java/com/fwdekker/randomness/string/StringSettingsComponent.java
+++ b/src/main/java/com/fwdekker/randomness/string/StringSettingsComponent.java
@@ -100,6 +100,11 @@ public final class StringSettingsComponent extends SettingsComponent<StringSetti
     }
 
     @Override
+    public boolean isModified(final @NotNull StringSettings settings) {
+        return symbolSetTable.getData().size() != settings.getSymbolSets().size();
+    }
+
+    @Override
     @Nullable
     public ValidationInfo doValidate() {
         if (symbolSetTable.getData().stream().anyMatch(it -> it.getName().isEmpty()))

--- a/src/main/java/com/fwdekker/randomness/word/WordSettingsComponent.java
+++ b/src/main/java/com/fwdekker/randomness/word/WordSettingsComponent.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
  *
  * @see WordSettings
  * @see WordSettingsAction
+ * @see DictionaryTable
  */
 public final class WordSettingsComponent extends SettingsComponent<WordSettings> {
     private JPanel contentPane;

--- a/src/main/java/com/fwdekker/randomness/word/WordSettingsComponent.java
+++ b/src/main/java/com/fwdekker/randomness/word/WordSettingsComponent.java
@@ -109,6 +109,12 @@ public final class WordSettingsComponent extends SettingsComponent<WordSettings>
     }
 
     @Override
+    public boolean isModified(@NotNull WordSettings settings) {
+        return dictionaryTable.getData().size() !=
+            settings.getBundledDictionaries().size() + settings.getUserDictionaries().size();
+    }
+
+    @Override
     @Nullable
     public ValidationInfo doValidate() {
         BundledDictionary.Companion.getCache().clear();

--- a/src/main/kotlin/com/fwdekker/randomness/SettingsComponent.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/SettingsComponent.kt
@@ -22,7 +22,18 @@ abstract class SettingsComponent<S : Settings<S>>(private val settings: S) : Set
      *
      * @return true if this component contains unsaved changes
      */
-    fun isModified() = settings.copyState().also { saveSettings(it) } != settings
+    fun isModified() = settings.copyState().also { saveSettings(it) } != settings || isModified(settings)
+
+    /**
+     * Returns true if this component contains unsaved changes.
+     *
+     * Implement this method if the user should be able to reset their changes even if saving would not actually change
+     * the settings object.
+     *
+     * @param settings the settings as they were loaded into the component
+     * @return true if this component contains unsaved changes
+     */
+    open fun isModified(settings: S): Boolean = false
 
     /**
      * Discards unsaved changes.

--- a/src/main/kotlin/com/fwdekker/randomness/string/StringSettings.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/string/StringSettings.kt
@@ -7,6 +7,7 @@ import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
 import com.intellij.util.xmlb.XmlSerializerUtil
+import com.intellij.util.xmlb.annotations.MapAnnotation
 import com.intellij.util.xmlb.annotations.Transient
 
 
@@ -30,8 +31,10 @@ data class StringSettings(
     var maxLength: Int = DEFAULT_MAX_LENGTH,
     var enclosure: String = DEFAULT_ENCLOSURE,
     var capitalization: CapitalizationMode = DEFAULT_CAPITALIZATION,
-    var symbolSets: Map<String, String> = SymbolSet.defaultSymbolSets.toMap(),
-    var activeSymbolSets: Map<String, String> = listOf(SymbolSet.ALPHABET, SymbolSet.DIGITS).toMap()
+    @MapAnnotation(sortBeforeSave = false)
+    var symbolSets: Map<String, String> = DEFAULT_SYMBOL_SETS.toMap(),
+    @MapAnnotation(sortBeforeSave = false)
+    var activeSymbolSets: Map<String, String> = DEFAULT_ACTIVE_SYMBOL_SETS.toMap()
 ) : Settings<StringSettings> {
     companion object {
         /**
@@ -50,6 +53,14 @@ data class StringSettings(
          * The default value of the [capitalization][StringSettings.capitalization] field.
          */
         val DEFAULT_CAPITALIZATION = CapitalizationMode.RANDOM
+        /**
+         * The default value of the [symbolSets][StringSettings.symbolSets] field.
+         */
+        val DEFAULT_SYMBOL_SETS = SymbolSet.defaultSymbolSets.toMap()
+        /**
+         * The default value of the [activeSymbolSets][StringSettings.activeSymbolSets] field.
+         */
+        val DEFAULT_ACTIVE_SYMBOL_SETS = listOf(SymbolSet.ALPHABET, SymbolSet.DIGITS).toMap()
 
 
         /**

--- a/src/main/kotlin/com/fwdekker/randomness/string/SymbolSetTable.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/string/SymbolSetTable.kt
@@ -10,6 +10,8 @@ private typealias EditableSymbolSet = EditableDatum<SymbolSet>
 
 /**
  * An editable table for selecting and editing [SymbolSet]s.
+ *
+ * @see StringSettingsComponent
  */
 class SymbolSetTable : ActivityTableModelEditor<SymbolSet>(
     arrayOf(NAME_COLUMN, SYMBOLS_COLUMN), ITEM_EDITOR, EMPTY_TEXT) {

--- a/src/main/kotlin/com/fwdekker/randomness/word/DictionaryTable.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/word/DictionaryTable.kt
@@ -71,8 +71,11 @@ class DictionaryTable : ActivityTableModelEditor<Dictionary>(
 
             override fun isRemovable(item: EditableDictionary) = item.datum is UserDictionary
 
-            override fun clone(item: EditableDictionary, forInPlaceEditing: Boolean) =
-                EditableDatum(item.active, item.datum)
+            override fun clone(item: EditableDictionary, forInPlaceEditing: Boolean): EditableDatum<Dictionary> =
+                if (item.datum is BundledDictionary)
+                    EditableDatum(item.active, UserDictionary.cache.get(""))
+                else
+                    EditableDatum(item.active, item.datum)
         }
 
         /**

--- a/src/main/kotlin/com/fwdekker/randomness/word/DictionaryTable.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/word/DictionaryTable.kt
@@ -71,6 +71,7 @@ class DictionaryTable : ActivityTableModelEditor<Dictionary>(
 
             override fun isRemovable(item: EditableDictionary) = item.datum is UserDictionary
 
+            // TODO #185 Conditionally disable copy button
             override fun clone(item: EditableDictionary, forInPlaceEditing: Boolean): EditableDatum<Dictionary> =
                 if (item.datum is BundledDictionary)
                     EditableDatum(item.active, UserDictionary.cache.get(""))

--- a/src/main/kotlin/com/fwdekker/randomness/word/DictionaryTable.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/word/DictionaryTable.kt
@@ -13,6 +13,8 @@ private typealias EditableDictionary = EditableDatum<Dictionary>
 
 /**
  * An editable table for selecting and editing [Dictionaries][Dictionary].
+ *
+ * @see WordSettingsComponent
  */
 class DictionaryTable : ActivityTableModelEditor<Dictionary>(
     arrayOf(TYPE_COLUMN, LOCATION_COLUMN), ITEM_EDITOR, EMPTY_TEXT) {

--- a/src/main/kotlin/com/fwdekker/randomness/word/WordSettings.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/word/WordSettings.kt
@@ -7,6 +7,7 @@ import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
 import com.intellij.util.xmlb.XmlSerializerUtil
+import com.intellij.util.xmlb.annotations.MapAnnotation
 import com.intellij.util.xmlb.annotations.Transient
 
 
@@ -34,14 +35,14 @@ data class WordSettings(
     var maxLength: Int = DEFAULT_MAX_LENGTH,
     var enclosure: String = DEFAULT_ENCLOSURE,
     var capitalization: CapitalizationMode = DEFAULT_CAPITALIZATION,
-    var bundledDictionaryFiles: MutableSet<String> =
-        mutableSetOf(BundledDictionary.SIMPLE_DICTIONARY, BundledDictionary.EXTENDED_DICTIONARY),
-    var userDictionaryFiles: MutableSet<String> =
-        mutableSetOf(),
-    var activeBundledDictionaryFiles: MutableSet<String> =
-        mutableSetOf(BundledDictionary.SIMPLE_DICTIONARY),
-    var activeUserDictionaryFiles: MutableSet<String> =
-        mutableSetOf()
+    @MapAnnotation(sortBeforeSave = false)
+    var bundledDictionaryFiles: MutableSet<String> = DEFAULT_BUNDLED_DICTIONARY_FILES.toMutableSet(),
+    @MapAnnotation(sortBeforeSave = false)
+    var activeBundledDictionaryFiles: MutableSet<String> = DEFAULT_ACTIVE_BUNDLED_DICTIONARY_FILES.toMutableSet(),
+    @MapAnnotation(sortBeforeSave = false)
+    var userDictionaryFiles: MutableSet<String> = DEFAULT_USER_DICTIONARY_FILES.toMutableSet(),
+    @MapAnnotation(sortBeforeSave = false)
+    var activeUserDictionaryFiles: MutableSet<String> = DEFAULT_ACTIVE_USER_DICTIONARY_FILES.toMutableSet()
 ) : Settings<WordSettings> {
     companion object {
         /**
@@ -60,6 +61,23 @@ data class WordSettings(
          * The default value of the [capitalization][WordSettings.capitalization] field.
          */
         val DEFAULT_CAPITALIZATION = CapitalizationMode.RETAIN
+        /**
+         * The default value of the [bundledDictionaryFiles][WordSettings.bundledDictionaryFiles] field.
+         */
+        val DEFAULT_BUNDLED_DICTIONARY_FILES =
+            setOf(BundledDictionary.SIMPLE_DICTIONARY, BundledDictionary.EXTENDED_DICTIONARY)
+        /**
+         * The default value of the [activeBundledDictionaryFiles][WordSettings.activeBundledDictionaryFiles] field.
+         */
+        val DEFAULT_ACTIVE_BUNDLED_DICTIONARY_FILES = setOf(BundledDictionary.SIMPLE_DICTIONARY)
+        /**
+         * The default value of the [userDictionaryFiles][WordSettings.userDictionaryFiles] field.
+         */
+        val DEFAULT_USER_DICTIONARY_FILES = setOf<String>()
+        /**
+         * The default value of the [activeUserDictionaryFiles][WordSettings.activeUserDictionaryFiles] field.
+         */
+        val DEFAULT_ACTIVE_USER_DICTIONARY_FILES = setOf<String>()
 
 
         /**

--- a/src/test/kotlin/com/fwdekker/randomness/string/StringSettingsComponentTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/string/StringSettingsComponentTest.kt
@@ -265,6 +265,18 @@ object StringSettingsComponentTest : Spek({
             }
         }
 
+        describe("duplication detection") {
+            it("detects a copy of a dictionary") {
+                val symbolSet = EditableDatum(false, SymbolSet("name", "symbols"))
+
+                GuiActionRunner.execute { symbolSetTable.listTableModel.addRow(symbolSet) }
+                stringSettingsComponentConfigurable.apply()
+                GuiActionRunner.execute { symbolSetTable.listTableModel.addRow(symbolSet) }
+
+                assertThat(stringSettingsComponentConfigurable.isModified).isTrue()
+            }
+        }
+
         describe("resets") {
             it("resets all fields properly") {
                 GuiActionRunner.execute {

--- a/src/test/kotlin/com/fwdekker/randomness/string/SymbolSetTableTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/string/SymbolSetTableTest.kt
@@ -1,6 +1,5 @@
 package com.fwdekker.randomness.string
 
-import com.fwdekker.randomness.ui.EditableDatum
 import com.intellij.testFramework.fixtures.IdeaTestFixture
 import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
 import org.assertj.core.api.Assertions.assertThat

--- a/src/test/kotlin/com/fwdekker/randomness/word/DictionaryTableTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/word/DictionaryTableTest.kt
@@ -1,6 +1,5 @@
 package com.fwdekker.randomness.word
 
-import com.fwdekker.randomness.ui.EditableDatum
 import com.intellij.testFramework.fixtures.IdeaTestFixture
 import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
 import com.nhaarman.mockitokotlin2.mock
@@ -95,12 +94,18 @@ object DictionaryTableTest : Spek({
         }
     }
 
-    // TODO: Remove button not accessible from tests
+    // TODO: Remove and copy buttons not accessible from tests
     xdescribe("itemEditor") {
-        it("does not remove a bundled dictionary") {
+        describe("remove") {
+            it("does not remove a bundled dictionary") {}
+
+            it("removes a user dictionary") {}
         }
 
-        it("removes a user dictionary") {
+        describe("copy") {
+            it("copies a bundled dictionary to a user dictionary") {}
+
+            it("copies a user dictionary to a user dictionary") {}
         }
     }
 })

--- a/src/test/kotlin/com/fwdekker/randomness/word/WordSettingsComponentTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/word/WordSettingsComponentTest.kt
@@ -326,6 +326,22 @@ object WordSettingsComponentTest : Spek({
             }
         }
 
+        describe("duplication detection") {
+            it("detects a copy of a dictionary") {
+                val dictionaryFile = createTempFile("test", ".dic")
+                dictionaryFile.writeText("somehow")
+                val dictionary = EditableDatum<Dictionary>(false, UserDictionary.cache.get(dictionaryFile.absolutePath))
+
+                GuiActionRunner.execute { dictionaryTable.listTableModel.addRow(dictionary) }
+                wordSettingsComponentConfigurable.apply()
+                GuiActionRunner.execute { dictionaryTable.listTableModel.addRow(dictionary) }
+
+                dictionaryFile.delete()
+
+                assertThat(wordSettingsComponentConfigurable.isModified).isTrue()
+            }
+        }
+
         describe("resets") {
             it("resets all fields properly") {
                 GuiActionRunner.execute {


### PR DESCRIPTION
Fixes #182.

* Adds `@MapAnnotation(sortBeforeSave = false)` to maps of which the order should be retained.
* Adds `isModified(settings: S): Boolean` to detect when duplicates are in a table; this cannot be detected using the original `isModified()` method.
* Moves default lists and maps in `Settings` objects to their respective companion objects.
* Prevents cloning of `BundledDictionary`s by returning a `UserDictionary` instead. There does not seem to be a way to disable the clone button, either permanently or conditionally.