### PR TITLE
Disable copy button conditionally

### DIFF
--- a/src/main/kotlin/com/fwdekker/randomness/ui/ActivityTableModelEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/ui/ActivityTableModelEditor.kt
@@ -1,5 +1,6 @@
 package com.fwdekker.randomness.ui
 
+import com.intellij.ui.ToolbarDecorator
 import com.intellij.util.ui.CollectionItemEditor
 import com.intellij.util.ui.ColumnInfo
 import com.intellij.util.ui.table.TableModelEditor
@@ -84,5 +85,8 @@ abstract class ActivityTableModelEditor<T>(
      *
      * @return a new `JPanel` with the table and the corresponding buttons
      */
-    override fun createComponent() = super.createComponent() as JPanel
+    override fun createComponent(): JPanel =
+        TableModelEditor::class.java.getDeclaredField("toolbarDecorator")
+            .apply { isAccessible = true }
+            .let { (it.get(this) as ToolbarDecorator).createPanel() }
 }

--- a/src/main/kotlin/com/fwdekker/randomness/ui/ActivityTableModelEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/ui/ActivityTableModelEditor.kt
@@ -1,6 +1,12 @@
 package com.fwdekker.randomness.ui
 
+import com.intellij.ide.IdeBundle
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.wm.IdeFocusManager
+import com.intellij.ui.TableUtil
 import com.intellij.ui.ToolbarDecorator
+import com.intellij.ui.table.TableView
+import com.intellij.util.PlatformIcons
 import com.intellij.util.ui.CollectionItemEditor
 import com.intellij.util.ui.ColumnInfo
 import com.intellij.util.ui.table.TableModelEditor
@@ -27,11 +33,13 @@ data class EditableDatum<T>(var active: Boolean, var datum: T)
  * @param columns the columns of the table, excluding the activity column
  * @param itemEditor describes what happens when a row is edited
  * @param emptyText the text to display when the table is empty
+ * @param isCopyable returns `true` if and only if the given datum can be copied
  */
 abstract class ActivityTableModelEditor<T>(
     columns: Array<ColumnInfo<EditableDatum<T>, *>>,
     itemEditor: CollectionItemEditor<EditableDatum<T>>,
-    emptyText: String
+    emptyText: String,
+    private val isCopyable: (T) -> Boolean = { true }
 ) : TableModelEditor<EditableDatum<T>>(
     arrayOf<ColumnInfo<EditableDatum<T>, *>>(createActivityColumn()).plus(columns),
     itemEditor,
@@ -85,8 +93,33 @@ abstract class ActivityTableModelEditor<T>(
      *
      * @return a new `JPanel` with the table and the corresponding buttons
      */
-    override fun createComponent(): JPanel =
-        TableModelEditor::class.java.getDeclaredField("toolbarDecorator")
+    override fun createComponent(): JPanel {
+        @Suppress("UNCHECKED_CAST") // Reflection, see superclass for correctness
+        val table = TableModelEditor::class.java.getDeclaredField("table")
             .apply { isAccessible = true }
-            .let { (it.get(this) as ToolbarDecorator).createPanel() }
+            .get(this) as TableView<EditableDatum<T>>
+
+        return TableModelEditor::class.java.getDeclaredField("toolbarDecorator")
+            .apply { isAccessible = true }
+            .let { it.get(this) as ToolbarDecorator }
+            .addExtraAction(object :
+                ToolbarDecorator.ElementActionButton(IdeBundle.message("button.copy"), PlatformIcons.COPY_ICON) {
+                // Implementation copied from superclass' `createComponent` method
+                override fun actionPerformed(e: AnActionEvent) {
+                    TableUtil.stopEditing(table)
+
+                    table.selectedObjects
+                        .also { if (it.isEmpty()) return }
+                        .forEach { model.addRow(itemEditor.clone(it, false)) }
+
+                    IdeFocusManager
+                        .getGlobalInstance()
+                        .doWhenFocusSettlesDown { IdeFocusManager.getGlobalInstance().requestFocus(table, true) }
+                    TableUtil.updateScroller(table)
+                }
+
+                override fun isEnabled() = table.selection.all { isCopyable(it.datum) }
+            })
+            .createPanel()
+    }
 }

--- a/src/main/kotlin/com/fwdekker/randomness/word/DictionaryTable.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/word/DictionaryTable.kt
@@ -17,7 +17,7 @@ private typealias EditableDictionary = EditableDatum<Dictionary>
  * @see WordSettingsComponent
  */
 class DictionaryTable : ActivityTableModelEditor<Dictionary>(
-    arrayOf(TYPE_COLUMN, LOCATION_COLUMN), ITEM_EDITOR, EMPTY_TEXT) {
+    arrayOf(TYPE_COLUMN, LOCATION_COLUMN), ITEM_EDITOR, EMPTY_TEXT, { it is UserDictionary }) {
     companion object {
         /**
          * The error message that is displayed if an unknown dictionary implementation is used.

--- a/src/test/kotlin/com/fwdekker/randomness/ui/ActivityTableModelEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/ui/ActivityTableModelEditorTest.kt
@@ -8,6 +8,7 @@ import org.assertj.swing.edt.GuiActionRunner
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
+import org.jetbrains.spek.api.dsl.xdescribe
 
 
 /**
@@ -118,5 +119,18 @@ object ActivityTableModelEditorTest : Spek({
 
             Assertions.assertThat(modelEditor.model.items[0].active).isTrue()
         }
+    }
+
+    // TODO: Copy functionality not accessible from tests
+    xdescribe("copying") {
+        it("copies a copyable element") {}
+
+        it("copies copyable elements") {}
+
+        it("does not copy an uncopyable element") {}
+
+        it("does not copy uncopyable elements") {}
+
+        it("does not copy a mixture of copyable and uncopyable elements") {}
     }
 })


### PR DESCRIPTION
Fixes #185.

It is not possible to get the `TableModelEditor` to remove or conditionally disable the copy button when invoking `createComponent`, so this PR uses reflection to emulate the functionality of that method and adds a custom copy button that _does_ disable the copy button conditionally.

A neater solution would be to get an `isCopyable` method next to the `isRemovable` method. I have opened issue [IJSDK-745](https://youtrack.jetbrains.com/issue/IJSDK-745) on YouTrack to suggest this, but even if it were implemented it would obviously not be available in the older API which this plugin depends on.