### PR TITLE
Provide API v181+ compatibility hotfix

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group   = com.fwdekker
-version = 2.4.0
+version = 2.4.1
 
 kotlin.code.style = official
 

--- a/src/main/kotlin/com/fwdekker/randomness/ui/ActivityTableModelEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/ui/ActivityTableModelEditor.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonShortcuts
 import com.intellij.openapi.keymap.KeymapUtil
 import com.intellij.openapi.wm.IdeFocusManager
+import com.intellij.ui.DarculaColors
 import com.intellij.ui.SimpleTextAttributes
 import com.intellij.ui.TableUtil
 import com.intellij.ui.ToolbarDecorator
@@ -14,7 +15,6 @@ import com.intellij.util.ui.CollectionItemEditor
 import com.intellij.util.ui.ColumnInfo
 import com.intellij.util.ui.StatusText
 import com.intellij.util.ui.table.TableModelEditor
-import java.awt.Color
 import javax.swing.JPanel
 
 
@@ -106,8 +106,8 @@ abstract class ActivityTableModelEditor<T>(
             .apply { isAccessible = true }
             .get(this) as TableView<EditableDatum<T>>
 
-        // TODO (#209) Use `LINK_PLAIN_ATTRIBUTES` instead of custom `SimpleTextAttributes`
-        val style = SimpleTextAttributes(SimpleTextAttributes.STYLE_PLAIN, Color(0x589df6))
+        // TODO (#209) Use `LINK_PLAIN_ATTRIBUTES` instead of custom `SimpleTextAttributes` and hard-coded color
+        val style = SimpleTextAttributes(SimpleTextAttributes.STYLE_PLAIN, DarculaColors.BLUE)
         table.emptyText.apply {
             appendSecondaryText(emptySubText, style) {
                 model.addRow(createElement())

--- a/src/main/kotlin/com/fwdekker/randomness/ui/ActivityTableModelEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/ui/ActivityTableModelEditor.kt
@@ -12,9 +12,9 @@ import com.intellij.ui.table.TableView
 import com.intellij.util.PlatformIcons
 import com.intellij.util.ui.CollectionItemEditor
 import com.intellij.util.ui.ColumnInfo
-import com.intellij.util.ui.JBUI
 import com.intellij.util.ui.StatusText
 import com.intellij.util.ui.table.TableModelEditor
+import java.awt.Color
 import javax.swing.JPanel
 
 
@@ -107,7 +107,7 @@ abstract class ActivityTableModelEditor<T>(
             .get(this) as TableView<EditableDatum<T>>
 
         // TODO (#209) Use `LINK_PLAIN_ATTRIBUTES` instead of custom `SimpleTextAttributes`
-        val style = SimpleTextAttributes(SimpleTextAttributes.STYLE_PLAIN, JBUI.CurrentTheme.Link.linkColor())
+        val style = SimpleTextAttributes(SimpleTextAttributes.STYLE_PLAIN, Color(0x589df6))
         table.emptyText.apply {
             appendSecondaryText(emptySubText, style) {
                 model.addRow(createElement())

--- a/src/main/resources/META-INF/change-notes.html
+++ b/src/main/resources/META-INF/change-notes.html
@@ -1,4 +1,4 @@
-<b>All Randomness settings will be reset when updating to v2.4.0 because of changes in how settings are stored.</b>
+<b>All Randomness settings will be reset when updating to v2.4.1 because of changes in how settings are stored.</b>
 You can safely reconfigure Randomness after updating.<br />
 <br />
 <b>New features</b>

--- a/src/main/resources/META-INF/description.html
+++ b/src/main/resources/META-INF/description.html
@@ -3,8 +3,7 @@ Insert random numbers, strings, and UUIDs using an IntelliJ action.<br />
 To insert random data, press <kbd>Alt + R</kbd> (<kbd>⌥R</kbd>) and choose the type of data you want to insert.
 A different value will be inserted at each caret.<br />
 <br />
-<img align="right"
-     src="https://user-images.githubusercontent.com/13442533/71769827-0bb69800-2f26-11ea-9a99-caace85e922d.gif"
+<img src="https://user-images.githubusercontent.com/13442533/71769827-0bb69800-2f26-11ea-9a99-caace85e922d.gif"
      alt="Animated sample usage of Randomness." />
 
 <h2>🕸 Data Types</h2>


### PR DESCRIPTION
As per the [update details of v2.4.0](https://plugins.jetbrains.com/plugin/9836-randomness/update/75531), v2.4.0 is incompatible with IntelliJ versions below 191. This PR fixes the incompatible API usage and bumps the version to v2.4.1.