### PR TITLE
Generate other types of UUIDs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ repositories {
 }
 
 dependencies {
+    implementation group: "com.fasterxml.uuid", name: "java-uuid-generator", version: uuidGeneratorVersion
     implementation group: "org.jetbrains.kotlin", name: "kotlin-stdlib-jdk8"
     implementation group: "org.jetbrains.kotlin", name: "kotlin-reflect"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,3 +11,4 @@ junitVersion          = 5.5.2
 junitRunnerVersion    = 1.5.2
 mockitoKotlinVersion  = 2.2.0
 spekVersion           = 1.1.5
+uuidGeneratorVersion  = 3.2.0

--- a/src/main/kotlin/com/fwdekker/randomness/uuid/UuidActions.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/uuid/UuidActions.kt
@@ -1,11 +1,12 @@
 package com.fwdekker.randomness.uuid
 
+import com.fasterxml.uuid.Generators
 import com.fwdekker.randomness.DataGroupAction
 import com.fwdekker.randomness.DataInsertAction
 import com.fwdekker.randomness.DataInsertArrayAction
 import com.fwdekker.randomness.SettingsAction
 import com.fwdekker.randomness.array.ArraySettings
-import java.util.UUID
+import kotlin.random.asJavaRandom
 
 
 /**
@@ -36,17 +37,18 @@ class UuidInsertAction(private val settings: UuidSettings = UuidSettings.default
      * @param count the number of type 4 UUIDs to generate
      * @return random type 4 UUIDs
      */
-    override fun generateStrings(count: Int) =
-        List(count) {
-            val uuid = UUID.randomUUID().toString()
-            val formattedUuid = settings.capitalization.transform(uuid)
-                .let {
-                    if (settings.addDashes) it
-                    else it.replace("-", "")
-                }
+    override fun generateStrings(count: Int): List<String> {
+        val generator = Generators.randomBasedGenerator(random.asJavaRandom())
 
-            settings.enclosure + formattedUuid + settings.enclosure
-        }
+        return (0 until count)
+            .map { generator.generate().toString() }
+            .map { settings.capitalization.transform(it) }
+            .map {
+                if (settings.addDashes) it
+                else it.replace("-", "")
+            }
+            .map { settings.enclosure + it + settings.enclosure }
+    }
 }
 
 

--- a/src/main/kotlin/com/fwdekker/randomness/uuid/UuidActions.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/uuid/UuidActions.kt
@@ -1,6 +1,9 @@
 package com.fwdekker.randomness.uuid
 
+import com.fasterxml.uuid.EthernetAddress
 import com.fasterxml.uuid.Generators
+import com.fasterxml.uuid.UUIDTimer
+import com.fwdekker.randomness.DataGenerationException
 import com.fwdekker.randomness.DataGroupAction
 import com.fwdekker.randomness.DataInsertAction
 import com.fwdekker.randomness.DataInsertArrayAction
