### PR TITLE
Fix issues surrounding dialog sizes

### DIFF
--- a/src/main/kotlin/com/fwdekker/randomness/array/ArraySettingsComponent.form
+++ b/src/main/kotlin/com/fwdekker/randomness/array/ArraySettingsComponent.form
@@ -10,7 +10,7 @@
     <children>
       <component id="1f193" class="com.fwdekker.randomness.SchemesPanel" binding="schemesPanel" custom-create="true">
         <constraints>
-          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
       </component>
@@ -33,7 +33,7 @@
           </component>
           <component id="38ced" class="com.fwdekker.randomness.ui.JIntSpinner" binding="countSpinner" custom-create="true">
             <constraints>
-              <grid row="0" column="1" row-span="1" col-span="5" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
+              <grid row="0" column="1" row-span="1" col-span="5" vsize-policy="3" hsize-policy="3" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <name value="count" noi18n="true"/>

--- a/src/main/kotlin/com/fwdekker/randomness/integer/IntegerSettingsComponent.form
+++ b/src/main/kotlin/com/fwdekker/randomness/integer/IntegerSettingsComponent.form
@@ -10,7 +10,7 @@
     <children>
       <component id="36036" class="com.fwdekker.randomness.SchemesPanel" binding="schemesPanel" custom-create="true">
         <constraints>
-          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
       </component>
@@ -42,7 +42,7 @@
           </component>
           <component id="44ac7" class="com.fwdekker.randomness.ui.JLongSpinner" binding="minValue" custom-create="true">
             <constraints>
-              <grid row="0" column="1" row-span="1" col-span="5" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
+              <grid row="0" column="1" row-span="1" col-span="5" vsize-policy="3" hsize-policy="3" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <name value="minValue" noi18n="true"/>
@@ -50,7 +50,7 @@
           </component>
           <component id="b9000" class="com.fwdekker.randomness.ui.JLongSpinner" binding="maxValue" custom-create="true">
             <constraints>
-              <grid row="1" column="1" row-span="1" col-span="5" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
+              <grid row="1" column="1" row-span="1" col-span="5" vsize-policy="3" hsize-policy="3" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <name value="maxValue" noi18n="true"/>

--- a/src/main/kotlin/com/fwdekker/randomness/string/StringSettingsComponent.form
+++ b/src/main/kotlin/com/fwdekker/randomness/string/StringSettingsComponent.form
@@ -3,25 +3,21 @@
   <grid id="cbd77" binding="contentPane" layout-manager="GridLayoutManager" row-count="9" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="48" y="54" width="518" height="316"/>
+      <xy x="48" y="54" width="531" height="316"/>
     </constraints>
     <properties/>
     <border type="none"/>
     <children>
       <component id="f6838" class="com.fwdekker.randomness.SchemesPanel" binding="schemesPanel" custom-create="true">
         <constraints>
-          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false">
-            <preferred-size width="10" height="21"/>
-          </grid>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
       </component>
       <grid id="b7518" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false">
-            <preferred-size width="209" height="48"/>
-          </grid>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
@@ -46,9 +42,7 @@
           </component>
           <component id="1885f" class="com.fwdekker.randomness.ui.JIntSpinner" binding="minLength" custom-create="true">
             <constraints>
-              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
-                <preferred-size width="405" height="10"/>
-              </grid>
+              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <name value="minLength" noi18n="true"/>
@@ -56,9 +50,7 @@
           </component>
           <component id="ae252" class="com.fwdekker.randomness.ui.JIntSpinner" binding="maxLength" custom-create="true">
             <constraints>
-              <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
-                <preferred-size width="405" height="10"/>
-              </grid>
+              <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <name value="maxLength" noi18n="true"/>
@@ -186,16 +178,14 @@
       <grid id="bc372" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="7" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false">
-            <preferred-size width="28" height="108"/>
-          </grid>
+          <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="7" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
         <children>
           <component id="2c95a" class="javax.swing.JComponent" binding="symbolSetSeparator" custom-create="true">
             <constraints>
