### PR TITLE
Update dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 plugins {
     // Compilation
     id "org.jetbrains.kotlin.jvm" version "1.3.61"
-    id "org.jetbrains.intellij" version "0.4.15"
+    id "org.jetbrains.intellij" version "0.4.16"
 
     // Tests/coverage
     id "jacoco"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,15 +1,15 @@
 group   = com.fwdekker
-version = 2.5.1
+version = 2.5.2-dev
 
 kotlin.code.style = official
 
-assertjVersion        = 3.8.0
-assertjSwingVersion   = 3.8.0
+assertjVersion        = 3.11.1
+assertjSwingVersion   = 3.9.2
 detektVersion         = 1.4.0
 emojiVersion          = 5.1.1
 intellijVersion       = 2019.3
-junitVersion          = 5.5.2
-junitRunnerVersion    = 1.5.2
+junitVersion          = 5.6.0
+junitRunnerVersion    = 1.6.0
 mockitoKotlinVersion  = 2.2.0
 spekVersion           = 2.0.9
 uuidGeneratorVersion  = 3.3.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip

--- a/src/main/resources/META-INF/change-notes.html
+++ b/src/main/resources/META-INF/change-notes.html
@@ -1,18 +1,13 @@
+Insert notice here <br />
+<br />
 <b>New features</b>
 <ul>
-    <li>
-        <b>🚨 Error reporter</b>.
-        Easily report fatal Randomness errors to GitHub by clicking the report button in IntelliJ's
-        <a href="https://www.jetbrains.com/help/idea/event-log-tool-window.html">event log.</a>
-    </li>
+    <li>Insert feature here.</li>
 </ul>
-
+<br />
 <b>Fixes</b>
 <ul>
-    <li>Time-based UUID previews now use fixed seed until preview is refreshed.</li>
-    <li>Radio buttons are no longer in a grid, giving the corresponding labels more natural sizes.</li>
-    <li>The layout of UUID options has been altered slightly.</li>
-    <li>Holding modifier keys in settings-only popup now triggers normal behavior of opening settings window.</li>
+    <li>Insert fix here.</li>
 </ul>
 <br />
 Change notes of previous updates can be found on the


### PR DESCRIPTION
Updates a number of dependencies.

Notably,
* Detekt was not updated because running the latest version causes a large number of exceptions in the log.
* Dokka was not updated because the latest update features a confusing layout (see Kotlin/dokka#624).
* AssertJ was finally updated; I previously postponed updates because the version numbering is confusing and there are compatibility issues with the Swing package and the core. I found [a page explaining which versions are compatible](https://joel-costigliola.github.io/assertj/assertj-swing-news.html) and used this to determine the latest core version that is compatible.