@@ -38,7 +41,16 @@ class UuidInsertAction(private val settings: UuidSettings = UuidSettings.default
      * @return random type 4 UUIDs
      */
     override fun generateStrings(count: Int): List<String> {
-        val generator = Generators.randomBasedGenerator(random.asJavaRandom())
+        @Suppress("MagicNumber") // UUID version is not magic
+        val generator = when (settings.version) {
+            1 ->
+                Generators.timeBasedGenerator(
+                    EthernetAddress(random.nextLong()),
+                    UUIDTimer(random.asJavaRandom(), null)
+                )
+            4 -> Generators.randomBasedGenerator(random.asJavaRandom())
+            else -> throw DataGenerationException("Unknown UUID version `${settings.version}`.")
+        }
 
         return (0 until count)
             .map { generator.generate().toString() }

--- a/src/main/kotlin/com/fwdekker/randomness/uuid/UuidSettings.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/uuid/UuidSettings.kt
@@ -22,11 +22,16 @@ import com.intellij.util.xmlb.XmlSerializerUtil
  */
 @State(name = "UuidSettings", storages = [Storage("\$APP_CONFIG\$/randomness.xml")])
 data class UuidSettings(
+    var version: Int = DEFAULT_VERSION,
     var enclosure: String = DEFAULT_ENCLOSURE,
     var capitalization: CapitalizationMode = DEFAULT_CAPITALIZATION,
     var addDashes: Boolean = DEFAULT_ADD_DASHES
 ) : Settings<UuidSettings> {
     companion object {
+        /**
+         * The default value of the [version][UuidSettings.version] field.
+         */
+        const val DEFAULT_VERSION = 4
         /**
          * The default value of the [enclosure][UuidSettings.enclosure] field.
          */

--- a/src/main/kotlin/com/fwdekker/randomness/uuid/UuidSettingsComponent.form
+++ b/src/main/kotlin/com/fwdekker/randomness/uuid/UuidSettingsComponent.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.fwdekker.randomness.uuid.UuidSettingsComponent">
-  <grid id="cbd77" binding="contentPane" layout-manager="GridLayoutManager" row-count="7" column-count="6" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="cbd77" binding="contentPane" layout-manager="GridLayoutManager" row-count="9" column-count="6" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="48" y="54" width="436" height="297"/>
@@ -13,7 +13,7 @@
       <grid id="b9dc4" layout-manager="GridLayoutManager" row-count="3" column-count="6" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="0" column="0" row-span="3" col-span="6" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="2" column="0" row-span="3" col-span="6" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
@@ -114,7 +114,7 @@
       </grid>
       <vspacer id="3773">
         <constraints>
-          <grid row="3" column="0" row-span="1" col-span="6" vsize-policy="0" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
+          <grid row="5" column="0" row-span="1" col-span="6" vsize-policy="0" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
             <preferred-size width="-1" height="15"/>
           </grid>
         </constraints>
@@ -122,7 +122,7 @@
       <grid id="a78da" binding="previewPanel" custom-create="true" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="4" column="0" row-span="1" col-span="6" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="6" column="0" row-span="1" col-span="6" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
@@ -130,7 +130,57 @@
       </grid>
       <vspacer id="4d1ec">
         <constraints>
-          <grid row="5" column="0" row-span="2" col-span="6" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="7" column="0" row-span="2" col-span="6" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+        </constraints>
+      </vspacer>
+      <grid id="a88b5" layout-manager="GridLayoutManager" row-count="1" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+        <margin top="0" left="0" bottom="0" right="0"/>
+        <constraints>
+          <grid row="0" column="0" row-span="1" col-span="6" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+        <border type="none"/>
+        <children>
+          <component id="aafa9" class="javax.swing.JLabel">
+            <constraints>
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text resource-bundle="randomness" key="settings.type"/>
+            </properties>
+          </component>
+          <hspacer id="d36ec">
+            <constraints>
+              <grid row="0" column="3" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+            </constraints>
+          </hspacer>
+          <component id="1c5cf" class="javax.swing.JRadioButton" default-binding="true">
+            <constraints>
+              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <actionCommand value="1"/>
+              <name value="version1" noi18n="true"/>
+              <text resource-bundle="randomness" key="settings.uuid.1"/>
+            </properties>
+          </component>
+          <component id="23ba4" class="javax.swing.JRadioButton" default-binding="true">
+            <constraints>
+              <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <actionCommand value="4"/>
+              <name value="version4" noi18n="true"/>
+              <text resource-bundle="randomness" key="settings.uuid.4"/>
+            </properties>
+          </component>
+        </children>
+      </grid>
+      <vspacer id="bddf0">
+        <constraints>
+          <grid row="1" column="0" row-span="1" col-span="6" vsize-policy="0" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
+            <preferred-size width="-1" height="15"/>
+          </grid>
         </constraints>
       </vspacer>
     </children>
@@ -145,6 +195,10 @@
     <group name="capitalizationGroup" bound="true">
       <member id="e2448"/>
       <member id="15731"/>
+    </group>
+    <group name="versionGroup" bound="true">
+      <member id="1c5cf"/>
+      <member id="23ba4"/>
     </group>
   </buttonGroups>
 </form>

--- a/src/main/kotlin/com/fwdekker/randomness/uuid/UuidSettingsComponent.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/uuid/UuidSettingsComponent.kt
@@ -7,6 +7,7 @@ import com.fwdekker.randomness.ui.getValue
 import com.fwdekker.randomness.ui.setValue
 import com.fwdekker.randomness.uuid.UuidSettings.Companion.DEFAULT_CAPITALIZATION
 import com.fwdekker.randomness.uuid.UuidSettings.Companion.DEFAULT_ENCLOSURE
+import com.fwdekker.randomness.uuid.UuidSettings.Companion.DEFAULT_VERSION
 import com.fwdekker.randomness.uuid.UuidSettings.Companion.default
 import com.intellij.openapi.ui.ValidationInfo
 import javax.swing.ButtonGroup
@@ -25,6 +26,7 @@ class UuidSettingsComponent(settings: UuidSettings = default) : SettingsComponen
     private lateinit var contentPane: JPanel
     private lateinit var previewPanelHolder: PreviewPanel<UuidInsertAction>
     private lateinit var previewPanel: JPanel
+    private lateinit var versionGroup: ButtonGroup
     private lateinit var enclosureGroup: ButtonGroup
     private lateinit var capitalizationGroup: ButtonGroup
     private lateinit var addDashesCheckBox: JCheckBox
@@ -35,7 +37,7 @@ class UuidSettingsComponent(settings: UuidSettings = default) : SettingsComponen
     init {
         loadSettings()
 
-        previewPanelHolder.updatePreviewOnUpdateOf(enclosureGroup, capitalizationGroup, addDashesCheckBox)
+        previewPanelHolder.updatePreviewOnUpdateOf(versionGroup, enclosureGroup, capitalizationGroup, addDashesCheckBox)
         previewPanelHolder.updatePreview()
     }
 
@@ -53,12 +55,14 @@ class UuidSettingsComponent(settings: UuidSettings = default) : SettingsComponen
 
 
     override fun loadSettings(settings: UuidSettings) {
+        versionGroup.setValue(settings.version.toString())
         enclosureGroup.setValue(settings.enclosure)
         capitalizationGroup.setValue(settings.capitalization)
         addDashesCheckBox.isSelected = settings.addDashes
     }
 
     override fun saveSettings(settings: UuidSettings) {
+        settings.version = versionGroup.getValue()?.toInt() ?: DEFAULT_VERSION
         settings.enclosure = enclosureGroup.getValue() ?: DEFAULT_ENCLOSURE
         settings.capitalization = capitalizationGroup.getValue()?.let { getMode(it) } ?: DEFAULT_CAPITALIZATION
         settings.addDashes = addDashesCheckBox.isSelected

--- a/src/main/resources/randomness.properties
+++ b/src/main/resources/randomness.properties
@@ -28,3 +28,6 @@ settings.separator                               = Separator:
 settings.show_trailing_zeroes                    = &Show trailing zeroes
 settings.space_after_separator                   = &Space after separator
 settings.symbol_sets                             = Symbol sets
+settings.type                                    = Type:
+settings.uuid.1                                  = Time-based
+settings.uuid.4                                  = Random

--- a/src/test/kotlin/com/fwdekker/randomness/uuid/UuidInsertActionTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/uuid/UuidInsertActionTest.kt
@@ -1,7 +1,10 @@
 package com.fwdekker.randomness.uuid
 
 import com.fwdekker.randomness.CapitalizationMode
+import com.fwdekker.randomness.DataGenerationException
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 
@@ -13,19 +16,19 @@ class UuidInsertActionTest {
     companion object {
         @JvmStatic
         private fun provider() = listOf(
-            arrayOf("", CapitalizationMode.LOWER, true),
-            arrayOf("'", CapitalizationMode.LOWER, true),
-            arrayOf("Eglzfpf5", CapitalizationMode.LOWER, true),
-            arrayOf("", CapitalizationMode.UPPER, true),
-            arrayOf("'", CapitalizationMode.UPPER, false)
+            arrayOf(1, "", CapitalizationMode.LOWER, true),
+            arrayOf(4, "'", CapitalizationMode.LOWER, true),
+            arrayOf(1, "Eglzfpf5", CapitalizationMode.LOWER, true),
+            arrayOf(4, "", CapitalizationMode.UPPER, true),
+            arrayOf(1, "'", CapitalizationMode.UPPER, false)
         )
     }
 
 
     @ParameterizedTest
     @MethodSource("provider")
-    fun testEnclosure(enclosure: String, capitalizationMode: CapitalizationMode, addDashes: Boolean) {
-        val insertRandomUuid = UuidInsertAction(UuidSettings(enclosure, capitalizationMode, addDashes))
+    fun testEnclosure(version: Int, enclosure: String, capitalizationMode: CapitalizationMode, addDashes: Boolean) {
+        val insertRandomUuid = UuidInsertAction(UuidSettings(version, enclosure, capitalizationMode, addDashes))
         val generatedString = insertRandomUuid.generateString()
 
         val alphabet = capitalizationMode.transform("0-9a-fA-F")
@@ -38,5 +41,12 @@ class UuidInsertActionTest {
                 "$enclosure$"
             ).matches(generatedString)
         ).isTrue()
+    }
+
+    @Test
+    fun testInvalidVersion() {
+        assertThatThrownBy { UuidInsertAction(UuidSettings(9)).generateString()}
+            .isInstanceOf(DataGenerationException::class.java)
+            .hasMessage("Unknown UUID version `9`.")
     }
 }

--- a/src/test/kotlin/com/fwdekker/randomness/uuid/UuidSettingsComponentTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/uuid/UuidSettingsComponentTest.kt
@@ -27,6 +27,7 @@ object UuidSettingsComponentTest : Spek({
 
     beforeEachTest {
         uuidSettings = UuidSettings()
+        uuidSettings.version = 4
         uuidSettings.enclosure = "'"
         uuidSettings.capitalization = CapitalizationMode.UPPER
         uuidSettings.addDashes = false
@@ -42,6 +43,11 @@ object UuidSettingsComponentTest : Spek({
 
 
     describe("loading settings") {
+        it("loads the settings' version") {
+            frame.radioButton("version1").requireSelected(false)
+            frame.radioButton("version4").requireSelected(true)
+        }
+
         it("loads the settings' enclosure") {
             frame.radioButton("enclosureNone").requireSelected(false)
             frame.radioButton("enclosureSingle").requireSelected(true)
@@ -69,12 +75,14 @@ object UuidSettingsComponentTest : Spek({
 
     describe("saving settings") {
         it("correctly saves settings to a settings object") {
+            GuiActionRunner.execute { frame.radioButton("version1").target().isSelected = true }
             GuiActionRunner.execute { frame.radioButton("enclosureBacktick").target().isSelected = true }
             GuiActionRunner.execute { frame.radioButton("capitalizationUpper").target().isSelected = true }
             GuiActionRunner.execute { frame.checkBox("addDashesCheckBox").target().isSelected = true }
 
             uuidSettingsComponent.saveSettings()
 
+            assertThat(uuidSettings.version).isEqualTo(1)
             assertThat(uuidSettings.enclosure).isEqualTo("`")
             assertThat(uuidSettings.capitalization).isEqualTo(CapitalizationMode.UPPER)
             assertThat(uuidSettings.addDashes).isEqualTo(true)
@@ -88,12 +96,14 @@ object UuidSettingsComponentTest : Spek({
 
         describe("saving modifications") {
             it("accepts correct settings") {
+                GuiActionRunner.execute { frame.radioButton("version1").target().isSelected = true }
                 GuiActionRunner.execute { frame.radioButton("enclosureBacktick").target().isSelected = true }
                 GuiActionRunner.execute { frame.radioButton("capitalizationLower").target().isSelected = true }
                 GuiActionRunner.execute { frame.checkBox("addDashesCheckBox").target().isSelected = false }
 
                 uuidSettingsComponentConfigurable.apply()
 
+                assertThat(uuidSettings.version).isEqualTo(1)
                 assertThat(uuidSettings.enclosure).isEqualTo("`")
                 assertThat(uuidSettings.capitalization).isEqualTo(CapitalizationMode.LOWER)
                 assertThat(uuidSettings.addDashes).isEqualTo(false)
@@ -130,6 +140,7 @@ object UuidSettingsComponentTest : Spek({
         describe("resets") {
             it("resets all fields properly") {
                 GuiActionRunner.execute {
+                    GuiActionRunner.execute { frame.radioButton("version1").target().isSelected = true }
                     GuiActionRunner.execute { frame.radioButton("enclosureNone").target().isSelected = true }
                     GuiActionRunner.execute { frame.radioButton("capitalizationLower").target().isSelected = true }
                     GuiActionRunner.execute { frame.checkBox("addDashesCheckBox").target().isSelected = true }

--- a/src/test/kotlin/com/fwdekker/randomness/uuid/UuidSettingsTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/uuid/UuidSettingsTest.kt
@@ -22,19 +22,23 @@ object UuidSettingsTest : Spek({
     describe("state management") {
         it("creates an independent copy") {
             val copy = uuidSettings.copyState()
+            uuidSettings.version = 1
             uuidSettings.enclosure = "D"
             uuidSettings.capitalization = CapitalizationMode.RANDOM
             uuidSettings.addDashes = false
+            copy.version = 4
             copy.enclosure = "p"
             copy.capitalization = CapitalizationMode.UPPER
             copy.addDashes = true
 
+            assertThat(uuidSettings.version).isEqualTo(1)
             assertThat(uuidSettings.enclosure).isEqualTo("D")
             assertThat(uuidSettings.capitalization).isEqualTo(CapitalizationMode.RANDOM)
             assertThat(uuidSettings.addDashes).isEqualTo(false)
         }
 
         it("copies state from another instance") {
+            uuidSettings.version = 4
             uuidSettings.enclosure = "nvpB"
             uuidSettings.capitalization = CapitalizationMode.FIRST_LETTER
             uuidSettings.addDashes = true
@@ -42,6 +46,7 @@ object UuidSettingsTest : Spek({
             val newUuidSettings = UuidSettings()
             newUuidSettings.loadState(uuidSettings.state)
 
+            assertThat(newUuidSettings.version).isEqualTo(4)
             assertThat(newUuidSettings.enclosure).isEqualTo("nvpB")
             assertThat(newUuidSettings.capitalization).isEqualTo(CapitalizationMode.FIRST_LETTER)
             assertThat(newUuidSettings.addDashes).isEqualTo(true)


### PR DESCRIPTION
Fixes #154.

Generating types other than 1 and 4 does not make much sense since these are not random.