### PR TITLE
Display different values in array preview

### DIFF
--- a/src/main/kotlin/com/fwdekker/randomness/DataActions.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/DataActions.kt
@@ -219,6 +219,7 @@ abstract class DataInsertArrayAction(
         if (arrayScheme.count <= 0)
             throw DataGenerationException("Array cannot have fewer than 1 element.")
 
+        dataInsertAction.random = random
         return dataInsertAction.generateStrings(count * arrayScheme.count)
             .chunked(arrayScheme.count)
             .map { arrayScheme.arrayify(it) }

--- a/src/main/kotlin/com/fwdekker/randomness/DummyActions.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/DummyActions.kt
@@ -3,6 +3,7 @@ package com.fwdekker.randomness
 import com.fwdekker.randomness.array.ArrayScheme
 import com.fwdekker.randomness.array.ArraySettings
 import icons.RandomnessIcons
+import kotlin.random.Random
 
 
 /**
@@ -10,12 +11,12 @@ import icons.RandomnessIcons
  *
  * Mostly for testing and demonstration purposes.
  *
- * @property dummyValue the dummy value that is inserted
+ * @property dummySupplier generates dummy values to insert
  */
-class DummyInsertAction(private val dummyValue: String) : DataInsertAction(RandomnessIcons.Data.Base) {
+class DummyInsertAction(private val dummySupplier: (Random) -> String) : DataInsertAction(RandomnessIcons.Data.Base) {
     override val name = "Random Dummy"
 
-    override fun generateStrings(count: Int) = List(count) { dummyValue }
+    override fun generateStrings(count: Int) = List(count) { dummySupplier(random) }
 }
 
 /**
@@ -24,8 +25,11 @@ class DummyInsertAction(private val dummyValue: String) : DataInsertAction(Rando
  * Mostly for testing and demonstration purposes.
  *
  * @param arrayScheme the scheme to use for generating arrays
+ * @param dummySupplier generates dummy values to insert
  */
-class DummyInsertArrayAction(arrayScheme: ArrayScheme = ArraySettings.default.currentScheme, dummyValue: String) :
-    DataInsertArrayAction(arrayScheme, DummyInsertAction(dummyValue), RandomnessIcons.Data.Array) {
+class DummyInsertArrayAction(
+    arrayScheme: ArrayScheme = ArraySettings.default.currentScheme,
+    dummySupplier: (Random) -> String
+) : DataInsertArrayAction(arrayScheme, DummyInsertAction(dummySupplier), RandomnessIcons.Data.Array) {
     override val name = "Random Dummy Array"
 }

--- a/src/main/kotlin/com/fwdekker/randomness/array/ArraySettingsComponent.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/array/ArraySettingsComponent.kt
@@ -29,7 +29,14 @@ import javax.swing.event.ChangeEvent
 class ArraySettingsComponent(settings: ArraySettings = default) :
     SettingsComponent<ArraySettings, ArrayScheme>(settings) {
     companion object {
-        private const val previewPlaceholder = "17"
+        /**
+         * The minimal value in the preview (inclusive).
+         */
+        private const val previewMin = 1
+        /**
+         * The maximal value in the preview (inclusive).
+         */
+        private const val previewMax = 20
     }
 
 
@@ -37,7 +44,7 @@ class ArraySettingsComponent(settings: ArraySettings = default) :
     override lateinit var schemesPanel: SchemesPanel<ArrayScheme>
 
     private lateinit var contentPane: JPanel
-    private lateinit var previewPanelHolder: PreviewPanel<DummyInsertArrayAction>
+    private lateinit var previewPanelHolder: PreviewPanel
     private lateinit var previewPanel: JPanel
     private lateinit var countSpinner: JIntSpinner
     private lateinit var bracketsGroup: ButtonGroup
@@ -74,7 +81,8 @@ class ArraySettingsComponent(settings: ArraySettings = default) :
             .also { it.addListener(SettingsComponentListener(this)) }
 
         previewPanelHolder = PreviewPanel {
-            DummyInsertArrayAction(ArrayScheme().also { saveScheme(it) }, previewPlaceholder)
+            val scheme = ArrayScheme().also { saveScheme(it) }
+            DummyInsertArrayAction(scheme) { it.nextInt(previewMin, previewMax + 1).toString() }
         }
         previewPanel = previewPanelHolder.rootPane
 

--- a/src/main/kotlin/com/fwdekker/randomness/decimal/DecimalSettingsComponent.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/decimal/DecimalSettingsComponent.kt
@@ -30,7 +30,7 @@ class DecimalSettingsComponent(settings: DecimalSettings = default) :
     override lateinit var schemesPanel: SchemesPanel<DecimalScheme>
 
     private lateinit var contentPane: JPanel
-    private lateinit var previewPanelHolder: PreviewPanel<DecimalInsertAction>
+    private lateinit var previewPanelHolder: PreviewPanel
     private lateinit var previewPanel: JPanel
     private lateinit var valueRange: JSpinnerRange
     private lateinit var minValue: JDoubleSpinner

--- a/src/main/kotlin/com/fwdekker/randomness/integer/IntegerSettingsComponent.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/integer/IntegerSettingsComponent.kt
@@ -30,7 +30,7 @@ class IntegerSettingsComponent(settings: IntegerSettings = default) :
     override lateinit var schemesPanel: SchemesPanel<IntegerScheme>
 
     private lateinit var contentPane: JPanel
-    private lateinit var previewPanelHolder: PreviewPanel<IntegerInsertAction>
+    private lateinit var previewPanelHolder: PreviewPanel
     private lateinit var previewPanel: JPanel
     private lateinit var valueRange: JSpinnerRange
     private lateinit var minValue: JLongSpinner

--- a/src/main/kotlin/com/fwdekker/randomness/string/StringSettingsComponent.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/string/StringSettingsComponent.kt
@@ -33,7 +33,7 @@ class StringSettingsComponent(settings: StringSettings = default) :
     override lateinit var schemesPanel: SchemesPanel<StringScheme>
 
     private lateinit var contentPane: JPanel
-    private lateinit var previewPanelHolder: PreviewPanel<StringInsertAction>
+    private lateinit var previewPanelHolder: PreviewPanel
     private lateinit var previewPanel: JPanel
     private lateinit var lengthRange: JSpinnerRange
     private lateinit var minLength: JIntSpinner

--- a/src/main/kotlin/com/fwdekker/randomness/ui/PreviewPanel.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/ui/PreviewPanel.kt
@@ -22,11 +22,10 @@ import kotlin.random.Random
  * changes. After registering some components with this panel, the preview will be updated whenever those components are
  * updated.
  *
- * @param T the type of [DataInsertAction]
  * @property getGenerator returns a [DataInsertAction] that uses the given source of randomness
  */
 @Suppress("LateinitUsage") // Initialized by scene builder
-class PreviewPanel<T : DataInsertAction>(private val getGenerator: () -> T) {
+class PreviewPanel(private val getGenerator: () -> DataInsertAction) {
     /**
      * The root panel containing the preview elements.
      */

--- a/src/main/kotlin/com/fwdekker/randomness/uuid/UuidSettingsComponent.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/uuid/UuidSettingsComponent.kt
@@ -30,7 +30,7 @@ class UuidSettingsComponent(settings: UuidSettings = default) : SettingsComponen
     override lateinit var schemesPanel: SchemesPanel<UuidScheme>
 
     private lateinit var contentPane: JPanel
-    private lateinit var previewPanelHolder: PreviewPanel<UuidInsertAction>
+    private lateinit var previewPanelHolder: PreviewPanel
     private lateinit var previewPanel: JPanel
     private lateinit var versionGroup: ButtonGroup
     private lateinit var enclosureGroup: ButtonGroup

--- a/src/main/kotlin/com/fwdekker/randomness/word/WordSettingsComponent.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/word/WordSettingsComponent.kt
@@ -31,7 +31,7 @@ class WordSettingsComponent(settings: WordSettings = default) : SettingsComponen
     override lateinit var schemesPanel: SchemesPanel<WordScheme>
 
     private lateinit var contentPane: JPanel
-    private lateinit var previewPanelHolder: PreviewPanel<WordInsertAction>
+    private lateinit var previewPanelHolder: PreviewPanel
     private lateinit var previewPanel: JPanel
     private lateinit var lengthRange: JSpinnerRange
     private lateinit var minLength: JIntSpinner

--- a/src/test/kotlin/com/fwdekker/randomness/DataInsertActionIntegrationTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/DataInsertActionIntegrationTest.kt
@@ -34,7 +34,7 @@ class DataInsertActionIntegrationTest : BasePlatformTestCase() {
 
         document = myFixture.editor.document
         caretModel = myFixture.editor.caretModel
-        insertRandomSimple = DummyInsertAction(RANDOM_STRING)
+        insertRandomSimple = DummyInsertAction { RANDOM_STRING }
     }
 
     override fun getTestDataPath() = javaClass.classLoader.getResource("integration-project/")?.path
@@ -137,7 +137,7 @@ class DataInsertActionIntegrationTest : BasePlatformTestCase() {
         WriteCommandAction.runWriteCommandAction(myFixture.project) { document.setText("wizard\nsirens\nvanity") }
 
         setSelection(5, 9)
-        myFixture.testAction(DummyInsertArrayAction(ArrayScheme(count = 2), RANDOM_STRING))
+        myFixture.testAction(DummyInsertArrayAction(ArrayScheme(count = 2)) { RANDOM_STRING })
 
         assertThat(document.text).isEqualTo("wizar[$RANDOM_STRING, $RANDOM_STRING]rens\nvanity")
     }

--- a/src/test/kotlin/com/fwdekker/randomness/DataInsertActionTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/DataInsertActionTest.kt
@@ -24,7 +24,7 @@ object DataInsertActionTest : Spek({
 
 
     beforeEachTest {
-        dataInsertAction = DummyInsertAction("random_value")
+        dataInsertAction = DummyInsertAction { "random_value" }
     }
 
 

--- a/src/test/kotlin/com/fwdekker/randomness/array/DataInsertArrayActionTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/array/DataInsertArrayActionTest.kt
@@ -16,14 +16,14 @@ object DataInsertArrayActionTest : Spek({
 
 
     it("throws an exception if the count is empty") {
-        val action = DummyInsertArrayAction(ArrayScheme(count = 0), randomValue)
+        val action = DummyInsertArrayAction(ArrayScheme(count = 0)) { randomValue }
         assertThatThrownBy { action.generateString() }
             .isInstanceOf(DataGenerationException::class.java)
             .hasMessage("Array cannot have fewer than 1 element.")
     }
 
     it("throws an exception if the count is negative") {
-        val action = DummyInsertArrayAction(ArrayScheme(count = -3), randomValue)
+        val action = DummyInsertArrayAction(ArrayScheme(count = -3)) { randomValue }
         assertThatThrownBy { action.generateString() }
             .isInstanceOf(DataGenerationException::class.java)
             .hasMessage("Array cannot have fewer than 1 element.")
@@ -31,7 +31,7 @@ object DataInsertArrayActionTest : Spek({
 
     it("chunks the values according to the settings") {
         val randomArray = "[$randomValue, $randomValue]"
-        assertThat(DummyInsertArrayAction(ArrayScheme(count = 2), randomValue).generateStrings(4))
+        assertThat(DummyInsertArrayAction(ArrayScheme(count = 2)) { randomValue }.generateStrings(4))
             .containsExactly(randomArray, randomArray, randomArray, randomArray)
     }
 })

--- a/src/test/kotlin/com/fwdekker/randomness/ui/PreviewPanelTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/ui/PreviewPanelTest.kt
@@ -29,7 +29,7 @@ object PreviewPanelTest : Spek({
     val randomText = "random_value"
     val randomTextHtml = "<html>$randomText</html>"
 
-    lateinit var panel: PreviewPanel<DummyInsertAction>
+    lateinit var panel: PreviewPanel
     lateinit var frame: FrameFixture
 
 
@@ -38,8 +38,8 @@ object PreviewPanelTest : Spek({
     }
 
     beforeEachTest {
-        panel = GuiActionRunner.execute<PreviewPanel<DummyInsertAction>> {
-            PreviewPanel { DummyInsertAction(randomText).also { action = it } }
+        panel = GuiActionRunner.execute<PreviewPanel> {
+            PreviewPanel { DummyInsertAction { randomText }.also { action = it } }
         }
         frame = Containers.showInFrame(panel.rootPane)
 
@@ -90,7 +90,7 @@ object PreviewPanelTest : Spek({
                     override fun clone(item: EditableDatum<String>, forInPlaceEditing: Boolean) =
                         EditableDatum(item.active, item.datum)
                 }
-                val table = object : ActivityTableModelEditor<String>(arrayOf(), itemEditor, "" , "") {}
+                val table = object : ActivityTableModelEditor<String>(arrayOf(), itemEditor, "", "") {}
 
                 panel.updatePreviewOnUpdateOf(table)
                 table.data = listOf("a")


### PR DESCRIPTION
Fixes #240 and fixes #239.

Random values are used for the preview, thus fixing #240. Because these values are random and use the seed, #239 is no longer valid.

Additionally, the generic part of the `PreviewPanel` has been removed because it was not necessary.