### PR TITLE
Error report fixes

### DIFF
--- a/src/main/kotlin/com/fwdekker/randomness/ErrorReporter.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/ErrorReporter.kt
@@ -113,7 +113,7 @@ class ErrorReporter : ErrorReportSubmitter() {
         )
         return baseUrl + candidates.first { encodeUrl(baseUrl + it).length <= MAX_URL_LENGTH }
             .replace(' ', '+')
-            .replace("&", "")
+            .filterNot { it in listOf('#', '&', ';') }
     }
 
     /**

--- a/src/main/kotlin/com/fwdekker/randomness/ErrorReporter.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/ErrorReporter.kt
@@ -13,6 +13,9 @@ import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.Task.Backgroundable
 import com.intellij.util.Consumer
 import java.awt.Component
+import java.net.IDN
+import java.net.URI
+import java.net.URL
 
 
 /**
@@ -22,6 +25,14 @@ import java.awt.Component
  * as a notification by IntelliJ.
  */
 class ErrorReporter : ErrorReportSubmitter() {
+    companion object {
+        /**
+         * Maximum URL length supported by GitHub, experimentally verified.
+         */
+        const val MAX_URL_LENGTH = 8000
+    }
+
+
     /**
      * Returns the text that is displayed in the button to report the error.
      *
@@ -47,21 +58,7 @@ class ErrorReporter : ErrorReportSubmitter() {
         val project = CommonDataKeys.PROJECT.getData(DataManager.getInstance().getDataContext(parentComponent))
         object : Backgroundable(project, "Opening GitHub in Browser") {
             override fun run(indicator: ProgressIndicator) {
-                BrowserUtil.open(
-                    "https://github.com/FWDekker/intellij-randomness/issues/new" +
-                        "?labels=bug" +
-                        "&assignee=FWDekker" +
-                        "&title=Bug report" +
-                        "&body=" +
-                        createMarkdownSection(
-                            "Additional info",
-                            if (additionalInfo.isNullOrBlank()) "_No additional information provided._"
-                            else additionalInfo
-                        ) +
-                        createMarkdownSection("Stacktraces", formatEvents(events)) +
-                        createMarkdownSection("Version information", getFormattedVersionInformation())
-                )
-
+                BrowserUtil.open(getIssueUrl(events, additionalInfo))
                 ApplicationManager.getApplication().invokeLater {
                     consumer.consume(
                         SubmittedReportInfo(
@@ -88,6 +85,37 @@ class ErrorReporter : ErrorReportSubmitter() {
         GitHub's privacy policy</a>.
         """.trimIndent()
 
+
+    /**
+     * Constructs a URL to create an issue with the given information that is below the maximum URL limit.
+     *
+     * @param events the events that caused the exception
+     * @param additionalInfo additional information provided by the user
+     * @return a URL to create an issue with the given information that is below the maximum URL limit
+     */
+    private fun getIssueUrl(events: Array<out IdeaLoggingEvent>, additionalInfo: String?): String {
+        val baseUrl = "https://github.com/FWDekker/intellij-randomness/issues/new" +
+            "?labels=bug" +
+            "&assignee=FWDekker" +
+            "&title=Bug report" +
+            "&body="
+        val additionalInfoSection = createMarkdownSection(
+            "Additional info",
+            if (additionalInfo.isNullOrBlank()) "_No additional information provided._"
+            else additionalInfo
+        )
+        val stackTracesSection = createMarkdownSection("Stacktraces", formatEvents(events))
+        val versionSection = createMarkdownSection("Version information", getFormattedVersionInformation())
+
+        val candidates = listOf(
+            additionalInfoSection + stackTracesSection + versionSection,
+            additionalInfoSection + versionSection,
+            stackTracesSection + versionSection,
+            versionSection,
+            ""
+        )
+        return baseUrl + candidates.first { encodeUrl(it).length <= MAX_URL_LENGTH - baseUrl.length }.replace(' ', '+')
+    }
 
     /**
      * Creates a Markdown "section" containing the title in bold followed by the contents on the next line, finalized by
@@ -153,4 +181,17 @@ class ErrorReporter : ErrorReportSubmitter() {
             Pair("Operating system", System.getProperty("os.name")),
             Pair("Java version", System.getProperty("java.version"))
         ).joinToString("\n") { "- ${it.first}: ${it.second}" }
+
+    /**
+     * Correctly encodes a string describing a URL.
+     *
+     * Taken from https://stackoverflow.com/a/25735202.
+     *
+     * @param urlString the string to encode
+     * @return an encoded URL
+     */
+    private fun encodeUrl(urlString: String) =
+        URL(urlString.replace(' ', '+'))
+            .let { URI(it.protocol, it.userInfo, IDN.toASCII(it.host), it.port, it.path, it.query, it.ref) }
+            .toASCIIString()
 }

