### PR TITLE
Focus order

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
     <a href="https://fwdekker.github.io/intellij-randomness/"><img src="https://img.shields.io/badge/documentation-ready-blue.svg?style=for-the-badge" alt="Documentation" /></a>
     <br />
     <a href="https://travis-ci.com/FWDekker/intellij-randomness"><img src="https://img.shields.io/travis/com/FWDekker/intellij-randomness/master?style=for-the-badge" alt="Travis build status" /></a>
-    <a href="https://codecov.io/gh/FWDekker/intellij-randomness"><img src="https://img.shields.io/codecov/c/github/FWDekker/intellij-randomness.svg?style=for-the-badge" alt="Branch coverage" /></a>
+    <a href="https://codecov.io/gh/FWDekker/intellij-randomness"><img src="https://img.shields.io/codecov/c/github/FWDekker/intellij-randomness.svg?style=for-the-badge" alt="Line coverage" /></a>
 </p>
 
 Rather than going to [random.org](https://www.random.org/) or making up your own random data, you can now insert random
@@ -30,8 +30,7 @@ You can modify this behavior by holding a key while selecting the type of data t
 * Hold <kbd>Alt</kbd> (<kbd>⌥</kbd>) to insert the same value at each caret.
 You can also hold multiple modifier keys to combine their effects.
 
-Randomness can also be found in the main menu under <kbd>Tools</kbd> or in the
-[<kbd>Generate</kbd> menu](https://www.jetbrains.com/help/idea/generating-code.html).
+Randomness can also be found in the main menu under <kbd>Tools</kbd> or in <kbd>Code > Generate</kbd>.
 
 ## ✨ Features
 * 🕸 **Data Types**<br />

--- a/build.gradle
+++ b/build.gradle
@@ -31,13 +31,12 @@ dependencies {
     testImplementation group: "com.nhaarman.mockitokotlin2", name: "mockito-kotlin", version: mockitoKotlinVersion
     testImplementation group: "org.assertj", name: "assertj-core", version: assertjVersion
     testImplementation group: "org.assertj", name: "assertj-swing-junit", version: assertjSwingVersion
-    testImplementation group: "org.spekframework.spek2", name: "spek-dsl-jvm", version: spekVersion
-    testRuntimeOnly group: "org.spekframework.spek2", name: "spek-runner-junit5", version: spekVersion
     testImplementation group: "org.junit.platform", name: "junit-platform-runner", version: junitRunnerVersion
     testImplementation group: "org.junit.jupiter", name: "junit-jupiter-api", version: junitVersion
     testImplementation group: "org.junit.jupiter", name: "junit-jupiter-engine", version: junitVersion
-    testImplementation group: "org.junit.jupiter", name: "junit-jupiter-params", version: junitVersion
     testImplementation group: "org.junit.vintage", name: "junit-vintage-engine", version: junitVersion
+    testImplementation group: "org.spekframework.spek2", name: "spek-dsl-jvm", version: spekVersion
+    testRuntimeOnly group: "org.spekframework.spek2", name: "spek-runner-junit5", version: spekVersion
 
     detektPlugins group: "io.gitlab.arturbosch.detekt", name: "detekt-formatting", version: detektVersion
 }

--- a/src/main/kotlin/com/fwdekker/randomness/array/ArraySettingsComponent.form
+++ b/src/main/kotlin/com/fwdekker/randomness/array/ArraySettingsComponent.form
@@ -27,7 +27,6 @@
               <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
-              <labelFor value="38ced"/>
               <text resource-bundle="randomness" key="settings.count"/>
             </properties>
           </component>

--- a/src/main/kotlin/com/fwdekker/randomness/decimal/DecimalSettingsComponent.form
+++ b/src/main/kotlin/com/fwdekker/randomness/decimal/DecimalSettingsComponent.form
@@ -47,7 +47,6 @@
               <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
-              <labelFor value="6a447"/>
               <text resource-bundle="randomness" key="settings.minimum_value"/>
             </properties>
           </component>
@@ -56,7 +55,6 @@
               <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
-              <labelFor value="7daea"/>
               <text resource-bundle="randomness" key="settings.maximum_value"/>
             </properties>
           </component>
@@ -90,7 +88,6 @@
               <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
-              <labelFor value="b93dd"/>
               <text resource-bundle="randomness" key="settings.number_of_decimals"/>
             </properties>
           </component>

--- a/src/main/kotlin/com/fwdekker/randomness/integer/IntegerSettingsComponent.form
+++ b/src/main/kotlin/com/fwdekker/randomness/integer/IntegerSettingsComponent.form
@@ -27,7 +27,6 @@
               <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
-              <labelFor value="44ac7"/>
               <text resource-bundle="randomness" key="settings.minimum_value"/>
             </properties>
           </component>
@@ -36,7 +35,6 @@
               <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
-              <labelFor value="b9000"/>
               <text resource-bundle="randomness" key="settings.maximum_value"/>
             </properties>
           </component>
@@ -106,7 +104,6 @@
               <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
-              <labelFor value="ad1d8"/>
               <text resource-bundle="randomness" key="settings.base"/>
             </properties>
           </component>

--- a/src/main/kotlin/com/fwdekker/randomness/string/StringSettingsComponent.form
+++ b/src/main/kotlin/com/fwdekker/randomness/string/StringSettingsComponent.form
@@ -241,9 +241,9 @@
       <member id="364e0"/>
     </group>
     <group name="capitalizationGroup" bound="true">
-      <member id="c6fa1"/>
-      <member id="e20f5"/>
       <member id="4426c"/>
+      <member id="e20f5"/>
+      <member id="c6fa1"/>
     </group>
   </buttonGroups>
 </form>

--- a/src/main/kotlin/com/fwdekker/randomness/string/StringSettingsComponent.form
+++ b/src/main/kotlin/com/fwdekker/randomness/string/StringSettingsComponent.form
@@ -27,7 +27,6 @@
               <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
-              <labelFor value="1885f"/>
               <text resource-bundle="randomness" key="settings.minimum_length"/>
             </properties>
           </component>
@@ -36,7 +35,6 @@
               <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
-              <labelFor value="ae252"/>
               <text resource-bundle="randomness" key="settings.maximum_length"/>
             </properties>
           </component>

--- a/src/main/kotlin/com/fwdekker/randomness/word/WordSettingsComponent.form
+++ b/src/main/kotlin/com/fwdekker/randomness/word/WordSettingsComponent.form
@@ -27,7 +27,6 @@
               <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
-              <labelFor value="8a66f"/>
               <text resource-bundle="randomness" key="settings.minimum_length"/>
             </properties>
           </component>
@@ -44,7 +43,6 @@
               <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
-              <labelFor value="2e2f"/>
               <text resource-bundle="randomness" key="settings.maximum_length"/>
             </properties>
           </component>

--- a/src/main/kotlin/com/fwdekker/randomness/word/WordSettingsComponent.form
+++ b/src/main/kotlin/com/fwdekker/randomness/word/WordSettingsComponent.form
@@ -3,7 +3,7 @@
   <grid id="27dc6" binding="contentPane" layout-manager="GridLayoutManager" row-count="9" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="815" height="315"/>
+      <xy x="20" y="20" width="815" height="381"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -91,22 +91,44 @@
               <text resource-bundle="randomness" key="settings.none"/>
             </properties>
           </component>
+          <component id="d5ff3" class="javax.swing.JRadioButton" default-binding="true">
+            <constraints>
+              <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <name value="enclosureSingle" noi18n="true"/>
+              <text value="'" noi18n="true"/>
+            </properties>
+          </component>
+          <component id="4715d" class="javax.swing.JRadioButton" default-binding="true">
+            <constraints>
+              <grid row="0" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <name value="enclosureDouble" noi18n="true"/>
+              <text value="&quot;" noi18n="true"/>
+            </properties>
+          </component>
+          <component id="65560" class="javax.swing.JRadioButton" default-binding="true">
+            <constraints>
+              <grid row="0" column="4" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <name value="enclosureBacktick" noi18n="true"/>
+              <text value="`" noi18n="true"/>
+            </properties>
+          </component>
+          <hspacer id="7e6ae">
+            <constraints>
+              <grid row="0" column="5" row-span="1" col-span="3" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+            </constraints>
+          </hspacer>
           <component id="19950" class="javax.swing.JLabel">
             <constraints>
               <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text resource-bundle="randomness" key="settings.capitalization"/>
-            </properties>
-          </component>
-          <component id="85d22" class="javax.swing.JRadioButton" default-binding="true">
-            <constraints>
-              <grid row="1" column="5" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <actionCommand value="sentence" noi18n="true"/>
-              <name value="capitalizationSentence" noi18n="true"/>
-              <text resource-bundle="randomness" key="settings.capitalization.sentence"/>
             </properties>
           </component>
           <component id="5bc1d" class="javax.swing.JRadioButton" default-binding="true">
@@ -119,26 +141,6 @@
               <text resource-bundle="randomness" key="settings.capitalization.retain"/>
             </properties>
           </component>
-          <component id="5602b" class="javax.swing.JRadioButton" default-binding="true">
-            <constraints>
-              <grid row="1" column="6" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <actionCommand value="first letter" noi18n="true"/>
-              <name value="capitalizationFirstLetter" noi18n="true"/>
-              <text resource-bundle="randomness" key="settings.capitalization.first_letter"/>
-            </properties>
-          </component>
-          <hspacer id="7e6ae">
-            <constraints>
-              <grid row="0" column="5" row-span="1" col-span="3" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
-            </constraints>
-          </hspacer>
-          <hspacer id="175d1">
-            <constraints>
-              <grid row="1" column="7" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
-            </constraints>
-          </hspacer>
           <component id="bf7aa" class="javax.swing.JRadioButton" default-binding="true">
             <constraints>
               <grid row="1" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
@@ -147,15 +149,6 @@
               <actionCommand value="lower" noi18n="true"/>
               <name value="capitalizationLower" noi18n="true"/>
               <text resource-bundle="randomness" key="settings.capitalization.lower"/>
-            </properties>
-          </component>
-          <component id="d5ff3" class="javax.swing.JRadioButton" default-binding="true">
-            <constraints>
-              <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <name value="enclosureSingle" noi18n="true"/>
-              <text value="'" noi18n="true"/>
             </properties>
           </component>
           <component id="2d597" class="javax.swing.JRadioButton" default-binding="true">
@@ -178,24 +171,31 @@
               <text resource-bundle="randomness" key="settings.capitalization.random"/>
             </properties>
           </component>
-          <component id="4715d" class="javax.swing.JRadioButton" default-binding="true">
+          <component id="85d22" class="javax.swing.JRadioButton" default-binding="true">
             <constraints>
-              <grid row="0" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="1" column="5" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
-              <name value="enclosureDouble" noi18n="true"/>
-              <text value="&quot;" noi18n="true"/>
+              <actionCommand value="sentence" noi18n="true"/>
+              <name value="capitalizationSentence" noi18n="true"/>
+              <text resource-bundle="randomness" key="settings.capitalization.sentence"/>
             </properties>
           </component>
-          <component id="65560" class="javax.swing.JRadioButton" default-binding="true">
+          <component id="5602b" class="javax.swing.JRadioButton" default-binding="true">
             <constraints>
-              <grid row="0" column="4" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="1" column="6" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
-              <name value="enclosureBacktick" noi18n="true"/>
-              <text value="`" noi18n="true"/>
+              <actionCommand value="first letter" noi18n="true"/>
+              <name value="capitalizationFirstLetter" noi18n="true"/>
+              <text resource-bundle="randomness" key="settings.capitalization.first_letter"/>
             </properties>
           </component>
+          <hspacer id="175d1">
+            <constraints>
+              <grid row="1" column="7" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+            </constraints>
+          </hspacer>
         </children>
       </grid>
       <vspacer id="83bb5">
@@ -257,17 +257,17 @@
   <buttonGroups>
     <group name="enclosureGroup" bound="true">
       <member id="82f47"/>
-      <member id="4715d"/>
       <member id="d5ff3"/>
+      <member id="4715d"/>
       <member id="65560"/>
     </group>
     <group name="capitalizationGroup" bound="true">
-      <member id="85d22"/>
-      <member id="2d597"/>
-      <member id="bf7aa"/>
       <member id="5bc1d"/>
-      <member id="5602b"/>
+      <member id="bf7aa"/>
+      <member id="2d597"/>
       <member id="367dc"/>
+      <member id="85d22"/>
+      <member id="5602b"/>
     </group>
   </buttonGroups>
 </form>

--- a/src/main/resources/META-INF/change-notes.html
+++ b/src/main/resources/META-INF/change-notes.html
@@ -14,5 +14,5 @@
     <li>Leading and trailing whitespace characters no longer disappear when expanding a symbol set field.</li>
     <li>Pressing <kbd>Enter</kbd> in a table now opens the editor for the current selection.</li>
     <li>Duplicate symbols in symbol sets are now ignored.</li>
-    <li>Fix focus order of radio buttons in settings.</li>
+    <li>Fix focus order of radio buttons and number inputs in settings.</li>
 </ul>

--- a/src/main/resources/META-INF/change-notes.html
+++ b/src/main/resources/META-INF/change-notes.html
@@ -14,4 +14,5 @@
     <li>Leading and trailing whitespace characters no longer disappear when expanding a symbol set field.</li>
     <li>Pressing <kbd>Enter</kbd> in a table now opens the editor for the current selection.</li>
     <li>Duplicate symbols in symbol sets are now ignored.</li>
+    <li>Fix focus order of radio buttons in settings.</li>
 </ul>


### PR DESCRIPTION
Fixes #283 (both checkboxes).

* Reorders the order of radio buttons in the button groups, and
* removes the `labelFor` properties of labels.