### PR TITLE
Add Randomness to insert menu

### DIFF
--- a/src/main/kotlin/com/fwdekker/randomness/PopupAction.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/PopupAction.kt
@@ -22,9 +22,9 @@ import com.intellij.ui.popup.list.ListPopupImpl
  */
 class PopupAction : AnAction() {
     companion object {
-        private const val TITLE = "Insert Random Data"
-        private const val SHIFT_TITLE = "Insert Random Array"
-        private const val CTRL_TITLE = "Insert Random Settings"
+        private const val TITLE = "Insert Data"
+        private const val SHIFT_TITLE = "Insert Array"
+        private const val CTRL_TITLE = "Change Settings"
         private const val AD_TEXT = "Shift = Array. Ctrl = Settings."
     }
 

--- a/src/main/kotlin/com/fwdekker/randomness/decimal/DecimalActions.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/decimal/DecimalActions.kt
@@ -29,7 +29,7 @@ class DecimalGroupAction : DataGroupAction() {
  * @see DecimalSettings
  */
 class DecimalInsertAction(private val settings: DecimalSettings = DecimalSettings.default) : DataInsertAction() {
-    override val name = "Insert Decimal"
+    override val name = "Random Decimal"
 
 
     /**
@@ -76,7 +76,7 @@ class DecimalInsertArrayAction(
     arraySettings: ArraySettings = ArraySettings.default,
     settings: DecimalSettings = DecimalSettings.default
 ) : DataInsertArrayAction(arraySettings, DecimalInsertAction(settings)) {
-    override val name = "Insert Decimal Array"
+    override val name = "Random Decimal Array"
 }
 
 

--- a/src/main/kotlin/com/fwdekker/randomness/integer/IntegerActions.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/integer/IntegerActions.kt
@@ -28,7 +28,7 @@ class IntegerGroupAction : DataGroupAction() {
  * @see IntegerSettings
  */
 class IntegerInsertAction(private val settings: IntegerSettings = IntegerSettings.default) : DataInsertAction() {
-    override val name = "Insert Integer"
+    override val name = "Random Integer"
 
 
     /**
@@ -77,7 +77,7 @@ class IntegerInsertArrayAction(
     arraySettings: ArraySettings = ArraySettings.default,
     settings: IntegerSettings = IntegerSettings.default
 ) : DataInsertArrayAction(arraySettings, IntegerInsertAction(settings)) {
-    override val name = "Insert Integer Array"
+    override val name = "Random Integer Array"
 }
 
 

--- a/src/main/kotlin/com/fwdekker/randomness/string/StringActions.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/string/StringActions.kt
@@ -27,7 +27,7 @@ class StringGroupAction : DataGroupAction() {
  * @see StringSettings
  */
 class StringInsertAction(private val settings: StringSettings = StringSettings.default) : DataInsertAction() {
-    override val name = "Insert String"
+    override val name = "Random String"
 
 
     /**
@@ -73,7 +73,7 @@ class StringInsertArrayAction(
     arraySettings: ArraySettings = ArraySettings.default,
     settings: StringSettings = StringSettings.default
 ) : DataInsertArrayAction(arraySettings, StringInsertAction(settings)) {
-    override val name = "Insert String Array"
+    override val name = "Random String Array"
 }
 
 

--- a/src/main/kotlin/com/fwdekker/randomness/uuid/UuidActions.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/uuid/UuidActions.kt
@@ -27,7 +27,7 @@ class UuidGroupAction : DataGroupAction() {
  * @see UuidSettings
  */
 class UuidInsertAction(private val settings: UuidSettings = UuidSettings.default) : DataInsertAction() {
-    override val name = "Insert UUID"
+    override val name = "Random UUID"
 
 
     /**
@@ -62,7 +62,7 @@ class UuidInsertArrayAction(
     arraySettings: ArraySettings = ArraySettings.default,
     settings: UuidSettings = UuidSettings.default
 ) : DataInsertArrayAction(arraySettings, UuidInsertAction(settings)) {
-    override val name = "Insert UUID Array"
+    override val name = "Random UUID Array"
 }
 
 

--- a/src/main/kotlin/com/fwdekker/randomness/word/WordActions.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/word/WordActions.kt
@@ -27,7 +27,7 @@ class WordGroupAction : DataGroupAction() {
  * @see WordSettings
  */
 class WordInsertAction(private val settings: WordSettings = WordSettings.default) : DataInsertAction() {
-    override val name = "Insert Word"
+    override val name = "Random Word"
 
 
     /**
@@ -72,7 +72,7 @@ class WordInsertArrayAction(
     arraySettings: ArraySettings = ArraySettings.default,
     settings: WordSettings = WordSettings.default
 ) : DataInsertArrayAction(arraySettings, WordInsertAction(settings)) {
-    override val name = "Insert Word Array"
+    override val name = "Random Word Array"
 }
 
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -9,6 +9,7 @@
     <idea-version since-build="171.0" />
 
     <extensions defaultExtensionNs="com.intellij">
+        <!-- Persistence -->
         <applicationService serviceImplementation="com.fwdekker.randomness.integer.IntegerSettings" />
         <applicationService serviceImplementation="com.fwdekker.randomness.decimal.DecimalSettings" />
         <applicationService serviceImplementation="com.fwdekker.randomness.string.StringSettings" />
@@ -16,6 +17,7 @@
         <applicationService serviceImplementation="com.fwdekker.randomness.uuid.UuidSettings" />
         <applicationService serviceImplementation="com.fwdekker.randomness.array.ArraySettings" />
 
+        <!-- Settings window -->
         <applicationConfigurable instance="com.fwdekker.randomness.RandomnessConfigurable"
                                  id="randomness.MainConfigurable"
                                  groupId="tools"
@@ -46,38 +48,49 @@
         <action id="randomness.ShowGroup" class="com.fwdekker.randomness.PopupAction"
                 text="Randomness" description="Opens the Randomness popup.">
             <keyboard-shortcut first-keystroke="alt R" keymap="$default" />
+            <add-to-group group-id="GenerateGroup" anchor="last" />
             <add-to-group group-id="ToolsMenu" anchor="last" />
         </action>
 
         <!-- Integers -->
         <action id="randomness.InsertInteger" class="com.fwdekker.randomness.integer.IntegerInsertAction"
-                text="Insert Integer" description="Inserts random integers at the carets." />
+                text="Random Integer" description="Inserts a random integer at each caret." />
+        <action id="randomness.InsertIntegerArray" class="com.fwdekker.randomness.integer.IntegerInsertArrayAction"
+                text="Random Integer Array" description="Inserts an array of random integers at each caret." />
         <action id="randomness.IntegerSettings" class="com.fwdekker.randomness.integer.IntegerSettingsAction"
-                text="Integer Settings" description="Settings for the Insert Integer action." />
+                text="Integer Settings" description="Settings for the Random Integer action." />
 
         <!-- Decimals -->
         <action id="randomness.InsertDecimal" class="com.fwdekker.randomness.decimal.DecimalInsertAction"
-                text="Insert Decimal" description="Inserts random decimals at the carets." />
+                text="Random Decimal" description="Inserts a random decimal at each caret." />
+        <action id="randomness.InsertDecimalArray" class="com.fwdekker.randomness.decimal.DecimalInsertArrayAction"
+                text="Random Decimal Array" description="Inserts an array of random decimals at each caret." />
         <action id="randomness.DecimalSettings" class="com.fwdekker.randomness.decimal.DecimalSettingsAction"
-                text="Decimal Settings" description="Settings for the Insert Decimal action." />
+                text="Decimal Settings" description="Settings for the Random Decimal action." />
 
         <!-- Strings -->
         <action id="randomness.InsertString" class="com.fwdekker.randomness.string.StringInsertAction"
-                text="Insert String" description="Inserts random strings at the carets." />
+                text="Random String" description="Inserts a random string at each caret." />
+        <action id="randomness.InsertStringArray" class="com.fwdekker.randomness.string.StringInsertArrayAction"
+                text="Random String Array" description="Insert an array of random strings at each caret." />
         <action id="randomness.StringSettings" class="com.fwdekker.randomness.string.StringSettingsAction"
-                text="String Settings" description="Settings for the Insert String action." />
+                text="String Settings" description="Settings for the Random String action." />
 
         <!-- Words -->
         <action id="randomness.InsertWord" class="com.fwdekker.randomness.word.WordInsertAction"
-                text="Insert Word" description="Inserts random words at the carets." />
+                text="Random Word" description="Inserts a random word at each caret." />
+        <action id="randomness.InsertWordArray" class="com.fwdekker.randomness.word.WordInsertArrayAction"
+                text="Random Word Array" description="Inserts an array of random words at each caret." />
         <action id="randomness.WordSettings" class="com.fwdekker.randomness.word.WordSettingsAction"
-                text="Word Settings" description="Settings for the Insert Word action." />
+                text="Word Settings" description="Settings for the Random Word action." />
 
         <!-- UUIDs -->
         <action id="randomness.InsertUuid" class="com.fwdekker.randomness.uuid.UuidInsertAction"
-                text="Insert UUID" description="Inserts random UUIDs at the carets." />
+                text="Random UUID" description="Inserts a random UUID at each caret." />
+        <action id="randomness.InsertUuidArray" class="com.fwdekker.randomness.uuid.UuidInsertArrayAction"
+                text="Random UUID Array" description="Inserts an array of random UUIDs at each caret." />
         <action id="randomness.UuidSettings" class="com.fwdekker.randomness.uuid.UuidSettingsAction"
-                text="UUID Settings" description="Settings for the Insert UUID action." />
+                text="UUID Settings" description="Settings for the Random UUID action." />
 
         <!-- Arrays -->
         <action id="randomness.ArraySettings" class="com.fwdekker.randomness.array.ArraySettingsAction"


### PR DESCRIPTION
Fixes #200.

Unlike the issue, this PR only adds the main Randomness action to the menu. Adding all 10 actions (5 normal + 5 array variants) would have been rather messy.

Additionally, this PR
* renames the actions to indicate that they insert _random_ values, and
* adds array insertion actions to the list of actions so that these can be found by searching and can be bound to shortcuts.