### PR TITLE
Revert #297

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,8 @@ repositories {
 
 dependencies {
     implementation group: "com.fasterxml.uuid", name: "java-uuid-generator", version: uuidGeneratorVersion
+    implementation group: "org.jetbrains.kotlin", name: "kotlin-stdlib-jdk8"
+    implementation group: "org.jetbrains.kotlin", name: "kotlin-reflect"
     implementation group: "com.vdurmont", name: "emoji-java", version: emojiVersion
 
     testImplementation group: "com.nhaarman.mockitokotlin2", name: "mockito-kotlin", version: mockitoKotlinVersion
@@ -42,6 +44,14 @@ dependencies {
 
 
 /// Configuration
+// Compilation
+compileKotlin {
+    kotlinOptions.jvmTarget = "1.8"
+}
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "1.8"
+}
+
 intellij {
     version = intellijVersion
     updateSinceUntilBuild = false


### PR DESCRIPTION
Reverts #297; by not bundling Kotlin in the distribution the plugin was no longer compatible with IntelliJ 2018.1 because that version uses Kotlin 1.2 while the distribution was compiled for Kotlin 1.3. I could not find an easy way to compile for Kotlin 1.2 using IntelliJ, so I've decided to continue bundling Kotlin with the distribution.