### PR TITLE
Ensure time-based UUID previews respect seed

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group   = com.fwdekker
-version = 2.5.0
+version = 2.5.1-dev
 
 kotlin.code.style = official
 
@@ -12,4 +12,4 @@ junitVersion          = 5.5.2
 junitRunnerVersion    = 1.5.2
 mockitoKotlinVersion  = 2.2.0
 spekVersion           = 2.0.9
-uuidGeneratorVersion  = 3.2.0
+uuidGeneratorVersion  = 3.3.0

--- a/src/main/kotlin/com/fwdekker/randomness/uuid/UuidActions.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/uuid/UuidActions.kt
@@ -2,6 +2,7 @@ package com.fwdekker.randomness.uuid
 
 import com.fasterxml.uuid.EthernetAddress
 import com.fasterxml.uuid.Generators
+import com.fasterxml.uuid.UUIDClock
 import com.fasterxml.uuid.UUIDTimer
 import com.fwdekker.randomness.DataGenerationException
 import com.fwdekker.randomness.DataGroupAction
@@ -54,7 +55,9 @@ class UuidInsertAction(private val scheme: UuidScheme = UuidSettings.default.cur
             1 ->
                 Generators.timeBasedGenerator(
                     EthernetAddress(random.nextLong()),
-                    UUIDTimer(random.asJavaRandom(), null)
+                    UUIDTimer(random.asJavaRandom(), null, object : UUIDClock() {
+                        override fun currentTimeMillis() = random.nextLong()
+                    })
                 )
             4 -> Generators.randomBasedGenerator(random.asJavaRandom())
             else -> throw DataGenerationException("Unknown UUID version `${scheme.version}`.")

--- a/src/main/resources/META-INF/change-notes.html
+++ b/src/main/resources/META-INF/change-notes.html
@@ -1,35 +1,14 @@
-<b>Symbol set settings will be reset when updating to v2.5.0 because of changes in how settings are stored.</b>
-You can re-add your custom symbol sets after updating.
-
+<!-- Insert notice here <br />
+<br />-->
 <b>New features</b>
 <ul>
-    <li>
-        <b>♻️ Scheme switcher</b>.
-        Quickly switch between your schemes by holding <kbd>Alt + Ctrl</kbd> while selecting a data type.
-    </li>
-    <li>
-        <b>😀 Emoji</b>.
-        Generate random strings of emoji by adding them to symbol sets.
-    </li>
-    <li>
-        <b>🕵 Look-alike characters</b>.
-        Exclude characters that look like each other (e.g. `1`, `l`, `I`) in generated strings to prevent confusion.
-    </li>
-    <li>Change your settings using the Randomness popup even when you don't have an editor opened.</li>
-    <li>Slightly friendlier and more accurate error messages for tables.</li>
+    <li>...</li>
 </ul>
 
 <b>Fixes</b>
 <ul>
-    <li>Input fields now correctly resize when shrinking the dialog.</li>
-    <li>Symbol set table now makes full use of vertical space.</li>
-    <li>Dictionary table no longer exceeds dialog width.</li>
-    <li>Adding a new entry to a table using the "Add" button will now allow you to immediately edit the new entry.</li>
-    <li>Leading and trailing whitespace characters no longer disappear when expanding a symbol set field.</li>
-    <li>Pressing <kbd>Enter</kbd> in a table now activates the editor for the currently-selected cell.</li>
-    <li>Duplicate symbols in single symbol sets are now ignored.</li>
-    <li>Arrow keys now work correctly for all radio buttons.</li>
+    <li>Time-based UUID previews now use fixed seed until preview is refreshed.</li>
 </ul>
-
+<br />
 Change notes of previous updates can be found on the
 <a href="https://plugins.jetbrains.com/plugin/9836-randomness/versions">plugin repository</a>.


### PR DESCRIPTION
Fixes #282 by using the new custom-clock functionality of v3.3.0 of the UUID generator library.