### PR TITLE
Allow reset after reorder

### DIFF
--- a/src/main/java/com/fwdekker/randomness/string/StringSettingsComponent.java
+++ b/src/main/java/com/fwdekker/randomness/string/StringSettingsComponent.java
@@ -12,6 +12,8 @@ import org.jetbrains.annotations.Nullable;
 
 import javax.swing.ButtonGroup;
 import javax.swing.JPanel;
+import java.util.ArrayList;
+import java.util.List;
 
 
 /**
@@ -101,7 +103,10 @@ public final class StringSettingsComponent extends SettingsComponent<StringSetti
 
     @Override
     public boolean isModified(final @NotNull StringSettings settings) {
-        return symbolSetTable.getData().size() != settings.getSymbolSets().size();
+        final List<SymbolSet> tableSymbolSets = new ArrayList<>(symbolSetTable.getData());
+        final List<SymbolSet> settingsSymbolSets = new ArrayList<>(settings.getSymbolSetList());
+
+        return !JavaHelperKt.orderedEquals(tableSymbolSets, settingsSymbolSets);
     }
 
     @Override

--- a/src/main/java/com/fwdekker/randomness/word/WordSettingsComponent.java
+++ b/src/main/java/com/fwdekker/randomness/word/WordSettingsComponent.java
@@ -12,7 +12,10 @@ import org.jetbrains.annotations.Nullable;
 
 import javax.swing.ButtonGroup;
 import javax.swing.JPanel;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -110,8 +113,12 @@ public final class WordSettingsComponent extends SettingsComponent<WordSettings>
 
     @Override
     public boolean isModified(@NotNull WordSettings settings) {
-        return dictionaryTable.getData().size() !=
-            settings.getBundledDictionaries().size() + settings.getUserDictionaries().size();
+        final List<Dictionary> tableDictionaries = new ArrayList<>(dictionaryTable.getData());
+        final List<Dictionary> settingsDictionaries = new ArrayList<>(
+            WordSettingsComponentHelperKt.addSets(settings.getBundledDictionaries(), settings.getUserDictionaries())
+        );
+
+        return !JavaHelperKt.orderedEquals(tableDictionaries, settingsDictionaries);
     }
 
     @Override
@@ -192,6 +199,9 @@ public final class WordSettingsComponent extends SettingsComponent<WordSettings>
      * @return a list containing the values of {@code list} that are of class {@code cls}
      */
     private static <SUB, SUP> Set<SUB> filterIsInstance(final Collection<SUP> list, final Class<SUB> cls) {
-        return list.stream().filter(cls::isInstance).map(cls::cast).collect(Collectors.toSet());
+        return list.stream()
+            .filter(cls::isInstance)
+            .map(cls::cast)
+            .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 }

--- a/src/main/kotlin/com/fwdekker/randomness/JavaHelper.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/JavaHelper.kt
@@ -1,6 +1,8 @@
 package com.fwdekker.randomness
 
 
+// TODO Inline these methods once UI has been migrated to Kotlin
+
 /**
  * Returns the first non-null value in [values], or null if all values are null.
  *
@@ -9,3 +11,13 @@ package com.fwdekker.randomness
  * @return the first non-null value in [values], or null if all values are null.
  */
 fun <T : Any> firstNonNull(vararg values: T?) = values.firstOrNull { it != null }
+
+/**
+ * Returns `true` iff `this` and [that] have the same elements in the same order.
+ *
+ * @param T the type of elements in the collections
+ * @param that a collection that may have the same elements in the same order as `this`
+ * @return `true` iff `this` and [that] have the same elements in the same order
+ */
+fun <T : Any> Collection<T>.orderedEquals(that: Collection<T>) =
+    this.size == that.size && this.zip(that).all { it.first == it.second }

--- a/src/test/kotlin/com/fwdekker/randomness/string/StringSettingsComponentTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/string/StringSettingsComponentTest.kt
@@ -263,16 +263,31 @@ object StringSettingsComponentTest : Spek({
 
                 assertThat(stringSettingsComponentConfigurable.isModified).isFalse()
             }
-        }
 
