### PR TITLE
Fix SDK compatibility and update Gradle

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.4-all.zip

--- a/src/main/kotlin/com/fwdekker/randomness/array/ArraySettings.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/array/ArraySettings.kt
@@ -4,9 +4,9 @@ import com.fwdekker.randomness.Scheme
 import com.fwdekker.randomness.Scheme.Companion.DEFAULT_NAME
 import com.fwdekker.randomness.Settings
 import com.fwdekker.randomness.SettingsConfigurable
+import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
-import com.intellij.openapi.components.service
 import com.intellij.util.xmlb.XmlSerializerUtil
 import com.intellij.util.xmlb.annotations.MapAnnotation
 
@@ -41,7 +41,7 @@ data class ArraySettings(
          * The persistent `ArraySettings` instance.
          */
         val default: ArraySettings
-            get() = service()
+            get() = ServiceManager.getService(ArraySettings::class.java)
     }
 
 

--- a/src/main/kotlin/com/fwdekker/randomness/decimal/DecimalSettings.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/decimal/DecimalSettings.kt
@@ -4,9 +4,9 @@ import com.fwdekker.randomness.Scheme
 import com.fwdekker.randomness.Scheme.Companion.DEFAULT_NAME
 import com.fwdekker.randomness.Settings
 import com.fwdekker.randomness.SettingsConfigurable
+import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
-import com.intellij.openapi.components.service
 import com.intellij.util.xmlb.XmlSerializerUtil
 import com.intellij.util.xmlb.annotations.MapAnnotation
 
@@ -41,7 +41,7 @@ data class DecimalSettings(
          * The persistent `DecimalSettings` instance.
          */
         val default: DecimalSettings
-            get() = service()
+            get() = ServiceManager.getService(DecimalSettings::class.java)
     }
 
 

--- a/src/main/kotlin/com/fwdekker/randomness/integer/IntegerSettings.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/integer/IntegerSettings.kt
@@ -4,9 +4,9 @@ import com.fwdekker.randomness.Scheme
 import com.fwdekker.randomness.Scheme.Companion.DEFAULT_NAME
 import com.fwdekker.randomness.Settings
 import com.fwdekker.randomness.SettingsConfigurable
+import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
-import com.intellij.openapi.components.service
 import com.intellij.util.xmlb.XmlSerializerUtil
 import com.intellij.util.xmlb.annotations.MapAnnotation
 
@@ -44,7 +44,7 @@ data class IntegerSettings(
          * The persistent `IntegerSettings` instance.
          */
         val default: IntegerSettings
-            get() = service()
+            get() = ServiceManager.getService(IntegerSettings::class.java)
     }
 
 

--- a/src/main/kotlin/com/fwdekker/randomness/string/StringSettings.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/string/StringSettings.kt
@@ -5,9 +5,9 @@ import com.fwdekker.randomness.Scheme
 import com.fwdekker.randomness.Scheme.Companion.DEFAULT_NAME
 import com.fwdekker.randomness.Settings
 import com.fwdekker.randomness.SettingsConfigurable
+import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
-import com.intellij.openapi.components.service
 import com.intellij.util.xmlb.XmlSerializerUtil
 import com.intellij.util.xmlb.annotations.MapAnnotation
 import com.intellij.util.xmlb.annotations.Transient
@@ -44,7 +44,7 @@ data class StringSettings(
          * The persistent `StringSettings` instance.
          */
         val default: StringSettings
-            get() = service()
+            get() = ServiceManager.getService(StringSettings::class.java)
     }
 
 

--- a/src/main/kotlin/com/fwdekker/randomness/uuid/UuidSettings.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/uuid/UuidSettings.kt
@@ -5,9 +5,9 @@ import com.fwdekker.randomness.Scheme
 import com.fwdekker.randomness.Scheme.Companion.DEFAULT_NAME
 import com.fwdekker.randomness.Settings
 import com.fwdekker.randomness.SettingsConfigurable
+import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
-import com.intellij.openapi.components.service
 import com.intellij.util.xmlb.XmlSerializerUtil
 import com.intellij.util.xmlb.annotations.MapAnnotation
 
@@ -42,7 +42,7 @@ data class UuidSettings(
          * The persistent `UuidSettings` instance.
          */
         val default: UuidSettings
-            get() = service()
+            get() = ServiceManager.getService(UuidSettings::class.java)
     }
 
 

--- a/src/main/kotlin/com/fwdekker/randomness/word/WordSettings.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/word/WordSettings.kt
@@ -5,9 +5,9 @@ import com.fwdekker.randomness.Scheme
 import com.fwdekker.randomness.Scheme.Companion.DEFAULT_NAME
 import com.fwdekker.randomness.Settings
 import com.fwdekker.randomness.SettingsConfigurable
+import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
-import com.intellij.openapi.components.service
 import com.intellij.util.xmlb.XmlSerializerUtil
 import com.intellij.util.xmlb.annotations.MapAnnotation
 import com.intellij.util.xmlb.annotations.Transient
@@ -43,7 +43,7 @@ data class WordSettings(
          * The persistent `WordSettings` instance.
          */
         val default: WordSettings
-            get() = service()
+            get() = ServiceManager.getService(WordSettings::class.java)
     }
 
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -4,7 +4,7 @@
     <version>0.0.0</version>
     <vendor email="felix@fwdekker.com" url="https://fwdekker.com/">FWDekker</vendor>
 
-    <depends>com.intellij.modules.lang</depends>
+    <depends>com.intellij.modules.platform</depends>
 
     <idea-version since-build="181.0" />
 


### PR DESCRIPTION
Fixes #323, i.e. changes the plugin dependency from `com.intellij.modules.lang` to `com.intellij.modules.platform`.

Also, reverts a change made in #324 where `service()` was used, because that function is not compatible with IntelliJ API 181+. 

Finally, updates Gradle to the latest version.