### PR TITLE
Migrate to Spek 2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,8 +31,8 @@ dependencies {
     testImplementation group: "com.nhaarman.mockitokotlin2", name: "mockito-kotlin", version: mockitoKotlinVersion
     testImplementation group: "org.assertj", name: "assertj-core", version: assertjVersion
     testImplementation group: "org.assertj", name: "assertj-swing-junit", version: assertjSwingVersion
-    testImplementation group: "org.jetbrains.spek", name: "spek-api", version: spekVersion
-    testImplementation group: "org.jetbrains.spek", name: "spek-junit-platform-engine", version: spekVersion
+    testImplementation group: "org.spekframework.spek2", name: "spek-dsl-jvm", version: spekVersion
+    testRuntimeOnly group: "org.spekframework.spek2", name: "spek-runner-junit5", version: spekVersion
     testImplementation group: "org.junit.platform", name: "junit-platform-runner", version: junitRunnerVersion
     testImplementation group: "org.junit.jupiter", name: "junit-jupiter-api", version: junitVersion
     testImplementation group: "org.junit.jupiter", name: "junit-jupiter-engine", version: junitVersion
@@ -65,7 +65,7 @@ patchPluginXml {
 // Tests/coverage
 test {
     useJUnitPlatform {
-        includeEngines "junit-vintage", "junit-jupiter", "spek"
+        includeEngines "junit-vintage", "junit-jupiter", "spek2"
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,5 +10,5 @@ intellijVersion       = 2019.3
 junitVersion          = 5.5.2
 junitRunnerVersion    = 1.5.2
 mockitoKotlinVersion  = 2.2.0
-spekVersion           = 1.1.5
+spekVersion           = 2.0.9
 uuidGeneratorVersion  = 3.2.0

--- a/src/main/kotlin/com/fwdekker/randomness/CapitalizationMode.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/CapitalizationMode.kt
@@ -1,7 +1,6 @@
 package com.fwdekker.randomness
 
 import java.util.Locale
-import java.util.NoSuchElementException
 
 
 /**
@@ -54,7 +53,7 @@ enum class CapitalizationMode(val descriptor: String, val transform: (String) ->
          */
         fun getMode(descriptor: String) =
             values().firstOrNull { it.descriptor == descriptor }
-                ?: throw NoSuchElementException("There does not exist a capitalization mode with name `$descriptor`.")
+                ?: throw IllegalArgumentException("There does not exist a capitalization mode with name `$descriptor`.")
 
         /**
          * Randomly converts this character to uppercase or lowercase.

--- a/src/test/kotlin/com/fwdekker/randomness/CacheTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/CacheTest.kt
@@ -1,9 +1,8 @@
 package com.fwdekker.randomness
 
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 
 /**

--- a/src/test/kotlin/com/fwdekker/randomness/CapitalizationModeTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/CapitalizationModeTest.kt
@@ -2,10 +2,8 @@ package com.fwdekker.randomness
 
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
-import java.util.NoSuchElementException
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 
 /**
@@ -75,7 +73,7 @@ object CapitalizationModeTest : Spek({
 
         it("throws an exception if the descriptor is not recognized") {
             assertThatThrownBy { CapitalizationMode.getMode("") }
-                .isInstanceOf(NoSuchElementException::class.java)
+                .isInstanceOf(IllegalArgumentException::class.java)
                 .hasMessage("There does not exist a capitalization mode with name ``.")
                 .hasNoCause()
         }

--- a/src/test/kotlin/com/fwdekker/randomness/DataInsertActionTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/DataInsertActionTest.kt
@@ -9,9 +9,8 @@ import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 
 /**

--- a/src/test/kotlin/com/fwdekker/randomness/SettingsComponentTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/SettingsComponentTest.kt
@@ -10,9 +10,8 @@ import org.assertj.swing.edt.FailOnThreadViolationRepaintManager
 import org.assertj.swing.edt.GuiActionRunner
 import org.assertj.swing.fixture.Containers
 import org.assertj.swing.fixture.FrameFixture
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 
 /**

--- a/src/test/kotlin/com/fwdekker/randomness/SettingsConfigurableTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/SettingsConfigurableTest.kt
@@ -9,9 +9,8 @@ import org.assertj.swing.edt.FailOnThreadViolationRepaintManager
 import org.assertj.swing.edt.GuiActionRunner
 import org.assertj.swing.fixture.Containers
 import org.assertj.swing.fixture.FrameFixture
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 
 /**
@@ -47,8 +46,10 @@ object SettingsConfigurableTest : Spek({
     }
 
 
-    it("returns the correct display name") {
-        assertThat(settingsComponentConfigurable.displayName).isEqualTo("Dummy")
+    describe("display name") {
+        it("returns the correct display name") {
+            assertThat(settingsComponentConfigurable.displayName).isEqualTo("Dummy")
+        }
     }
 
     describe("saving modifications") {

--- a/src/test/kotlin/com/fwdekker/randomness/array/ArraySettingsComponentTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/array/ArraySettingsComponentTest.kt
@@ -7,9 +7,8 @@ import org.assertj.swing.edt.FailOnThreadViolationRepaintManager
 import org.assertj.swing.edt.GuiActionRunner
 import org.assertj.swing.fixture.Containers.showInFrame
 import org.assertj.swing.fixture.FrameFixture
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 
 /**

--- a/src/test/kotlin/com/fwdekker/randomness/array/ArraySettingsTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/array/ArraySettingsTest.kt
@@ -1,9 +1,8 @@
 package com.fwdekker.randomness.array
 
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 
 /**
@@ -18,27 +17,29 @@ object ArraySettingsTest : Spek({
     }
 
 
-    it("creates an independent copy") {
-        val copy = arraySettings.deepCopy()
-        arraySettings.currentScheme.count = 44
-        copy.currentScheme.count = 15
+    describe("copying") {
+        it("creates an independent copy") {
+            val copy = arraySettings.deepCopy()
+            arraySettings.currentScheme.count = 44
+            copy.currentScheme.count = 15
 
-        assertThat(arraySettings.currentScheme.count).isEqualTo(44)
-    }
+            assertThat(arraySettings.currentScheme.count).isEqualTo(44)
+        }
 
-    it("copies state from another instance") {
-        arraySettings.currentScheme.count = 997
-        arraySettings.currentScheme.brackets = "0fWx<i6jTJ"
-        arraySettings.currentScheme.separator = "f3hu)Rxiz1"
-        arraySettings.currentScheme.isSpaceAfterSeparator = false
+        it("copies state from another instance") {
+            arraySettings.currentScheme.count = 997
+            arraySettings.currentScheme.brackets = "0fWx<i6jTJ"
+            arraySettings.currentScheme.separator = "f3hu)Rxiz1"
+            arraySettings.currentScheme.isSpaceAfterSeparator = false
 
-        val newArraySettings = ArraySettings()
-        newArraySettings.loadState(arraySettings.state)
+            val newArraySettings = ArraySettings()
+            newArraySettings.loadState(arraySettings.state)
 
-        assertThat(newArraySettings.currentScheme.count).isEqualTo(997)
-        assertThat(newArraySettings.currentScheme.brackets).isEqualTo("0fWx<i6jTJ")
-        assertThat(newArraySettings.currentScheme.separator).isEqualTo("f3hu)Rxiz1")
-        assertThat(newArraySettings.currentScheme.isSpaceAfterSeparator).isEqualTo(false)
+            assertThat(newArraySettings.currentScheme.count).isEqualTo(997)
+            assertThat(newArraySettings.currentScheme.brackets).isEqualTo("0fWx<i6jTJ")
+            assertThat(newArraySettings.currentScheme.separator).isEqualTo("f3hu)Rxiz1")
+            assertThat(newArraySettings.currentScheme.isSpaceAfterSeparator).isEqualTo(false)
+        }
     }
 })
 

--- a/src/test/kotlin/com/fwdekker/randomness/array/DataInsertArrayActionTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/array/DataInsertArrayActionTest.kt
@@ -4,8 +4,8 @@ import com.fwdekker.randomness.DataGenerationException
 import com.fwdekker.randomness.DummyInsertArrayAction
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 
 /**
@@ -15,23 +15,25 @@ object DataInsertArrayActionTest : Spek({
     val randomValue = "random_value"
 
 
-    it("throws an exception if the count is empty") {
-        val action = DummyInsertArrayAction(ArrayScheme(count = 0)) { randomValue }
-        assertThatThrownBy { action.generateString() }
-            .isInstanceOf(DataGenerationException::class.java)
-            .hasMessage("Array cannot have fewer than 1 element.")
-    }
+    describe("generateString") {
+        it("throws an exception if the count is empty") {
+            val action = DummyInsertArrayAction(ArrayScheme(count = 0)) { randomValue }
+            assertThatThrownBy { action.generateString() }
+                .isInstanceOf(DataGenerationException::class.java)
+                .hasMessage("Array cannot have fewer than 1 element.")
+        }
 
-    it("throws an exception if the count is negative") {
-        val action = DummyInsertArrayAction(ArrayScheme(count = -3)) { randomValue }
-        assertThatThrownBy { action.generateString() }
-            .isInstanceOf(DataGenerationException::class.java)
-            .hasMessage("Array cannot have fewer than 1 element.")
-    }
+        it("throws an exception if the count is negative") {
+            val action = DummyInsertArrayAction(ArrayScheme(count = -3)) { randomValue }
+            assertThatThrownBy { action.generateString() }
+                .isInstanceOf(DataGenerationException::class.java)
+                .hasMessage("Array cannot have fewer than 1 element.")
+        }
 
-    it("chunks the values according to the settings") {
-        val randomArray = "[$randomValue, $randomValue]"
-        assertThat(DummyInsertArrayAction(ArrayScheme(count = 2)) { randomValue }.generateStrings(4))
-            .containsExactly(randomArray, randomArray, randomArray, randomArray)
+        it("chunks the values according to the settings") {
+            val randomArray = "[$randomValue, $randomValue]"
+            assertThat(DummyInsertArrayAction(ArrayScheme(count = 2)) { randomValue }.generateStrings(4))
+                .containsExactly(randomArray, randomArray, randomArray, randomArray)
+        }
     }
 })

--- a/src/test/kotlin/com/fwdekker/randomness/decimal/DecimalSettingsComponentTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/decimal/DecimalSettingsComponentTest.kt
@@ -7,9 +7,8 @@ import org.assertj.swing.edt.FailOnThreadViolationRepaintManager
 import org.assertj.swing.edt.GuiActionRunner
 import org.assertj.swing.fixture.Containers.showInFrame
 import org.assertj.swing.fixture.FrameFixture
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 
 /**

--- a/src/test/kotlin/com/fwdekker/randomness/decimal/DecimalSettingsTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/decimal/DecimalSettingsTest.kt
@@ -1,9 +1,8 @@
 package com.fwdekker.randomness.decimal
 
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 
 /**
@@ -18,31 +17,33 @@ object DecimalSettingsTest : Spek({
     }
 
 
-    it("creates an independent copy") {
-        val copy = decimalSettings.deepCopy()
-        decimalSettings.currentScheme.minValue = 613.24
-        copy.currentScheme.minValue = 10.21
+    describe("copying") {
+        it("creates an independent copy") {
+            val copy = decimalSettings.deepCopy()
+            decimalSettings.currentScheme.minValue = 613.24
+            copy.currentScheme.minValue = 10.21
 
-        assertThat(decimalSettings.currentScheme.minValue).isEqualTo(613.24)
-    }
+            assertThat(decimalSettings.currentScheme.minValue).isEqualTo(613.24)
+        }
 
-    it("copies state from another instance") {
-        decimalSettings.currentScheme.minValue = 399.75
-        decimalSettings.currentScheme.maxValue = 928.22
-        decimalSettings.currentScheme.decimalCount = 205
-        decimalSettings.currentScheme.showTrailingZeroes = false
-        decimalSettings.currentScheme.groupingSeparator = "a"
-        decimalSettings.currentScheme.decimalSeparator = "D"
+        it("copies state from another instance") {
+            decimalSettings.currentScheme.minValue = 399.75
+            decimalSettings.currentScheme.maxValue = 928.22
+            decimalSettings.currentScheme.decimalCount = 205
+            decimalSettings.currentScheme.showTrailingZeroes = false
+            decimalSettings.currentScheme.groupingSeparator = "a"
+            decimalSettings.currentScheme.decimalSeparator = "D"
 
-        val newDecimalSettings = DecimalSettings()
-        newDecimalSettings.loadState(decimalSettings.state)
+            val newDecimalSettings = DecimalSettings()
+            newDecimalSettings.loadState(decimalSettings.state)
 
-        assertThat(newDecimalSettings.currentScheme.minValue).isEqualTo(399.75)
-        assertThat(newDecimalSettings.currentScheme.maxValue).isEqualTo(928.22)
-        assertThat(newDecimalSettings.currentScheme.decimalCount).isEqualTo(205)
-        assertThat(newDecimalSettings.currentScheme.showTrailingZeroes).isEqualTo(false)
-        assertThat(newDecimalSettings.currentScheme.groupingSeparator).isEqualTo("a")
-        assertThat(newDecimalSettings.currentScheme.decimalSeparator).isEqualTo("D")
+            assertThat(newDecimalSettings.currentScheme.minValue).isEqualTo(399.75)
+            assertThat(newDecimalSettings.currentScheme.maxValue).isEqualTo(928.22)
+            assertThat(newDecimalSettings.currentScheme.decimalCount).isEqualTo(205)
+            assertThat(newDecimalSettings.currentScheme.showTrailingZeroes).isEqualTo(false)
+            assertThat(newDecimalSettings.currentScheme.groupingSeparator).isEqualTo("a")
+            assertThat(newDecimalSettings.currentScheme.decimalSeparator).isEqualTo("D")
+        }
     }
 })
 

--- a/src/test/kotlin/com/fwdekker/randomness/integer/IntegerSettingsComponentTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/integer/IntegerSettingsComponentTest.kt
@@ -7,9 +7,8 @@ import org.assertj.swing.edt.FailOnThreadViolationRepaintManager
 import org.assertj.swing.edt.GuiActionRunner
 import org.assertj.swing.fixture.Containers.showInFrame
 import org.assertj.swing.fixture.FrameFixture
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 
 /**

--- a/src/test/kotlin/com/fwdekker/randomness/integer/IntegerSettingsTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/integer/IntegerSettingsTest.kt
@@ -1,9 +1,8 @@
 package com.fwdekker.randomness.integer
 
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 
 /**
@@ -18,25 +17,27 @@ object IntegerSettingsTest : Spek({
     }
 
 
-    it("creates an independent copy") {
-        val copy = integerSettings.deepCopy()
-        integerSettings.currentScheme.minValue = 159
-        copy.currentScheme.minValue = 48
+    describe("copying") {
+        it("creates an independent copy") {
+            val copy = integerSettings.deepCopy()
+            integerSettings.currentScheme.minValue = 159
+            copy.currentScheme.minValue = 48
 
-        assertThat(integerSettings.currentScheme.minValue).isEqualTo(159)
-    }
+            assertThat(integerSettings.currentScheme.minValue).isEqualTo(159)
+        }
 
-    it("copies state from another instance") {
-        integerSettings.currentScheme.minValue = 742
-        integerSettings.currentScheme.maxValue = 908
-        integerSettings.currentScheme.base = 12
+        it("copies state from another instance") {
+            integerSettings.currentScheme.minValue = 742
+            integerSettings.currentScheme.maxValue = 908
+            integerSettings.currentScheme.base = 12
 
-        val newIntegerSettings = IntegerSettings()
-        newIntegerSettings.loadState(integerSettings.state)
+            val newIntegerSettings = IntegerSettings()
+            newIntegerSettings.loadState(integerSettings.state)
 
-        assertThat(newIntegerSettings.currentScheme.minValue).isEqualTo(742)
-        assertThat(newIntegerSettings.currentScheme.maxValue).isEqualTo(908)
-        assertThat(newIntegerSettings.currentScheme.base).isEqualTo(12)
+            assertThat(newIntegerSettings.currentScheme.minValue).isEqualTo(742)
+            assertThat(newIntegerSettings.currentScheme.maxValue).isEqualTo(908)
+            assertThat(newIntegerSettings.currentScheme.base).isEqualTo(12)
+        }
     }
 })
 

--- a/src/test/kotlin/com/fwdekker/randomness/string/StringSettingsComponentTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/string/StringSettingsComponentTest.kt
@@ -10,9 +10,8 @@ import org.assertj.swing.edt.FailOnThreadViolationRepaintManager
 import org.assertj.swing.edt.GuiActionRunner
 import org.assertj.swing.fixture.Containers.showInFrame
 import org.assertj.swing.fixture.FrameFixture
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 
 /**

--- a/src/test/kotlin/com/fwdekker/randomness/string/StringSettingsTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/string/StringSettingsTest.kt
@@ -1,9 +1,8 @@
 package com.fwdekker.randomness.string
 
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 
 /**

--- a/src/test/kotlin/com/fwdekker/randomness/string/SymbolSetTableTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/string/SymbolSetTableTest.kt
@@ -4,10 +4,9 @@ import com.intellij.testFramework.fixtures.IdeaTestFixture
 import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.swing.edt.GuiActionRunner
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.api.dsl.xdescribe
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import org.spekframework.spek2.style.specification.xdescribe
 
 
 /**

--- a/src/test/kotlin/com/fwdekker/randomness/string/SymbolSetTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/string/SymbolSetTest.kt
@@ -1,9 +1,8 @@
 package com.fwdekker.randomness.string
 
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 
 /**

--- a/src/test/kotlin/com/fwdekker/randomness/ui/ActivityTableModelEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/ui/ActivityTableModelEditorTest.kt
@@ -5,10 +5,9 @@ import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
 import com.intellij.util.ui.CollectionItemEditor
 import org.assertj.core.api.Assertions
 import org.assertj.swing.edt.GuiActionRunner
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.api.dsl.xdescribe
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import org.spekframework.spek2.style.specification.xdescribe
 
 
 /**

--- a/src/test/kotlin/com/fwdekker/randomness/ui/ButtonGroupKtTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/ui/ButtonGroupKtTest.kt
@@ -2,9 +2,9 @@ package com.fwdekker.randomness.ui
 
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.swing.edt.GuiActionRunner
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
 import javax.swing.ButtonGroup
 import javax.swing.JButton
 

--- a/src/test/kotlin/com/fwdekker/randomness/ui/JNumberSpinnerTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/ui/JNumberSpinnerTest.kt
@@ -3,9 +3,9 @@ package com.fwdekker.randomness.ui
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.swing.edt.GuiActionRunner
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
 import javax.swing.JSpinner
 
 

--- a/src/test/kotlin/com/fwdekker/randomness/ui/JSpinnerRangeTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/ui/JSpinnerRangeTest.kt
@@ -4,9 +4,9 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.swing.edt.FailOnThreadViolationRepaintManager
 import org.assertj.swing.edt.GuiActionRunner
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
 import javax.swing.JSpinner
 
 

--- a/src/test/kotlin/com/fwdekker/randomness/ui/PreviewPanelTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/ui/PreviewPanelTest.kt
@@ -8,10 +8,8 @@ import org.assertj.swing.edt.FailOnThreadViolationRepaintManager
 import org.assertj.swing.edt.GuiActionRunner
 import org.assertj.swing.fixture.Containers
 import org.assertj.swing.fixture.FrameFixture
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.api.dsl.xit
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 import java.util.ResourceBundle
 import javax.swing.ButtonGroup
 import javax.swing.JCheckBox

--- a/src/test/kotlin/com/fwdekker/randomness/uuid/UuidSettingsComponentTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/uuid/UuidSettingsComponentTest.kt
@@ -8,9 +8,8 @@ import org.assertj.swing.edt.FailOnThreadViolationRepaintManager
 import org.assertj.swing.edt.GuiActionRunner
 import org.assertj.swing.fixture.Containers.showInFrame
 import org.assertj.swing.fixture.FrameFixture
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 
 /**

--- a/src/test/kotlin/com/fwdekker/randomness/uuid/UuidSettingsTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/uuid/UuidSettingsTest.kt
@@ -1,11 +1,9 @@
 package com.fwdekker.randomness.uuid
 
 import com.fwdekker.randomness.CapitalizationMode
-import com.fwdekker.randomness.array.ArrayScheme
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 
 /**

--- a/src/test/kotlin/com/fwdekker/randomness/word/DictionaryTableTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/word/DictionaryTableTest.kt
@@ -6,10 +6,9 @@ import com.nhaarman.mockitokotlin2.mock
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.swing.edt.GuiActionRunner
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.api.dsl.xdescribe
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import org.spekframework.spek2.style.specification.xdescribe
 
 
 /**

--- a/src/test/kotlin/com/fwdekker/randomness/word/DictionaryTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/word/DictionaryTest.kt
@@ -3,10 +3,9 @@ package com.fwdekker.randomness.word
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatCode
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
 import org.junit.jupiter.api.fail
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 import java.io.IOException
 
 

--- a/src/test/kotlin/com/fwdekker/randomness/word/WordInsertActionTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/word/WordInsertActionTest.kt
@@ -3,11 +3,10 @@ package com.fwdekker.randomness.word
 import com.fwdekker.randomness.DataGenerationException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 
 /**

--- a/src/test/kotlin/com/fwdekker/randomness/word/WordSettingsComponentTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/word/WordSettingsComponentTest.kt
@@ -10,9 +10,8 @@ import org.assertj.swing.edt.FailOnThreadViolationRepaintManager
 import org.assertj.swing.edt.GuiActionRunner
 import org.assertj.swing.fixture.Containers.showInFrame
 import org.assertj.swing.fixture.FrameFixture
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 
 /**

--- a/src/test/kotlin/com/fwdekker/randomness/word/WordSettingsTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/word/WordSettingsTest.kt
@@ -1,9 +1,8 @@
 package com.fwdekker.randomness.word
 
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 
 /**


### PR DESCRIPTION
Re-migrates to Spek 2, just like #176. By using a newer version of Spek 2, the hope is that CI builds don't unexpectedly fail (cf. #179).