### PR TITLE
Automatic verifier

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -26,7 +26,7 @@ Steps to reproduce the behavior:
 **Version information**
  - Operating system [e.g. Windows 10, Ubuntu 18.04, macOS 10.15]:
  - Java version [e.g. 1.8.202, 11.0.4]:
- - Randomness version [e.g. 2.4.0]:
+ - Randomness version [e.g. 2.4.1]:
 
 **Additional context**
 <!-- Add any other context about the problem here. -->

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ $ gradlew test                # Run tests
 $ gradlew test --tests X      # Run tests in class X
 $ gradlew check               # Run tests and static analysis
 $ gradlew codeCoverageReport  # Run tests and calculate coverage
+$ gradlew runPluginVerifier   # Check for compatibility issues
 ```
 
 ### 📚 Documentation

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,8 @@ plugins {
     id "org.jetbrains.dokka" version "0.9.18"
 }
 
+apply from: "$rootDir/gradle/scripts/verifier.gradle"
+
 
 /// Dependencies
 repositories {
@@ -100,4 +102,10 @@ dokka {
     skipDeprecated = false
     reportUndocumented = true
     skipEmptyPackages = true
+}
+
+// Compatibility checks
+runPluginVerifier {
+    ides = new ArrayList<String>(Arrays.asList("ideaIC-2018.1", "ideaIC-2019.1", "ideaIC-2019.3"))
+    pluginFileName = "$rootProject.name-$version"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -106,6 +106,6 @@ dokka {
 
 // Compatibility checks
 runPluginVerifier {
-    ides = new ArrayList<String>(Arrays.asList("ideaIC-2018.1", "ideaIC-2019.1", "ideaIC-2019.3"))
     pluginFileName = "$rootProject.name-$version"
+    ides = ["idea-ideaIC-2018.1", "idea-ideaIC-2019.1", "idea-ideaIC-2019.3", "clion-clion-2019.3"]
 }

--- a/gradle/scripts/verifier.gradle
+++ b/gradle/scripts/verifier.gradle
@@ -1,0 +1,175 @@
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath "de.undercouch:gradle-download-task:4.0.2"
+    }
+}
+
+
+import de.undercouch.gradle.tasks.download.DownloadAction
+import org.gradle.api.internal.ConventionTask
+
+
+/**
+ * Runs the IntelliJ plugin verifier.
+ */
+class PluginVerifierRunner extends ConventionTask {
+    /**
+     * The file name to store the verifier JAR as.
+     */
+    private static final PLUGIN_VERIFIER_NAME = "verifier-all.jar"
+
+    /**
+     * The name of the plugin's distribution file, excluding the extension.
+     */
+    private String pluginFileName
+    /**
+     * The directory to store copies of the IDEs in.
+     */
+    @OutputDirectory
+    private File ideCacheDir = project.file("${project.buildDir}/ides/")
+    /**
+     * The identifiers of the IDEs to verify against.
+     */
+    private List<String> ides = new ArrayList<String>()
+    /**
+     * Whether to force this task to re-download all IDE distributions.
+     */
+    private boolean forceUpdateIdes = false
+    /**
+     * The version of the plugin verifier to use.
+     */
+    private String verifierVersion = "1.222"
+
+
+    @Input
+    String getPluginFileName() {
+        return pluginFileName
+    }
+
+    void setPluginFileName(String pluginFileName) {
+        this.pluginFileName = pluginFileName
+    }
+
+    @Input
+    File getIdeCacheDir() {
+        return ideCacheDir
+    }
+
+    void setIdeCacheDir(File target) {
+        this.ideCacheDir = target
+    }
+
+    @Input
+    List<String> getIdes() {
+        return ides
+    }
+
+    void setIdes(List<String> ides) {
+        this.ides = ides
+    }
+
+    @Input
+    boolean getForceUpdateIdes() {
+        return forceUpdateIdes
+    }
+
+    void setForceUpdateIdes(boolean forceUpdateIdes) {
+        this.forceUpdateIdes = forceUpdateIdes
+    }
+
+    @Input
+    String getVerifierVersion() {
+        return verifierVersion
+    }
+
+    void setVerifierVersion(String verifierVersion) {
+        this.verifierVersion = verifierVersion
+    }
+
+
+    /**
+     * Runs the plugin verifier.
+     */
+    @TaskAction
+    void runTaskAction() {
+        if (!project.file("${project.buildDir}/distributions/${pluginFileName}.zip").exists())
+            throw new IllegalStateException("Plugin file $pluginFileName does not exist.")
+
+        downloadVerifier()
+        this.ides.each { ide -> downloadIde(ide) }
+        runVerifier()
+    }
+
+
+    /**
+     * Downloads the verifier JAR.
+     */
+    void downloadVerifier() {
+        def url = "" +
+            "https://dl.bintray.com/jetbrains/intellij-plugin-service/org/jetbrains/intellij/" +
+            "plugins/verifier-cli/$verifierVersion/verifier-cli-$verifierVersion-all.jar"
+        new DownloadAction(project)
+            .with {
+                src(url)
+                dest(ideCacheDir.absolutePath + "/$PLUGIN_VERIFIER_NAME")
+                overwrite = false
+                tempAndMove = true
+                execute()
+            }
+    }
+
+    /**
+     * Downloads and extracts the IDE with the given identifier.
+     *
+     * @param identifier the identifier of the IDE to download
+     */
+    void downloadIde(String identifier) {
+        def (name, version) = identifier.split("-")
+        def url = "" +
+            "https://www.jetbrains.com/intellij-repository/releases/com/jetbrains/intellij/idea/" +
+            "$name/$version/${identifier}.zip"
+
+        new DownloadAction(project)
+            .with {
+                src(url)
+                dest(ideCacheDir.getAbsolutePath())
+                overwrite = forceUpdateIdes
+                tempAndMove = true
+                execute()
+            }
+
+        System.out.println("Extracting $identifier")
+        if (!project.file("$ideCacheDir/$identifier").exists() || forceUpdateIdes) {
+            project.mkdir("$ideCacheDir/$identifier")
+            project.copy {
+                duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+                from project.zipTree(project.file("$ideCacheDir/${identifier}.zip"))
+                into "$ideCacheDir/$identifier"
+            }
+        }
+    }
+
+    /**
+     * Runs the verifier JAR against the configured IDEs and plugin.
+     */
+    void runVerifier() {
+        project.javaexec {
+            classpath = project.files("$ideCacheDir.absolutePath/$PLUGIN_VERIFIER_NAME")
+            main = "com.jetbrains.pluginverifier.PluginVerifierMain"
+            args = [
+                "-runtime-dir", "/usr/lib/jvm/default-java/",
+                "-verification-reports-dir", "build/pluginVerifier",
+                "check-plugin",
+                "${project.buildDir}/distributions/${pluginFileName}.zip",
+                *ides.collect { "$ideCacheDir/$it" }
+            ]
+        }
+    }
+}
+
+
+project.tasks.create("runPluginVerifier", PluginVerifierRunner)
+    .with { it.dependsOn(project.tasks.findByName("buildPlugin")) }

--- a/gradle/scripts/verifier.gradle
+++ b/gradle/scripts/verifier.gradle
@@ -26,14 +26,14 @@ class PluginVerifierRunner extends ConventionTask {
      */
     private String pluginFileName
     /**
+     * The identifiers of the IDEs to verify against.
+     */
+    private List<String> ides = new ArrayList<String>()
+    /**
      * The directory to store copies of the IDEs in.
      */
     @OutputDirectory
     private File ideCacheDir = project.file("${project.buildDir}/ides/")
-    /**
-     * The identifiers of the IDEs to verify against.
-     */
-    private List<String> ides = new ArrayList<String>()
     /**
      * Whether to force this task to re-download all IDE distributions.
      */
@@ -54,21 +54,21 @@ class PluginVerifierRunner extends ConventionTask {
     }
 
     @Input
-    File getIdeCacheDir() {
-        return ideCacheDir
-    }
-
-    void setIdeCacheDir(File target) {
-        this.ideCacheDir = target
-    }
-
-    @Input
     List<String> getIdes() {
         return ides
     }
 
     void setIdes(List<String> ides) {
         this.ides = ides
+    }
+
+    @Input
+    File getIdeCacheDir() {
+        return ideCacheDir
+    }
+
+    void setIdeCacheDir(File target) {
+        this.ideCacheDir = target
     }
 
     @Input
@@ -124,18 +124,19 @@ class PluginVerifierRunner extends ConventionTask {
     /**
      * Downloads and extracts the IDE with the given identifier.
      *
-     * @param identifier the identifier of the IDE to download
+     * @param identifier the identifier of the IDE to download, consisting of a type, name, and version separated by a
+     * dash
      */
     void downloadIde(String identifier) {
-        def (name, version) = identifier.split("-")
+        def (type, name, version) = identifier.split("-")
         def url = "" +
-            "https://www.jetbrains.com/intellij-repository/releases/com/jetbrains/intellij/idea/" +
-            "$name/$version/${identifier}.zip"
+            "https://www.jetbrains.com/intellij-repository/releases/com/jetbrains/intellij/" +
+            "$type/$name/$version/$name-${version}.zip"
 
         new DownloadAction(project)
             .with {
                 src(url)
-                dest(ideCacheDir.getAbsolutePath())
+                dest("${ideCacheDir.getAbsolutePath()}/${identifier}.zip")
                 overwrite = forceUpdateIdes
                 tempAndMove = true
                 execute()


### PR DESCRIPTION
Fixes #261.

The implementation could certainly use some improvement because it must re-download all IDEs to check against if you run `clean`. The [Gradle IntelliJ plugin](https://github.com/JetBrains/gradle-intellij-plugin) uses the Maven cache for this. I don't think it's worthwhile trying to replicate this, so under the assumption that I'll only run this task once before every release I'm fine with it. Perhaps JetBrains/gradle-intellij-plugin#385 will be fixed one day.