-        describe("duplication detection") {
-            it("detects a copy of a dictionary") {
+            it("detects a copy of a symbol set") {
                 val symbolSet1 = EditableDatum(false, SymbolSet("name", "symbols"))
                 val symbolSet2 = EditableDatum(false, SymbolSet("name", "symbols"))
 
                 GuiActionRunner.execute { symbolSetTable.listTableModel.addRow(symbolSet1) }
                 stringSettingsComponentConfigurable.apply()
                 GuiActionRunner.execute { symbolSetTable.listTableModel.addRow(symbolSet2) }
+
+                assertThat(stringSettingsComponentConfigurable.isModified).isTrue()
+            }
+
+            it("detects reordering of the entries") {
+                val dictionary1 = EditableDatum(false, SymbolSet("name1", "symbols"))
+                val dictionary2 = EditableDatum(false, SymbolSet("name2", "symbols"))
+
+                GuiActionRunner.execute {
+                    symbolSetTable.listTableModel.addRow(dictionary1)
+                    symbolSetTable.listTableModel.addRow(dictionary2)
+                }
+                stringSettingsComponentConfigurable.apply()
+                GuiActionRunner.execute {
+                    symbolSetTable.listTableModel.removeRow(0)
+                    symbolSetTable.listTableModel.addRow(dictionary1)
+                }
 
                 assertThat(stringSettingsComponentConfigurable.isModified).isTrue()
             }

--- a/src/test/kotlin/com/fwdekker/randomness/word/WordSettingsComponentTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/word/WordSettingsComponentTest.kt
@@ -15,13 +15,13 @@ import org.assertj.swing.fixture.FrameFixture
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
-import org.junit.jupiter.api.fail
 
 
 /**
  * GUI tests for [WordSettingsComponent].
  */
 object WordSettingsComponentTest : Spek({
+    lateinit var tempFileHelper: TempFileHelper
     lateinit var ideaFixture: IdeaTestFixture
     lateinit var wordSettings: WordSettings
     lateinit var wordSettingsComponent: WordSettingsComponent
@@ -36,6 +36,8 @@ object WordSettingsComponentTest : Spek({
 
     @Suppress("UNCHECKED_CAST")
     beforeEachTest {
+        tempFileHelper = TempFileHelper()
+
         ideaFixture = IdeaTestFixtureFactory.getFixtureFactory().createBareFixture()
         ideaFixture.setUp()
 
@@ -56,6 +58,7 @@ object WordSettingsComponentTest : Spek({
     afterEachTest {
         ideaFixture.tearDown()
         frame.cleanUp()
+        tempFileHelper.cleanUp()
     }
 
 
@@ -172,12 +175,9 @@ object WordSettingsComponentTest : Spek({
 
         describe("dictionaries") {
             it("fails if a dictionary of a now-deleted file is given") {
-                val dictionaryFile = createTempFile("test", ".dic")
-                dictionaryFile.writeText("explore\nworm\ndamp")
+                val dictionaryFile = tempFileHelper.createFile("explore\nworm\ndamp", ".dic")
+                    .also { it.delete() }
                 val dictionary = UserDictionary.cache.get(dictionaryFile.absolutePath, true)
-
-                if (!dictionaryFile.delete())
-                    fail("Failed to delete file as part of test.")
 
                 GuiActionRunner.execute {
                     dictionaryTable.listTableModel.addRow(EditableDatum(true, dictionary))
@@ -220,7 +220,7 @@ object WordSettingsComponentTest : Spek({
             }
 
             it("fails if one the dictionaries is empty") {
-                val dictionaryFile = createTempFile("randomness", ".dic")
+                val dictionaryFile = tempFileHelper.createFile("", ".dic")
                 val dictionary = UserDictionary.cache.get(dictionaryFile.absolutePath, true)
 
                 wordSettings.userDictionaries = setOf(dictionary)
@@ -229,15 +229,13 @@ object WordSettingsComponentTest : Spek({
 
                 val validationInfo = wordSettingsComponent.doValidate()
 
-                dictionaryFile.delete()
-
                 assertThat(validationInfo).isNotNull()
                 assertThat(validationInfo?.component).isEqualTo(frame.panel("dictionaryPanel").target())
                 assertThat(validationInfo?.message).matches("Dictionary `.*\\.dic` is empty\\.")
             }
 
             it("fails if a dictionary is added twice") {
-                val dictionaryFile = createTempFile("randomness", ".dic")
+                val dictionaryFile = tempFileHelper.createFile("whistle", ".dic")
                 val dictionary = UserDictionary.cache.get(dictionaryFile.absolutePath, true)
 
                 wordSettings.userDictionaries = setOf(dictionary)
@@ -249,8 +247,6 @@ object WordSettingsComponentTest : Spek({
                 }
 
                 val validationInfo = wordSettingsComponent.doValidate()
-
-                dictionaryFile.delete()
 
                 assertThat(validationInfo).isNotNull()
                 assertThat(validationInfo?.component).isEqualTo(frame.panel("dictionaryPanel").target())
@@ -326,8 +322,7 @@ object WordSettingsComponentTest : Spek({
             }
 
             it("detects a copy of a dictionary") {
-                val dictionaryFile = createTempFile("test", ".dic")
-                dictionaryFile.writeText("somehow")
+                val dictionaryFile = tempFileHelper.createFile("somehow", ".dic")
                 val dictionary1 = UserDictionary.cache.get(dictionaryFile.absolutePath)
                 val dictionary2 = UserDictionary.cache.get(dictionaryFile.absolutePath)
 
@@ -335,19 +330,14 @@ object WordSettingsComponentTest : Spek({
                 wordSettingsComponentConfigurable.apply()
                 GuiActionRunner.execute { dictionaryTable.listTableModel.addRow(EditableDatum(false, dictionary2)) }
 
-                dictionaryFile.delete()
-
                 assertThat(wordSettingsComponentConfigurable.isModified).isTrue()
             }
 
-            // TODO Use `TempFileHelper`
             it("detects reordering of the entries") {
-                val dictionaryFile1 = createTempFile("test", ".dic")
-                    .also { it.writeText("harvest") }
+                val dictionaryFile1 = tempFileHelper.createFile("harvest", ".dic")
                 val dictionary1 =
                     EditableDatum<Dictionary>(false, UserDictionary.cache.get(dictionaryFile1.absolutePath))
-                val dictionaryFile2 = createTempFile("test", ".dic")
-                    .also { it.writeText("music") }
+                val dictionaryFile2 = tempFileHelper.createFile("music", ".dic")
                 val dictionary2 =
                     EditableDatum<Dictionary>(false, UserDictionary.cache.get(dictionaryFile2.absolutePath))
 
@@ -360,9 +350,6 @@ object WordSettingsComponentTest : Spek({
                     dictionaryTable.listTableModel.removeRow(0)
                     dictionaryTable.listTableModel.addRow(dictionary1)
                 }
-
-                dictionaryFile1.delete()
-                dictionaryFile2.delete()
 
                 assertThat(wordSettingsComponentConfigurable.isModified).isTrue()
             }

--- a/src/test/kotlin/com/fwdekker/randomness/word/WordSettingsComponentTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/word/WordSettingsComponentTest.kt
@@ -324,9 +324,7 @@ object WordSettingsComponentTest : Spek({
 
                 assertThat(wordSettingsComponentConfigurable.isModified).isFalse()
             }
-        }
 
-        describe("duplication detection") {
             it("detects a copy of a dictionary") {
                 val dictionaryFile = createTempFile("test", ".dic")
                 dictionaryFile.writeText("somehow")
@@ -338,6 +336,33 @@ object WordSettingsComponentTest : Spek({
                 GuiActionRunner.execute { dictionaryTable.listTableModel.addRow(EditableDatum(false, dictionary2)) }
 
                 dictionaryFile.delete()
+
+                assertThat(wordSettingsComponentConfigurable.isModified).isTrue()
+            }
+
+            // TODO Use `TempFileHelper`
+            it("detects reordering of the entries") {
+                val dictionaryFile1 = createTempFile("test", ".dic")
+                    .also { it.writeText("harvest") }
+                val dictionary1 =
+                    EditableDatum<Dictionary>(false, UserDictionary.cache.get(dictionaryFile1.absolutePath))
+                val dictionaryFile2 = createTempFile("test", ".dic")
+                    .also { it.writeText("music") }
+                val dictionary2 =
+                    EditableDatum<Dictionary>(false, UserDictionary.cache.get(dictionaryFile2.absolutePath))
+
+                GuiActionRunner.execute {
+                    dictionaryTable.listTableModel.addRow(dictionary1)
+                    dictionaryTable.listTableModel.addRow(dictionary2)
+                }
+                wordSettingsComponentConfigurable.apply()
+                GuiActionRunner.execute {
+                    dictionaryTable.listTableModel.removeRow(0)
+                    dictionaryTable.listTableModel.addRow(dictionary1)
+                }
+
+                dictionaryFile1.delete()
+                dictionaryFile2.delete()
 
                 assertThat(wordSettingsComponentConfigurable.isModified).isTrue()
             }


### PR DESCRIPTION
* Fixes an issue where the reset and save functions are not available when table entries are reordered but not otherwise edited. This because the `Settings` objects' `equals` methods do not return false if the contents of the sets are reordered.
* Simplifies tests in `WordSettingsComponentTest` by using the `TempFileHelper` where applicable.