### PR TITLE
Preview wrapping

### DIFF
--- a/src/main/kotlin/com/fwdekker/randomness/array/ArraySettingsComponent.form
+++ b/src/main/kotlin/com/fwdekker/randomness/array/ArraySettingsComponent.form
@@ -1,31 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.fwdekker.randomness.array.ArraySettingsComponent">
-  <grid id="27dc6" binding="contentPane" layout-manager="GridLayoutManager" row-count="8" column-count="6" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="contentPane" layout-manager="GridLayoutManager" row-count="5" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="500" height="400"/>
+      <xy x="20" y="20" width="385" height="217"/>
     </constraints>
     <properties/>
     <border type="none"/>
     <children>
-      <vspacer id="dc630">
+      <component id="1f193" class="com.fwdekker.randomness.SchemesPanel" binding="schemesPanel" custom-create="true">
         <constraints>
-          <grid row="7" column="0" row-span="1" col-span="6" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
-        </constraints>
-      </vspacer>
-      <grid id="abcc1" binding="previewPanel" custom-create="true" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
-        <margin top="0" left="0" bottom="0" right="0"/>
-        <constraints>
-          <grid row="6" column="0" row-span="1" col-span="6" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
-        <border type="none"/>
-        <children/>
-      </grid>
+      </component>
       <grid id="c14ec" layout-manager="GridLayoutManager" row-count="4" column-count="6" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="1" column="0" row-span="4" col-span="6" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
@@ -152,17 +144,25 @@
       </grid>
       <vspacer id="2bc85">
         <constraints>
-          <grid row="5" column="0" row-span="1" col-span="6" vsize-policy="0" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
+          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
             <preferred-size width="-1" height="15"/>
           </grid>
         </constraints>
       </vspacer>
-      <component id="1f193" class="com.fwdekker.randomness.SchemesPanel" binding="schemesPanel" custom-create="true">
+      <grid id="abcc1" binding="previewPanel" custom-create="true" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+        <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="0" column="0" row-span="1" col-span="6" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
-      </component>
+        <border type="none"/>
+        <children/>
+      </grid>
+      <vspacer id="dc630">
+        <constraints>
+          <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+        </constraints>
+      </vspacer>
     </children>
   </grid>
   <buttonGroups>

--- a/src/main/kotlin/com/fwdekker/randomness/decimal/DecimalSettingsComponent.form
+++ b/src/main/kotlin/com/fwdekker/randomness/decimal/DecimalSettingsComponent.form
@@ -1,24 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.fwdekker.randomness.decimal.DecimalSettingsComponent">
-  <grid id="cbd77" binding="contentPane" layout-manager="GridLayoutManager" row-count="13" column-count="6" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="cbd77" binding="contentPane" layout-manager="GridLayoutManager" row-count="9" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="48" y="54" width="442" height="451"/>
+      <xy x="48" y="54" width="488" height="315"/>
     </constraints>
     <properties/>
     <border type="none"/>
     <children>
-      <grid id="2e0f2" layout-manager="GridLayoutManager" row-count="2" column-count="6" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <component id="9a307" class="com.fwdekker.randomness.SchemesPanel" binding="schemesPanel" custom-create="true">
+        <constraints>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+      </component>
+      <grid id="2e0f2" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="1" column="0" row-span="2" col-span="6" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
         <children>
           <component id="6a447" class="com.fwdekker.randomness.ui.JDoubleSpinner" binding="minValue" custom-create="true">
             <constraints>
-              <grid row="0" column="1" row-span="1" col-span="5" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
+              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                <preferred-size width="292" height="10"/>
+              </grid>
             </constraints>
             <properties>
               <name value="minValue" noi18n="true"/>
@@ -26,7 +34,9 @@
           </component>
           <component id="7daea" class="com.fwdekker.randomness.ui.JDoubleSpinner" binding="maxValue" custom-create="true">
             <constraints>
-              <grid row="1" column="1" row-span="1" col-span="5" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
+              <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                <preferred-size width="292" height="10"/>
+              </grid>
             </constraints>
             <properties>
               <name value="maxValue" noi18n="true"/>