--- a/src/main/kotlin/com/fwdekker/randomness/ErrorReporter.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/ErrorReporter.kt
@@ -95,11 +95,7 @@ class ErrorReporter : ErrorReportSubmitter() {
      */
     // Public for testability
     fun getIssueUrl(events: Array<out IdeaLoggingEvent>, additionalInfo: String?): String {
-        val baseUrl = "https://github.com/FWDekker/intellij-randomness/issues/new" +
-            "?labels=bug" +
-            "&assignee=FWDekker" +
-            "&title=Bug report" +
-            "&body="
+        val baseUrl = "https://github.com/FWDekker/intellij-randomness/issues/new?body="
         val additionalInfoSection = createMarkdownSection(
             "Additional info",
             if (additionalInfo.isNullOrBlank()) "_No additional information provided._"
@@ -115,7 +111,9 @@ class ErrorReporter : ErrorReportSubmitter() {
             versionSection,
             ""
         )
-        return baseUrl + candidates.first { encodeUrl(baseUrl + it).length <= MAX_URL_LENGTH }.replace(' ', '+')
+        return baseUrl + candidates.first { encodeUrl(baseUrl + it).length <= MAX_URL_LENGTH }
+            .replace(' ', '+')
+            .replace("&", "")
     }
 
     /**

--- a/src/main/kotlin/com/fwdekker/randomness/ErrorReporter.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/ErrorReporter.kt
@@ -93,7 +93,8 @@ class ErrorReporter : ErrorReportSubmitter() {
      * @param additionalInfo additional information provided by the user
      * @return a URL to create an issue with the given information that is below the maximum URL limit
      */
-    private fun getIssueUrl(events: Array<out IdeaLoggingEvent>, additionalInfo: String?): String {
+    // Public for testability
+    fun getIssueUrl(events: Array<out IdeaLoggingEvent>, additionalInfo: String?): String {
         val baseUrl = "https://github.com/FWDekker/intellij-randomness/issues/new" +
             "?labels=bug" +
             "&assignee=FWDekker" +
@@ -114,7 +115,7 @@ class ErrorReporter : ErrorReportSubmitter() {
             versionSection,
             ""
         )
-        return baseUrl + candidates.first { encodeUrl(it).length <= MAX_URL_LENGTH - baseUrl.length }.replace(' ', '+')
+        return baseUrl + candidates.first { encodeUrl(baseUrl + it).length <= MAX_URL_LENGTH }.replace(' ', '+')
     }
 
     /**

--- a/src/main/resources/META-INF/change-notes.html
+++ b/src/main/resources/META-INF/change-notes.html
@@ -1,14 +1,15 @@
 <!--Insert notice here <br />
 <br />-->
-<!--<b>New features</b>
+<b>New features</b>
 <ul>
-    <li>Insert feature here.</li>
+    <li>Error reporter now has a privacy policy note.</li>
 </ul>
-<br />-->
-<!--<b>Fixes</b>
+<br />
+<b>Fixes</b>
 <ul>
-    <li>Insert fix here.</li>
+    <li>Excessively long error reports no longer cause errors.</li>
+    <li>Reserved characters in error reports are now truncated.</li>
 </ul>
-<br />-->
+<br />
 Change notes of previous updates can be found on the
 <a href="https://plugins.jetbrains.com/plugin/9836-randomness/versions">plugin repository</a>.

--- a/src/test/kotlin/com/fwdekker/randomness/ErrorReporterTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/ErrorReporterTest.kt
@@ -1,0 +1,120 @@
+package com.fwdekker.randomness
+
+import com.intellij.openapi.diagnostic.IdeaLoggingEvent
+import com.intellij.testFramework.fixtures.IdeaTestFixture
+import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
+import org.assertj.core.api.Assertions.assertThat
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+
+/**
+ * Unit tests for [ErrorReporter].
+ */
+object ErrorReporterTest : Spek({
+    describe("error reporter") {
+        lateinit var ideaFixture: IdeaTestFixture
+        lateinit var reporter: ErrorReporter
+
+
+        beforeEachTest {
+            ideaFixture = IdeaTestFixtureFactory.getFixtureFactory().createBareFixture()
+            ideaFixture.setUp()
+
+            reporter = ErrorReporter()
+        }
+
+        afterEachTest {
+            ideaFixture.tearDown()
+        }
+
+
+        describe("issue url") {
+            it("includes all components if they fit in the URL") {
+                val url = reporter.getIssueUrl(
+                    arrayOf(IdeaLoggingEvent("", Exception("EXCEPTION"))),
+                    "ADDITIONAL_INFO"
+                )
+
+                assertThat(url)
+                    .contains("ADDITIONAL_INFO")
+                    .contains("EXCEPTION")
+                    .contains("Randomness+version")
+            }
+
+            it("excludes the stacktraces if they are too long") {
+                val url = reporter.getIssueUrl(
+                    arrayOf(IdeaLoggingEvent("", Exception("EXCEPTION_${List(10000) { "A" }}"))),
+                    "ADDITIONAL_INFO"
+                )
+
+                assertThat(url)
+                    .contains("ADDITIONAL_INFO")
+                    .doesNotContain("EXCEPTION")
+                    .contains("Randomness+version")
+            }
+
+            it("excludes the additional info if they are too long") {
+                val url = reporter.getIssueUrl(
+                    arrayOf(IdeaLoggingEvent("", Exception("EXCEPTION"))),
+                    "ADDITIONAL_INFO_${List(10000) { "A" }}"
+                )
+
+                assertThat(url)
+                    .doesNotContain("ADDITIONAL_INFO")
+                    .contains("EXCEPTION")
+                    .contains("Randomness+version")
+            }
+
+            it("excludes both additional info and stacktraces if either is too long") {
+                val url = reporter.getIssueUrl(
+                    arrayOf(IdeaLoggingEvent("", Exception("EXCEPTION_${List(10000) { "A" }}"))),
+                    "ADDITIONAL_INFO_${List(10000) { "A" }}"
+                )
+
+                assertThat(url)
+                    .doesNotContain("ADDITIONAL_INFO")
+                    .doesNotContain("EXCEPTION")
+                    .contains("Randomness+version")
+            }
+
+            describe("encoding") {
+                it("includes all parts that are not expanded due to encoding") {
+                    val url = reporter.getIssueUrl(
+                        arrayOf(IdeaLoggingEvent("", Exception("EXCEPTION"))),
+                        "ADDITIONAL_INFO_${List(2000) { "A" }}"
+                    )
+
+                    assertThat(url)
+                        .contains("ADDITIONAL_INFO")
+                        .contains("EXCEPTION")
+                        .contains("Randomness+version")
+                }
+
+                it("does not expand whitespace") {
+                    val url = reporter.getIssueUrl(
+                        arrayOf(IdeaLoggingEvent("", Exception("EXCEPTION"))),
+                        "ADDITIONAL_INFO_${List(2000) { " " }}_" // Trailing ` ` to prevent trimming
+                    )
+
+                    assertThat(url)
+                        .contains("ADDITIONAL_INFO")
+                        .contains("EXCEPTION")
+                        .contains("Randomness+version")
+                }
+
+                it("excludes parts that are expanded") {
+                    val url = reporter.getIssueUrl(
+                        arrayOf(IdeaLoggingEvent("", Exception("EXCEPTION"))),
+                        "ADDITIONAL_INFO_${List(2000) { "\n" }}"
+                    )
+
+                    assertThat(url)
+                        .doesNotContain("ADDITIONAL_INFO")
+                        .contains("EXCEPTION")
+                        .contains("Randomness+version")
+                }
+            }
+        }
+    }
+})


### PR DESCRIPTION
Fixes #330 by trying out various combinations of the available information and choosing the option that fits given the maximum URL length supported by GitHub.

Fixes #335 by truncating ampersands altogether. The `BrowserUtil` currently cannot handle ampersands that are not used to separate query parameters because if they are not escaped they will be treated as query parameters, and if they are escaped with `%26` then the `%` in there will be escaped to `%25` resulting in `%2526` and then a literal `%26` in the input field. Similar issues apply to `#`, `;`, and ` `. Also see [IDEA-244360](https://youtrack.jetbrains.com/issue/IDEA-244360).