### PR TITLE
Fix scheme loading/saving (and update dependencies)

### DIFF
--- a/.config/detekt/.detekt.yml
+++ b/.config/detekt/.detekt.yml
@@ -1,4 +1,7 @@
 comments:
+    # License in each file is unnecessary.
+    AbsentOrWrongFileLicense:
+        active: false
     # Nothing wrong with documenting private methods.
     CommentOverPrivateFunction:
         active: false

--- a/build.gradle
+++ b/build.gradle
@@ -46,10 +46,10 @@ dependencies {
 /// Configuration
 // Compilation
 compileKotlin {
-    kotlinOptions.jvmTarget = "11"
+    kotlinOptions.jvmTarget = "1.8"
 }
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "11"
+    kotlinOptions.jvmTarget = "1.8"
 }
 
 intellij {

--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,14 @@
 /// Plugins
 plugins {
     // Compilation
-    id "org.jetbrains.kotlin.jvm" version "1.3.61"
-    id "org.jetbrains.intellij" version "0.4.16"
+    id "org.jetbrains.kotlin.jvm" version "1.3.72"
+    id "org.jetbrains.intellij" version "0.4.21"
 
     // Tests/coverage
     id "jacoco"
 
     // Static analysis
-    id "io.gitlab.arturbosch.detekt" version "1.4.0"
+    id "io.gitlab.arturbosch.detekt" version "1.9.0"
 
     // Documentation
     id "org.jetbrains.dokka" version "0.9.18"
@@ -46,10 +46,10 @@ dependencies {
 /// Configuration
 // Compilation
 compileKotlin {
-    kotlinOptions.jvmTarget = "1.8"
+    kotlinOptions.jvmTarget = "11"
 }
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "1.8"
+    kotlinOptions.jvmTarget = "11"
 }
 
 intellij {
@@ -97,7 +97,7 @@ dokka {
     outputFormat = "html"
     includes = ["packages.md"]
 
-    jdkVersion = 8
+    jdkVersion = 8 // stdlib documentation is broken in Dokka for JDK 11 (Kotlin/dokka#213)
 
     includeNonPublic = false
     skipDeprecated = false
@@ -108,5 +108,5 @@ dokka {
 // Compatibility checks
 runPluginVerifier {
     pluginFileName = "$rootProject.name-$version"
-    ides = ["IC-2018.1", "IC-2019.1", "IC-2019.3", "CL-2019.3"]
+    ides = ["IC-2018.1", "IC-2019.1", "IC-2020.1", "CL-2019.3"]
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,11 +5,11 @@ kotlin.code.style = official
 
 assertjVersion        = 3.11.1
 assertjSwingVersion   = 3.9.2
-detektVersion         = 1.4.0
+detektVersion         = 1.9.0
 emojiVersion          = 5.1.1
-intellijVersion       = 2019.3
-junitVersion          = 5.6.0
-junitRunnerVersion    = 1.6.0
+intellijVersion       = 2020.1
+junitVersion          = 5.6.2
+junitRunnerVersion    = 1.6.2
 mockitoKotlinVersion  = 2.2.0
 spekVersion           = 2.0.9
-uuidGeneratorVersion  = 3.3.0
+uuidGeneratorVersion  = 4.0.1

--- a/src/main/kotlin/com/fwdekker/randomness/Settings.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/Settings.kt
@@ -27,9 +27,11 @@ interface Settings<SELF, SCHEME : Scheme<SCHEME>> : PersistentStateComponent<SEL
      * This field is backed by [currentSchemeName]. If [currentSchemeName] refers to a scheme that is not contained in
      * [schemes], `get`ting this field will throw an exception.
      */
+    @Suppress("UseCheckOrError") // This is shorter and faster
     var currentScheme: SCHEME
         @Transient
-        get() = schemes.first { it.name == currentSchemeName }
+        get() = schemes.firstOrNull { it.name == currentSchemeName }
+            ?: throw IllegalStateException("Current scheme does not exist.")
         set(value) {
             currentSchemeName = value.name
         }

--- a/src/main/kotlin/com/fwdekker/randomness/array/ArraySettings.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/array/ArraySettings.kt
@@ -4,9 +4,9 @@ import com.fwdekker.randomness.Scheme
 import com.fwdekker.randomness.Scheme.Companion.DEFAULT_NAME
 import com.fwdekker.randomness.Settings
 import com.fwdekker.randomness.SettingsConfigurable
-import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
+import com.intellij.openapi.components.service
 import com.intellij.util.xmlb.XmlSerializerUtil
 import com.intellij.util.xmlb.annotations.MapAnnotation
 
@@ -41,7 +41,7 @@ data class ArraySettings(
          * The persistent `ArraySettings` instance.
          */
         val default: ArraySettings
-            get() = ServiceManager.getService(ArraySettings::class.java)
+            get() = service()
     }
 
 

--- a/src/main/kotlin/com/fwdekker/randomness/decimal/DecimalSettings.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/decimal/DecimalSettings.kt
@@ -4,9 +4,9 @@ import com.fwdekker.randomness.Scheme
 import com.fwdekker.randomness.Scheme.Companion.DEFAULT_NAME
 import com.fwdekker.randomness.Settings
 import com.fwdekker.randomness.SettingsConfigurable
-import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
+import com.intellij.openapi.components.service
 import com.intellij.util.xmlb.XmlSerializerUtil
 import com.intellij.util.xmlb.annotations.MapAnnotation
 
@@ -41,7 +41,7 @@ data class DecimalSettings(
          * The persistent `DecimalSettings` instance.
          */
         val default: DecimalSettings
-            get() = ServiceManager.getService(DecimalSettings::class.java)
+            get() = service()
     }
 
 

--- a/src/main/kotlin/com/fwdekker/randomness/integer/IntegerSettings.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/integer/IntegerSettings.kt
@@ -4,9 +4,9 @@ import com.fwdekker.randomness.Scheme
 import com.fwdekker.randomness.Scheme.Companion.DEFAULT_NAME
 import com.fwdekker.randomness.Settings
 import com.fwdekker.randomness.SettingsConfigurable
-import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
+import com.intellij.openapi.components.service
 import com.intellij.util.xmlb.XmlSerializerUtil
 import com.intellij.util.xmlb.annotations.MapAnnotation
 
@@ -44,7 +44,7 @@ data class IntegerSettings(
          * The persistent `IntegerSettings` instance.
          */
         val default: IntegerSettings
-            get() = ServiceManager.getService(IntegerSettings::class.java)
+            get() = service()
     }
 
 

--- a/src/main/kotlin/com/fwdekker/randomness/string/StringSettings.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/string/StringSettings.kt
@@ -5,9 +5,9 @@ import com.fwdekker.randomness.Scheme
 import com.fwdekker.randomness.Scheme.Companion.DEFAULT_NAME
 import com.fwdekker.randomness.Settings
 import com.fwdekker.randomness.SettingsConfigurable
-import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
+import com.intellij.openapi.components.service
 import com.intellij.util.xmlb.XmlSerializerUtil
 import com.intellij.util.xmlb.annotations.MapAnnotation
 import com.intellij.util.xmlb.annotations.Transient
@@ -44,7 +44,7 @@ data class StringSettings(
          * The persistent `StringSettings` instance.
          */
         val default: StringSettings
-            get() = ServiceManager.getService(StringSettings::class.java)
+            get() = service()
     }
 
 

--- a/src/main/kotlin/com/fwdekker/randomness/ui/JBPopupHelper.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/ui/JBPopupHelper.kt
@@ -96,5 +96,6 @@ private fun actionListener(actionPerformed: (ActionEvent?) -> Unit) =
  * @param other the list to multiply with
  * @return the cartesian product of `this` and [other]
  */
+@Suppress("UnusedPrivateMember") // False positive: Used as operator `*`
 private operator fun <E> List<List<E>>.times(other: List<List<E>>) =
     this.flatMap { t1 -> other.map { t2 -> t1 + t2 } }

--- a/src/main/kotlin/com/fwdekker/randomness/uuid/UuidSettings.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/uuid/UuidSettings.kt
@@ -5,9 +5,9 @@ import com.fwdekker.randomness.Scheme
 import com.fwdekker.randomness.Scheme.Companion.DEFAULT_NAME
 import com.fwdekker.randomness.Settings
 import com.fwdekker.randomness.SettingsConfigurable
-import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
+import com.intellij.openapi.components.service
 import com.intellij.util.xmlb.XmlSerializerUtil
 import com.intellij.util.xmlb.annotations.MapAnnotation
 
@@ -42,7 +42,7 @@ data class UuidSettings(
          * The persistent `UuidSettings` instance.
          */
         val default: UuidSettings
-            get() = ServiceManager.getService(UuidSettings::class.java)
+            get() = service()
     }
 
 

--- a/src/main/kotlin/com/fwdekker/randomness/word/WordSettings.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/word/WordSettings.kt
@@ -5,9 +5,9 @@ import com.fwdekker.randomness.Scheme
 import com.fwdekker.randomness.Scheme.Companion.DEFAULT_NAME
 import com.fwdekker.randomness.Settings
 import com.fwdekker.randomness.SettingsConfigurable
-import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
+import com.intellij.openapi.components.service
 import com.intellij.util.xmlb.XmlSerializerUtil
 import com.intellij.util.xmlb.annotations.MapAnnotation
 import com.intellij.util.xmlb.annotations.Transient
@@ -43,7 +43,7 @@ data class WordSettings(
          * The persistent `WordSettings` instance.
          */
         val default: WordSettings
-            get() = ServiceManager.getService(WordSettings::class.java)
+            get() = service()
     }
 
 


### PR DESCRIPTION
Fixes #322.

The cause of the bug was that, for some reason, the `@Transient` annotation on the `currentScheme` field was ignored, but only if the build wasn't compiled in debug mode. As a result, the current scheme was serialized into the configuration XML (which isn't really a problem per sé) and when reading it, the call to `schemes.first` would fail because the schemes had not loaded yet.

I still don't know why the annotation was ignored, but changing `first` to `firstOrNull ?: throw Exception` somehow caused the annotation to start working again. Additionally, settings files from previous versions that incorrectly contain the `currentScheme` field will be read without error by this patched version.

---

It took me a long while to figure that out, so I also ended up updating all dependencies and using some other cool stuff I found in the IntelliJ SDK docs.