@@ -54,22 +64,22 @@
       </grid>
       <vspacer id="dcbb">
         <constraints>
-          <grid row="3" column="0" row-span="1" col-span="6" vsize-policy="0" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
+          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
             <preferred-size width="-1" height="15"/>
           </grid>
         </constraints>
       </vspacer>
-      <grid id="1df67" layout-manager="GridLayoutManager" row-count="2" column-count="6" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="1df67" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="4" column="0" row-span="2" col-span="6" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
         <children>
           <component id="b93dd" class="com.fwdekker.randomness.ui.JIntSpinner" binding="decimalCount" custom-create="true">
             <constraints>
-              <grid row="0" column="1" row-span="1" col-span="5" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
+              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <name value="decimalCount" noi18n="true"/>
@@ -86,7 +96,7 @@
           </component>
           <component id="600de" class="javax.swing.JCheckBox" binding="showTrailingZeroesCheckBox" default-binding="true">
             <constraints>
-              <grid row="1" column="1" row-span="1" col-span="5" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <name value="showTrailingZeroes" noi18n="true"/>
@@ -97,7 +107,7 @@
       </grid>
       <vspacer id="9ef71">
         <constraints>
-          <grid row="6" column="0" row-span="1" col-span="6" vsize-policy="0" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
+          <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
             <preferred-size width="-1" height="15"/>
           </grid>
         </constraints>
@@ -105,7 +115,7 @@
       <grid id="c4e4c" layout-manager="GridLayoutManager" row-count="2" column-count="6" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="7" column="0" row-span="2" col-span="6" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
@@ -195,7 +205,7 @@
       </grid>
       <vspacer id="f6ee3">
         <constraints>
-          <grid row="9" column="0" row-span="1" col-span="6" vsize-policy="0" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
+          <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
             <preferred-size width="-1" height="15"/>
           </grid>
         </constraints>
@@ -203,7 +213,7 @@
       <grid id="4219f" binding="previewPanel" custom-create="true" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="10" column="0" row-span="1" col-span="6" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="7" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
@@ -211,15 +221,9 @@
       </grid>
       <vspacer id="3f22d">
         <constraints>
-          <grid row="11" column="0" row-span="2" col-span="6" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="8" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
-      <component id="9a307" class="com.fwdekker.randomness.SchemesPanel" binding="schemesPanel" custom-create="true">
-        <constraints>
-          <grid row="0" column="0" row-span="1" col-span="6" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties />
-      </component>
     </children>
   </grid>
   <buttonGroups>

--- a/src/main/kotlin/com/fwdekker/randomness/integer/IntegerSettings.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/integer/IntegerSettings.kt
@@ -1,6 +1,7 @@
 package com.fwdekker.randomness.integer
 
 import com.fwdekker.randomness.Scheme
+import com.fwdekker.randomness.Scheme.Companion.DEFAULT_NAME
 import com.fwdekker.randomness.Settings
 import com.fwdekker.randomness.SettingsConfigurable
 import com.intellij.openapi.components.ServiceManager
@@ -8,7 +9,6 @@ import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
 import com.intellij.util.xmlb.XmlSerializerUtil
 import com.intellij.util.xmlb.annotations.MapAnnotation
