### PR TITLE
Remove Kotlin as implementation dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,8 +25,6 @@ repositories {
 
 dependencies {
     implementation group: "com.fasterxml.uuid", name: "java-uuid-generator", version: uuidGeneratorVersion
-    implementation group: "org.jetbrains.kotlin", name: "kotlin-stdlib-jdk8"
-    implementation group: "org.jetbrains.kotlin", name: "kotlin-reflect"
     implementation group: "com.vdurmont", name: "emoji-java", version: emojiVersion
 
     testImplementation group: "com.nhaarman.mockitokotlin2", name: "mockito-kotlin", version: mockitoKotlinVersion
@@ -44,14 +42,6 @@ dependencies {
 
 
 /// Configuration
-// Compilation
-compileKotlin {
-    kotlinOptions.jvmTarget = "1.8"
-}
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "1.8"
-}
-
 intellij {
     version = intellijVersion
     updateSinceUntilBuild = false

--- a/src/main/resources/META-INF/change-notes.html
+++ b/src/main/resources/META-INF/change-notes.html
@@ -12,6 +12,7 @@
 <b>Fixes</b>
 <ul>
     <li>Time-based UUID previews now use fixed seed until preview is refreshed.</li>
+    <li>Plugin size has been reduced significantly.</li>
 </ul>
 <br />
 Change notes of previous updates can be found on the


### PR DESCRIPTION
See title. Reduces plugin distribution size by approx. 4 MB.