-              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
           </component>
           <grid id="90e" binding="symbolSetPanel" custom-create="true" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">

--- a/src/main/kotlin/com/fwdekker/randomness/ui/PreviewPanel.form
+++ b/src/main/kotlin/com/fwdekker/randomness/ui/PreviewPanel.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.fwdekker.randomness.ui.PreviewPanel">
-  <grid id="27dc6" binding="rootPane" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="rootPane" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="500" height="400"/>
@@ -10,19 +10,20 @@
     <children>
       <component id="af32c" class="javax.swing.JComponent" binding="separator" custom-create="true">
         <constraints>
-          <grid row="0" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="0" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
       </component>
       <component id="3e8d3" class="javax.swing.JTextArea" binding="previewLabel">
         <constraints>
-          <grid row="1" column="0" row-span="2" col-span="1" vsize-policy="6" hsize-policy="6" anchor="0" fill="3" indent="0" use-parent-layout="false">
-            <preferred-size width="150" height="50"/>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="6" anchor="0" fill="3" indent="0" use-parent-layout="false">
+            <minimum-size width="1" height="-1"/>
+            <preferred-size width="1" height="-1"/>
           </grid>
         </constraints>
         <properties>
           <editable value="false"/>
           <lineWrap value="true"/>
-          <name value="previewLabel"/>
+          <name value="previewLabel" noi18n="true"/>
           <opaque value="false"/>
           <text resource-bundle="randomness" key="settings.placeholder"/>
           <wrapStyleWord value="true"/>
@@ -30,18 +31,13 @@
       </component>
       <component id="71601" class="javax.swing.JButton" binding="refreshButton">
         <constraints>
-          <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="1" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <name value="refreshButton" noi18n="true"/>
           <text resource-bundle="randomness" key="settings.refresh"/>
         </properties>
       </component>
-      <vspacer id="62d40">
-        <constraints>
-          <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
-        </constraints>
-      </vspacer>
     </children>
   </grid>
 </form>

--- a/src/main/kotlin/com/fwdekker/randomness/uuid/UuidSettingsComponent.form
+++ b/src/main/kotlin/com/fwdekker/randomness/uuid/UuidSettingsComponent.form
@@ -12,7 +12,7 @@
     <children>
       <component id="57bff" class="com.fwdekker.randomness.SchemesPanel" binding="schemesPanel" custom-create="true">
         <constraints>
-          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
       </component>

--- a/src/main/kotlin/com/fwdekker/randomness/word/WordSettingsComponent.form
+++ b/src/main/kotlin/com/fwdekker/randomness/word/WordSettingsComponent.form
@@ -3,14 +3,14 @@
   <grid id="27dc6" binding="contentPane" layout-manager="GridLayoutManager" row-count="9" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="757" height="315"/>
+      <xy x="20" y="20" width="815" height="315"/>
     </constraints>
     <properties/>
     <border type="none"/>
     <children>
       <component id="ad466" class="com.fwdekker.randomness.SchemesPanel" binding="schemesPanel" custom-create="true">
         <constraints>
-          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
       </component>
@@ -33,7 +33,7 @@
           </component>
           <component id="8a66f" class="com.fwdekker.randomness.ui.JIntSpinner" binding="minLength" custom-create="true">
             <constraints>
-              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
+              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <name value="minLength" noi18n="true"/>
@@ -50,7 +50,7 @@
           </component>
           <component id="2e2f" class="com.fwdekker.randomness.ui.JIntSpinner" binding="maxLength" custom-create="true">
             <constraints>
-              <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
+              <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <name value="maxLength" noi18n="true"/>
@@ -136,9 +136,7 @@
           </hspacer>
           <hspacer id="175d1">
             <constraints>
