### PR TITLE
Activity table tab

### DIFF
--- a/src/main/kotlin/com/fwdekker/randomness/ui/ActivityTableModelEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/ui/ActivityTableModelEditor.kt
@@ -120,6 +120,10 @@ abstract class ActivityTableModelEditor<T>(
             .apply { isAccessible = true }
             .let { it.get(this) as ToolbarDecorator }
             .setAddAction { addItem(table) }
+            .setEditAction {
+                if (table.selectedObject != null)
+                    table.editCellAt(table.selectedRow, table.selectedColumn)
+            }
             .addExtraAction(object :
                 ToolbarDecorator.ElementActionButton(IdeBundle.message("button.copy"), PlatformIcons.COPY_ICON) {
                 // Implementation based on `TableModelEditor#createComponent`


### PR DESCRIPTION
Fixes #270, with a compromise. Instead of directly opening that cell's editor, the user must press <kbd>Enter</kbd> before they can edit the cell. Editing can be stopped by pressing the <kbd>Esc</kbd> key.