-import org.ini4j.Registry.Key.DEFAULT_NAME
 
 
 /**

--- a/src/main/kotlin/com/fwdekker/randomness/integer/IntegerSettingsComponent.form
+++ b/src/main/kotlin/com/fwdekker/randomness/integer/IntegerSettingsComponent.form
@@ -1,17 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.fwdekker.randomness.integer.IntegerSettingsComponent">
-  <grid id="cbd77" binding="contentPane" layout-manager="GridLayoutManager" row-count="9" column-count="6" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="cbd77" binding="contentPane" layout-manager="GridLayoutManager" row-count="5" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="48" y="54" width="541" height="297"/>
+      <xy x="48" y="54" width="394" height="205"/>
     </constraints>
     <properties/>
     <border type="none"/>
     <children>
+      <component id="36036" class="com.fwdekker.randomness.SchemesPanel" binding="schemesPanel" custom-create="true">
+        <constraints>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+      </component>
       <grid id="5fb42" layout-manager="GridLayoutManager" row-count="4" column-count="6" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="1" column="0" row-span="4" col-span="6" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
@@ -121,7 +127,7 @@
       </grid>
       <vspacer id="f841b">
         <constraints>
-          <grid row="5" column="0" row-span="1" col-span="6" vsize-policy="0" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
+          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
             <preferred-size width="-1" height="15"/>
           </grid>
         </constraints>
@@ -129,7 +135,7 @@
       <grid id="ab197" binding="previewPanel" custom-create="true" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="6" column="0" row-span="1" col-span="6" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
@@ -137,15 +143,9 @@
       </grid>
       <vspacer id="cd3f3">
         <constraints>
-          <grid row="7" column="0" row-span="2" col-span="6" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
-      <component id="36036" class="com.fwdekker.randomness.SchemesPanel" binding="schemesPanel" custom-create="true">
-        <constraints>
-          <grid row="0" column="0" row-span="1" col-span="6" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties />
-      </component>
     </children>
   </grid>
   <buttonGroups>

--- a/src/main/kotlin/com/fwdekker/randomness/string/StringSettingsComponent.form
+++ b/src/main/kotlin/com/fwdekker/randomness/string/StringSettingsComponent.form
@@ -1,17 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.fwdekker.randomness.string.StringSettingsComponent">
-  <grid id="cbd77" binding="contentPane" layout-manager="GridLayoutManager" row-count="15" column-count="6" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="cbd77" binding="contentPane" layout-manager="GridLayoutManager" row-count="9" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="48" y="54" width="475" height="421"/>
+      <xy x="48" y="54" width="518" height="316"/>
     </constraints>
     <properties/>
     <border type="none"/>
     <children>
-      <grid id="b7518" layout-manager="GridLayoutManager" row-count="2" column-count="6" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <component id="f6838" class="com.fwdekker.randomness.SchemesPanel" binding="schemesPanel" custom-create="true">
+        <constraints>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false">
+            <preferred-size width="10" height="21"/>
+          </grid>
+        </constraints>
+        <properties/>
+      </component>
+      <grid id="b7518" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="1" column="0" row-span="2" col-span="6" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false">
+            <preferred-size width="209" height="48"/>
+          </grid>
         </constraints>
         <properties/>
         <border type="none"/>
@@ -36,7 +46,9 @@
           </component>
           <component id="1885f" class="com.fwdekker.randomness.ui.JIntSpinner" binding="minLength" custom-create="true">
             <constraints>
-              <grid row="0" column="1" row-span="1" col-span="5" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
+              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                <preferred-size width="405" height="10"/>
+              </grid>
             </constraints>
             <properties>
               <name value="minLength" noi18n="true"/>
@@ -44,7 +56,9 @@
           </component>
           <component id="ae252" class="com.fwdekker.randomness.ui.JIntSpinner" binding="maxLength" custom-create="true">
             <constraints>
-              <grid row="1" column="1" row-span="1" col-span="5" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
+              <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                <preferred-size width="405" height="10"/>
+              </grid>
             </constraints>
             <properties>
               <name value="maxLength" noi18n="true"/>
@@ -54,7 +68,7 @@
       </grid>
       <vspacer id="da0c5">
         <constraints>
-          <grid row="3" column="0" row-span="1" col-span="6" vsize-policy="0" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
+          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
             <preferred-size width="-1" height="15"/>
           </grid>
         </constraints>
@@ -62,7 +76,7 @@
       <grid id="69997" layout-manager="GridLayoutManager" row-count="2" column-count="6" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="4" column="0" row-span="2" col-span="6" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
@@ -164,7 +178,7 @@
       </grid>
       <vspacer id="b761">
         <constraints>
-          <grid row="6" column="0" row-span="1" col-span="6" vsize-policy="0" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
+          <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
             <preferred-size width="-1" height="15"/>
           </grid>
         </constraints>
@@ -172,7 +186,9 @@
       <grid id="bc372" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="7" column="0" row-span="4" col-span="6" vsize-policy="7" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="7" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false">
+            <preferred-size width="28" height="108"/>
+          </grid>
         </constraints>
         <properties/>
         <border type="none"/>
@@ -197,7 +213,7 @@
       </grid>
       <vspacer id="d0ce2">
         <constraints>
-          <grid row="11" column="0" row-span="1" col-span="6" vsize-policy="0" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
+          <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
             <preferred-size width="-1" height="15"/>
           </grid>
         </constraints>
@@ -205,7 +221,7 @@
       <grid id="30409" binding="previewPanel" custom-create="true" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="12" column="0" row-span="1" col-span="6" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="7" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
@@ -213,15 +229,9 @@
       </grid>
       <vspacer id="8021d">
         <constraints>
-          <grid row="13" column="0" row-span="2" col-span="6" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="8" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
-      <component id="f6838" class="com.fwdekker.randomness.SchemesPanel" binding="schemesPanel" custom-create="true">
-        <constraints>
-          <grid row="0" column="0" row-span="1" col-span="6" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties/>
-      </component>
     </children>
   </grid>
   <buttonGroups>

--- a/src/main/kotlin/com/fwdekker/randomness/ui/PreviewPanel.form
+++ b/src/main/kotlin/com/fwdekker/randomness/ui/PreviewPanel.form
@@ -22,7 +22,9 @@
         <properties>
           <editable value="false"/>
           <lineWrap value="true"/>
+          <name value="previewLabel"/>
           <opaque value="false"/>
+          <text resource-bundle="randomness" key="settings.placeholder"/>
           <wrapStyleWord value="true"/>
         </properties>
       </component>

--- a/src/main/kotlin/com/fwdekker/randomness/ui/PreviewPanel.form
+++ b/src/main/kotlin/com/fwdekker/randomness/ui/PreviewPanel.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.fwdekker.randomness.ui.PreviewPanel">
-  <grid id="27dc6" binding="rootPane" layout-manager="GridLayoutManager" row-count="2" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="rootPane" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="500" height="400"/>
@@ -8,35 +8,38 @@
     <properties/>
     <border type="none"/>
     <children>
-      <component id="f0d8f" class="javax.swing.JLabel" binding="previewLabel">
+      <component id="af32c" class="javax.swing.JComponent" binding="separator" custom-create="true">
         <constraints>
-          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="0" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+      </component>
+      <component id="3e8d3" class="javax.swing.JTextArea" binding="previewLabel">
+        <constraints>
+          <grid row="1" column="0" row-span="2" col-span="1" vsize-policy="6" hsize-policy="6" anchor="0" fill="3" indent="0" use-parent-layout="false">
+            <preferred-size width="150" height="50"/>
+          </grid>
         </constraints>
         <properties>
-          <name value="previewLabel" noi18n="true"/>
-          <text resource-bundle="randomness" key="settings.placeholder"/>
+          <editable value="false"/>
+          <lineWrap value="true"/>
+          <opaque value="false"/>
+          <wrapStyleWord value="true"/>
         </properties>
       </component>
-      <hspacer id="2196e">
-        <constraints>
-          <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
-        </constraints>
-      </hspacer>
       <component id="71601" class="javax.swing.JButton" binding="refreshButton">
         <constraints>
-          <grid row="1" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <name value="refreshButton" noi18n="true"/>
           <text resource-bundle="randomness" key="settings.refresh"/>
         </properties>
       </component>
-      <component id="af32c" class="javax.swing.JComponent" binding="separator" custom-create="true">
+      <vspacer id="62d40">
         <constraints>
-          <grid row="0" column="0" row-span="1" col-span="3" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
-        <properties/>
-      </component>
+      </vspacer>
     </children>
   </grid>
 </form>

--- a/src/main/kotlin/com/fwdekker/randomness/ui/PreviewPanel.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/ui/PreviewPanel.kt
@@ -10,10 +10,10 @@ import javax.swing.ButtonGroup
 import javax.swing.JButton
 import javax.swing.JCheckBox
 import javax.swing.JComponent
-import javax.swing.JLabel
 import javax.swing.JPanel
 import javax.swing.JRadioButton
 import javax.swing.JSpinner
+import javax.swing.JTextArea
 import kotlin.random.Random
 
 
@@ -35,7 +35,7 @@ class PreviewPanel(private val getGenerator: () -> DataInsertAction) {
     lateinit var rootPane: JPanel
     private lateinit var separator: JComponent
     private lateinit var refreshButton: JButton
-    private lateinit var previewLabel: JLabel
+    private lateinit var previewLabel: JTextArea
 
     private var seed = Random.nextInt()
 
@@ -78,13 +78,7 @@ class PreviewPanel(private val getGenerator: () -> DataInsertAction) {
     @Suppress("SwallowedException") // Alternative is to add coupling to SettingsComponent
     fun updatePreview() {
         try {
-            previewLabel.text = "" +
-                "<html>" +
-                getGenerator().also { it.random = Random(seed) }
-                    .generateString()
-                    .replace("<", "&lt;")
-                    .replace("\n", "<br>") +
-                "</html>"
+            previewLabel.text = getGenerator().also { it.random = Random(seed) }.generateString()
         } catch (e: DataGenerationException) {
             // Ignore exception; invalid settings are handled by form validation
         } catch (e: IllegalArgumentException) {

--- a/src/main/kotlin/com/fwdekker/randomness/uuid/UuidSettingsComponent.form
+++ b/src/main/kotlin/com/fwdekker/randomness/uuid/UuidSettingsComponent.form
@@ -1,19 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.fwdekker.randomness.uuid.UuidSettingsComponent">
-  <grid id="cbd77" binding="contentPane" layout-manager="GridLayoutManager" row-count="10" column-count="6" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="cbd77" binding="contentPane" layout-manager="GridLayoutManager" row-count="7" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="48" y="54" width="436" height="297"/>
+      <xy x="48" y="54" width="449" height="249"/>
     </constraints>
     <properties>
       <preferredSize width="321" height="52"/>
     </properties>
     <border type="none"/>
     <children>
+      <component id="57bff" class="com.fwdekker.randomness.SchemesPanel" binding="schemesPanel" custom-create="true">
+        <constraints>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+      </component>
       <grid id="b9dc4" layout-manager="GridLayoutManager" row-count="3" column-count="6" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="3" column="0" row-span="3" col-span="6" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
@@ -114,29 +120,15 @@
       </grid>
       <vspacer id="3773">
         <constraints>
-          <grid row="6" column="0" row-span="1" col-span="6" vsize-policy="0" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
+          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
             <preferred-size width="-1" height="15"/>
           </grid>
-        </constraints>
-      </vspacer>
-      <grid id="a78da" binding="previewPanel" custom-create="true" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
-        <margin top="0" left="0" bottom="0" right="0"/>
-        <constraints>
-          <grid row="7" column="0" row-span="1" col-span="6" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties/>
-        <border type="none"/>
-        <children/>
-      </grid>
-      <vspacer id="4d1ec">
-        <constraints>
-          <grid row="8" column="0" row-span="2" col-span="6" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
       <grid id="a88b5" layout-manager="GridLayoutManager" row-count="1" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="1" column="0" row-span="1" col-span="6" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
@@ -178,17 +170,25 @@
       </grid>
       <vspacer id="bddf0">
         <constraints>
-          <grid row="2" column="0" row-span="1" col-span="6" vsize-policy="0" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
+          <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
             <preferred-size width="-1" height="15"/>
           </grid>
         </constraints>
       </vspacer>
-      <component id="57bff" class="com.fwdekker.randomness.SchemesPanel" binding="schemesPanel" custom-create="true">
+      <grid id="a78da" binding="previewPanel" custom-create="true" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+        <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="0" column="0" row-span="1" col-span="6" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
-      </component>
+        <border type="none"/>
+        <children/>
+      </grid>
+      <vspacer id="4d1ec">
+        <constraints>
+          <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+        </constraints>
+      </vspacer>
     </children>
   </grid>
   <buttonGroups>

--- a/src/main/kotlin/com/fwdekker/randomness/word/WordSettingsComponent.form
+++ b/src/main/kotlin/com/fwdekker/randomness/word/WordSettingsComponent.form
@@ -1,17 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.fwdekker.randomness.word.WordSettingsComponent">
-  <grid id="27dc6" binding="contentPane" layout-manager="GridLayoutManager" row-count="13" column-count="11" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="contentPane" layout-manager="GridLayoutManager" row-count="9" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="742" height="400"/>
+      <xy x="20" y="20" width="757" height="315"/>
     </constraints>
     <properties/>
     <border type="none"/>
     <children>
-      <grid id="1bc78" layout-manager="GridLayoutManager" row-count="2" column-count="11" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <component id="ad466" class="com.fwdekker.randomness.SchemesPanel" binding="schemesPanel" custom-create="true">
+        <constraints>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+      </component>
+      <grid id="1bc78" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="1" column="0" row-span="2" col-span="11" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
@@ -27,7 +33,7 @@
           </component>
           <component id="8a66f" class="com.fwdekker.randomness.ui.JIntSpinner" binding="minLength" custom-create="true">
             <constraints>
-              <grid row="0" column="1" row-span="1" col-span="10" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
+              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <name value="minLength" noi18n="true"/>
@@ -44,7 +50,7 @@
           </component>
           <component id="2e2f" class="com.fwdekker.randomness.ui.JIntSpinner" binding="maxLength" custom-create="true">
             <constraints>
-              <grid row="1" column="1" row-span="1" col-span="10" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
+              <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <name value="maxLength" noi18n="true"/>
@@ -54,15 +60,15 @@
       </grid>
       <vspacer id="42a4c">
         <constraints>
-          <grid row="3" column="0" row-span="1" col-span="11" vsize-policy="0" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
+          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
             <preferred-size width="-1" height="15"/>
           </grid>
         </constraints>
       </vspacer>
-      <grid id="907d8" layout-manager="GridLayoutManager" row-count="2" column-count="11" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="907d8" layout-manager="GridLayoutManager" row-count="2" column-count="8" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="4" column="0" row-span="2" col-span="11" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
@@ -125,12 +131,14 @@
           </component>
           <hspacer id="7e6ae">
             <constraints>
-              <grid row="0" column="5" row-span="1" col-span="6" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+              <grid row="0" column="5" row-span="1" col-span="3" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
           </hspacer>
           <hspacer id="175d1">
             <constraints>
-              <grid row="1" column="7" row-span="1" col-span="4" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+              <grid row="1" column="7" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false">
+                <preferred-size width="153" height="11"/>
+              </grid>
             </constraints>
           </hspacer>
           <component id="bf7aa" class="javax.swing.JRadioButton" default-binding="true">
@@ -194,7 +202,7 @@
       </grid>
       <vspacer id="83bb5">
         <constraints>
-          <grid row="6" column="0" row-span="1" col-span="11" vsize-policy="0" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
+          <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
             <preferred-size width="-1" height="15"/>
           </grid>
         </constraints>
@@ -202,7 +210,7 @@
       <grid id="3ace5" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="7" column="0" row-span="2" col-span="11" vsize-policy="7" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="7" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
@@ -227,7 +235,7 @@
       </grid>
       <vspacer id="7cea5">
         <constraints>
-          <grid row="9" column="0" row-span="1" col-span="11" vsize-policy="0" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
+          <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
             <preferred-size width="-1" height="15"/>
           </grid>
         </constraints>
@@ -235,7 +243,7 @@
       <grid id="45b39" binding="previewPanel" custom-create="true" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="10" column="0" row-span="1" col-span="11" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="7" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
@@ -243,15 +251,9 @@
       </grid>
       <vspacer id="2126">
         <constraints>
-          <grid row="11" column="0" row-span="2" col-span="11" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="8" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
-      <component id="ad466" class="com.fwdekker.randomness.SchemesPanel" binding="schemesPanel" custom-create="true">
-        <constraints>
-          <grid row="0" column="0" row-span="1" col-span="11" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties/>
-      </component>
     </children>
   </grid>
   <buttonGroups>

--- a/src/main/resources/META-INF/change-notes.html
+++ b/src/main/resources/META-INF/change-notes.html
@@ -25,4 +25,5 @@ All settings are invalidated as of this version. Beware.
         The symbol set and dictionary tables now focus on the first editable column when a new item is added instead
         instead of the activity column.
     </li>
+    <li>Previews no longer exceed the dialog width.</li>
 </ul>

--- a/src/test/kotlin/com/fwdekker/randomness/ui/PreviewPanelTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/ui/PreviewPanelTest.kt
@@ -27,7 +27,6 @@ object PreviewPanelTest : Spek({
 
     val placeholder = ResourceBundle.getBundle("randomness").getString("settings.placeholder")
     val randomText = "random_value"
-    val randomTextHtml = "<html>$randomText</html>"
 
     lateinit var panel: PreviewPanel
     lateinit var frame: FrameFixture
@@ -43,7 +42,7 @@ object PreviewPanelTest : Spek({
         }
         frame = Containers.showInFrame(panel.rootPane)
 
-        assertThat(frame.label("previewLabel").text()).isEqualTo(placeholder)
+        assertThat(frame.textBox("previewLabel").text()).isEqualTo(placeholder)
     }
 
     afterEachTest {
@@ -55,7 +54,7 @@ object PreviewPanelTest : Spek({
         it("updates the label's contents") {
             GuiActionRunner.execute { panel.updatePreview() }
 
-            assertThat(frame.label("previewLabel").text()).isEqualTo("<html>random_value</html>")
+            assertThat(frame.textBox("previewLabel").text()).isEqualTo(randomText)
         }
     }
 
@@ -67,7 +66,7 @@ object PreviewPanelTest : Spek({
                 spinner.value = 5
             }
 
-            assertThat(frame.label("previewLabel").text()).isEqualTo(randomTextHtml)
+            assertThat(frame.textBox("previewLabel").text()).isEqualTo(randomText)
         }
 
         it("updates when a JCheckBox is updated") {
@@ -77,7 +76,7 @@ object PreviewPanelTest : Spek({
                 spinner.isSelected = true
             }
 
-            assertThat(frame.label("previewLabel").text()).isEqualTo(randomTextHtml)
+            assertThat(frame.textBox("previewLabel").text()).isEqualTo(randomText)
         }
 
         // Requires dependency on IntelliJ classes
@@ -96,7 +95,7 @@ object PreviewPanelTest : Spek({
                 table.data = listOf("a")
             }
 
-            assertThat(frame.label("previewLabel").text()).isEqualTo(randomTextHtml)
+            assertThat(frame.textBox("previewLabel").text()).isEqualTo(randomText)
         }
 
         it("updates when a group of JRadioButtons is updated") {
@@ -132,7 +131,9 @@ object PreviewPanelTest : Spek({
             GuiActionRunner.execute { panel.updatePreview() }
             val oldRandom = action?.random
 
-            frame.button("refreshButton").target().mouseListeners.forEach { it.mouseClicked(null) }
+            GuiActionRunner.execute {
+                frame.button("refreshButton").target().mouseListeners.forEach { it.mouseClicked(null) }
+            }
 
             GuiActionRunner.execute { panel.updatePreview() }
             val newRandom = action?.random


### PR DESCRIPTION
Fixes #250.

Additionally, the form files had been accumulating weird garbage from years of usages, so this PR cleans them up a bit. It removes unnecessary columns and reorders some elements in the form so that they closer correspond to what they look like.

PS: And it also fixes a bug where the default integer scheme name was `@` instead of `Default`.