### PR TITLE
Use Gradle cache for verifier IDEs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,5 +107,5 @@ dokka {
 // Compatibility checks
 runPluginVerifier {
     pluginFileName = "$rootProject.name-$version"
-    ides = ["idea-ideaIC-2018.1", "idea-ideaIC-2019.1", "idea-ideaIC-2019.3", "clion-clion-2019.3"]
+    ides = ["IC-2018.1", "IC-2019.1", "IC-2019.3", "CL-2019.3"]
 }

--- a/gradle/scripts/verifier.gradle
+++ b/gradle/scripts/verifier.gradle
@@ -7,7 +7,6 @@ buildscript {
     }
 }
 
-
 import de.undercouch.gradle.tasks.download.DownloadAction
 import org.gradle.api.internal.ConventionTask
 
@@ -17,9 +16,18 @@ import org.gradle.api.internal.ConventionTask
  */
 class PluginVerifierRunner extends ConventionTask {
     /**
+     * The directory name to be used by the plugin verifier.
+     */
+    private static final PLUGIN_VERIFIER_DIR = "pluginVerifier"
+    /**
      * The file name to store the verifier JAR as.
      */
     private static final PLUGIN_VERIFIER_NAME = "verifier-all.jar"
+
+    /**
+     * The logger to use for logging.
+     */
+    private final logger = Logging.getLogger(PluginVerifierRunner)
 
     /**
      * The name of the plugin's distribution file, excluding the extension.
@@ -29,15 +37,6 @@ class PluginVerifierRunner extends ConventionTask {
      * The identifiers of the IDEs to verify against.
      */
     private List<String> ides = new ArrayList<String>()
-    /**
-     * The directory to store copies of the IDEs in.
-     */
-    @OutputDirectory
-    private File ideCacheDir = project.file("${project.buildDir}/ides/")
-    /**
-     * Whether to force this task to re-download all IDE distributions.
-     */
-    private boolean forceUpdateIdes = false
     /**
      * The version of the plugin verifier to use.
      */
@@ -63,24 +62,6 @@ class PluginVerifierRunner extends ConventionTask {
     }
 
     @Input
-    File getIdeCacheDir() {
-        return ideCacheDir
-    }
-
-    void setIdeCacheDir(File target) {
-        this.ideCacheDir = target
-    }
-
-    @Input
-    boolean getForceUpdateIdes() {
-        return forceUpdateIdes
-    }
-
-    void setForceUpdateIdes(boolean forceUpdateIdes) {
-        this.forceUpdateIdes = forceUpdateIdes
-    }
-
-    @Input
     String getVerifierVersion() {
         return verifierVersion
     }
@@ -99,8 +80,7 @@ class PluginVerifierRunner extends ConventionTask {
             throw new IllegalStateException("Plugin file $pluginFileName does not exist.")
 
         downloadVerifier()
-        this.ides.each { ide -> downloadIde(ide) }
-        runVerifier()
+        runVerifier(ides.collect { ide -> resolveIde(ide) })
     }
 
 
@@ -111,63 +91,95 @@ class PluginVerifierRunner extends ConventionTask {
         def url = "" +
             "https://dl.bintray.com/jetbrains/intellij-plugin-service/org/jetbrains/intellij/" +
             "plugins/verifier-cli/$verifierVersion/verifier-cli-$verifierVersion-all.jar"
+
         new DownloadAction(project)
             .with {
                 src(url)
-                dest(ideCacheDir.absolutePath + "/$PLUGIN_VERIFIER_NAME")
-                overwrite = false
-                tempAndMove = true
+                dest("$project.buildDir/$PLUGIN_VERIFIER_DIR/$PLUGIN_VERIFIER_NAME")
+                overwrite(false)
                 execute()
             }
     }
 
     /**
-     * Downloads and extracts the IDE with the given identifier.
+     * Resolves the IDE with the given identifier, ensuring that it is present in the Gradle cache, and extracts the
+     * archive in the same directory if it does not already exist.
      *
-     * @param identifier the identifier of the IDE to download, consisting of a type, name, and version separated by a
-     * dash
+     * @param identifier the IDE to download, described by its identifier and version, separated by a dash
+     * @return the link to the resolved archive
      */
-    void downloadIde(String identifier) {
-        def (type, name, version) = identifier.split("-")
-        def url = "" +
-            "https://www.jetbrains.com/intellij-repository/releases/com/jetbrains/intellij/" +
-            "$type/$name/$version/$name-${version}.zip"
+    File resolveIde(String identifier) {
+        logger.lifecycle("Resolving $identifier")
+        def dependency = project.dependencies.create(identifierToDependency(identifier))
+        def configuration = project.configurations.detachedConfiguration(dependency)
+        def archive = configuration.singleFile.absolutePath
 
-        new DownloadAction(project)
-            .with {
-                src(url)
-                dest("${ideCacheDir.getAbsolutePath()}/${identifier}.zip")
-                overwrite = forceUpdateIdes
-                tempAndMove = true
-                execute()
-            }
-
-        System.out.println("Extracting $identifier")
-        if (!project.file("$ideCacheDir/$identifier").exists() || forceUpdateIdes) {
-            project.mkdir("$ideCacheDir/$identifier")
+        def extractionTarget = new File(archive.substring(0, archive.length() - ".zip".length()))
+        if (!extractionTarget.exists()) {
+            logger.lifecycle("Extracting $identifier")
             project.copy {
-                duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-                from project.zipTree(project.file("$ideCacheDir/${identifier}.zip"))
-                into "$ideCacheDir/$identifier"
+                from project.zipTree(archive)
+                into extractionTarget
             }
         }
+        return extractionTarget
     }
 
     /**
      * Runs the verifier JAR against the configured IDEs and plugin.
+     *
+     * @param ides the locations of the IDEs to give to the verifier
      */
-    void runVerifier() {
+    void runVerifier(List<File> ides) {
         project.javaexec {
-            classpath = project.files("$ideCacheDir.absolutePath/$PLUGIN_VERIFIER_NAME")
+            classpath = project.files("$project.buildDir/$PLUGIN_VERIFIER_DIR/$PLUGIN_VERIFIER_NAME")
             main = "com.jetbrains.pluginverifier.PluginVerifierMain"
             args = [
-                "-runtime-dir", "/usr/lib/jvm/default-java/",
-                "-verification-reports-dir", "build/pluginVerifier",
+                "-verification-reports-dir", "build/$PLUGIN_VERIFIER_DIR/reports",
                 "check-plugin",
                 "${project.buildDir}/distributions/${pluginFileName}.zip",
-                *ides.collect { "$ideCacheDir/$it" }
+                *(ides*.absolutePath)
             ]
         }
+    }
+
+
+    /**
+     * Translates a user-friendly identifier to a Maven-style dependency.
+     *
+     * @param identifier the user-friendly identifier
+     * @return a Maven-style dependency
+     * @throws IllegalArgumentException if the identifier was not recognized
+     */
+    static String identifierToDependency(String identifier) {
+        def (type, version) = identifier.split("-")
+
+        def dependencyGroup
+        def dependencyName
+        switch (type) {
+            case "IC":
+            case "IU":
+                dependencyGroup = "com.jetbrains.intellij.idea"
+                dependencyName = "idea$type"
+                break
+            case "CL":
+                dependencyGroup = "com.jetbrains.intellij.clion"
+                dependencyName = "clion"
+                break
+            case "PC":
+            case "PY":
+                dependencyGroup = "com.jetbrains.intellij.pycharm"
+                dependencyName = "pycharm$type"
+                break
+            case "RD":
+                dependencyGroup = "com.jetbrains.intellij.rider"
+                dependencyName = "riderRD"
+                break
+            default:
+                throw new IllegalArgumentException("Unknown IDE type `$type`.")
+        }
+
+        return "$dependencyGroup:$dependencyName:$version"
     }
 }
 


### PR DESCRIPTION
Improves upon #262 by storing the IDEs in the Gradle cache.