-              <grid row="1" column="7" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false">
-                <preferred-size width="153" height="11"/>
-              </grid>
+              <grid row="1" column="7" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
           </hspacer>
           <component id="bf7aa" class="javax.swing.JRadioButton" default-binding="true">
@@ -217,7 +215,7 @@
         <children>
           <component id="c2838" class="javax.swing.JComponent" binding="dictionarySeparator" custom-create="true">
             <constraints>
-              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
           </component>
           <grid id="11d1" binding="dictionaryPanel" custom-create="true" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">

--- a/src/main/resources/META-INF/change-notes.html
+++ b/src/main/resources/META-INF/change-notes.html
@@ -1,49 +1,11 @@
-<b>All Randomness settings will be reset when updating to v2.4.1 because of changes in how settings are stored.</b>
-You can safely reconfigure Randomness after updating.<br />
-<br />
 <b>New features</b>
 <ul>
-    <li>
-        <b>🗃️ Schemes</b>.
-        Save your Randomness configurations using schemes.
-        Simply create some new schemes to your liking, and you can change back and forth between your schemes without
-        any typing.
-    </li>
-    <li>
-        <b>🖼️ Icons</b>.
-        In addition to Randomness' new logo, all Randomness actions can now be identified by their unique icons.
-    </li>
-    <li>
-        <b>♻️ Repeat</b>.
-        Hold <kbd>Alt</kbd> (<kbd>⌥</kbd>) while selecting a data type to insert will insert the same value at all
-        <a href="https://www.jetbrains.com/help/idea/working-with-source-code.html#multiple_cursor">carets</a>.
-        Like all other Randomness actions, the repeat action can be assigned a shortcut if you want.
-    </li>
-    <li>
-        <b>⌨️ Modifier keys</b>.
-        Hold multiple modifier keys (<kbd>Alt</kbd>, <kbd>Ctrl</kbd>, <kbd>Shift</kbd>) to combine their effects.
-        For example, hold <kbd>Ctrl + Shift</kbd> to change the array settings, or hold <kbd>Alt + Shift</kbd> to insert
-        repeated arrays.
-    </li>
-    <li>
-        <b>📏 Expandable fields</b>.
-        View large symbol sets in a single glance using expandable text fields.
-        No more horizontal scrolling back and forth.
-    </li>
-    <li>Empty tables now contain clickable links for adding new values.</li>
-    <li>Array previews now contain multiple random numbers instead of repeating the number 17.</li>
-    <li>Groups of settings are separated by horizontal lines instead of being surrounded by borders.</li>
+    ...
 </ul>
 
 <b>Fixes</b>
 <ul>
-    <li>The Randomness popup now appears at your caret instead of in the middle of the screen.</li>
-    <li>The Randomness popup no longer appears when the editor isn't selected.</li>
-    <li>The Randomness popup is now wide enough to display the full header text.</li>
-    <li>Invalid number inputs result in preciser error messages.</li>
-    <li>Previews that exceed the dialog width now wrap around.</li>
-    <li>
-        Adding a new symbol set or dictionary will move focus to the first editable column so you can start typing right
-        away.
-    </li>
+    <li>Inputs now correctly resize when shrinking the dialog.</li>
+    <li>Symbol set table now makes full use of vertical space.</li>
+    <li>Dictionary table no longer exceeds dialog width.</li>
 </ul>


### PR DESCRIPTION
Fixes #264. Fixes #265. Fixes #266.

* For some reason many of the GUI forms specified unnecessary preferred sizes for components, forcing them to a certain width even if that didn't make sense. In the words dialog, this caused the panel to be wider than the dialog, making the dictionary table think it had more space to expand into than it actually did.
* In the string dialog, the table wasn't configured to want to grow, and as a result it didn't make optimal use of the vertical space.
* In the preview panel (and thus in all settings dialogs), the textarea automatically changed its minimum width every time the dialog resized. By setting an explicit minimum and preferred width of 0, this behaviour stopped. ([Thanks, Datoraki.](https://stackoverflow.com/a/6022219/))