### PR TITLE
Add expandable text fields for symbol sets

### DIFF
--- a/src/main/kotlin/com/fwdekker/randomness/string/SymbolSetTable.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/string/SymbolSetTable.kt
@@ -2,7 +2,10 @@ package com.fwdekker.randomness.string
 
 import com.fwdekker.randomness.ui.ActivityTableModelEditor
 import com.fwdekker.randomness.ui.EditableDatum
+import com.intellij.ui.components.fields.ExpandableTextField
+import com.intellij.util.ui.AbstractTableCellEditor
 import com.intellij.util.ui.CollectionItemEditor
+import javax.swing.JTable
 
 
 private typealias EditableSymbolSet = EditableDatum<SymbolSet>
@@ -40,6 +43,26 @@ class SymbolSetTable : ActivityTableModelEditor<SymbolSet>(
             override fun setValue(item: EditableSymbolSet, value: String) {
                 item.datum.symbols = value
             }
+
+            override fun getEditor(item: EditableSymbolSet?) =
+                object : AbstractTableCellEditor() {
+                    private var component: ExpandableTextField? = null
+
+                    override fun getTableCellEditorComponent(
+                        table: JTable?,
+                        value: Any?,
+                        isSelected: Boolean,
+                        row: Int,
+                        column: Int
+                    ): ExpandableTextField =
+                        ExpandableTextField()
+                            .also {
+                                it.text = value as String
+                                component = it
+                            }
+
+                    override fun getCellEditorValue() = component?.text
+                }
         }
 
         /**

--- a/src/main/resources/META-INF/change-notes.html
+++ b/src/main/resources/META-INF/change-notes.html
@@ -15,6 +15,7 @@ All settings are invalidated as of this version. Beware.
     <li>Added schemes.</li>
     <li>Array previews now feature different, random numbers.</li>
     <li>No more bordered panels; these occurred on some operating systems.</li>
+    <li>Symbol set editing is now easier with expandable text fields.</li>
 </ul>
 
 <b>Fixes</b>


### PR DESCRIPTION
Implements the `ExpandableTextField` suggestion from #209.