### PR TITLE
Add dictionary help information to settings

### DIFF
--- a/src/main/kotlin/com/fwdekker/randomness/integer/IntegerSettings.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/integer/IntegerSettings.kt
@@ -106,12 +106,12 @@ data class IntegerScheme(
         /**
          * The minimum value of the [base][base] field.
          */
-        const val MIN_BASE = 2
+        const val MIN_BASE = Character.MIN_RADIX
 
         /**
          * The maximum value of the [base][base] field.
          */
-        const val MAX_BASE = 36
+        const val MAX_BASE = Character.MAX_RADIX
 
         /**
          * The definition of decimal base.

--- a/src/main/kotlin/com/fwdekker/randomness/string/StringSettings.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/string/StringSettings.kt
@@ -88,7 +88,7 @@ data class StringScheme(
      * Same as [symbolSets], except that all emoji are serialized.
      */
     @get:MapAnnotation(sortBeforeSave = false)
-    @Suppress("unused" /* Used by serializer */)
+    @Suppress("unused") // Used by serializer
     var serializedSymbolSets: Map<String, String>
         get() = symbolSets.map { SymbolSet(it.key, EmojiParser.parseToAliases(it.value)) }.toMap()
         set(value) {
@@ -99,7 +99,7 @@ data class StringScheme(
      * Same as [activeSymbolSets], except that all emoji are serialized.
      */
     @get:MapAnnotation(sortBeforeSave = false)
-    @Suppress("unused" /* Used by serializer */)
+    @Suppress("unused") // Used by serializer
     var serializedActiveSymbolSets: Map<String, String>
         get() = activeSymbolSets.map { SymbolSet(it.key, EmojiParser.parseToAliases(it.value)) }.toMap()
         set(value) {

--- a/src/main/kotlin/com/fwdekker/randomness/ui/ActivityTableModelEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/ui/ActivityTableModelEditor.kt
@@ -103,11 +103,11 @@ abstract class ActivityTableModelEditor<T>(
 
         val copyAction =
             object : ToolbarDecorator.ElementActionButton(IdeBundle.message("button.copy"), PlatformIcons.COPY_ICON) {
-                // Implementation based on `TableModelEditor#createComponent`
                 override fun actionPerformed(e: AnActionEvent) = copySelectedItems(table)
 
                 override fun isEnabled() = table.selection.all { isCopyable(it.datum) }
             }
+        // Implementation based on `TableModelEditor#createComponent`
         return TableModelEditor::class.java.getDeclaredField("toolbarDecorator")
             .apply { isAccessible = true }
             .let { it.get(this) as ToolbarDecorator }

--- a/src/main/kotlin/com/fwdekker/randomness/ui/PreviewPanel.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/ui/PreviewPanel.kt
@@ -47,6 +47,9 @@ class PreviewPanel(private val getGenerator: () -> DataInsertAction) {
 
 
     init {
+        previewLabel.border = null
+        previewLabel.isFocusable = false
+
         refreshButton.addMouseListener(object : MouseListener {
             override fun mouseReleased(e: MouseEvent?) = Unit
 

--- a/src/main/kotlin/com/fwdekker/randomness/word/WordSettingsComponent.form
+++ b/src/main/kotlin/com/fwdekker/randomness/word/WordSettingsComponent.form
@@ -3,7 +3,7 @@
   <grid id="27dc6" binding="contentPane" layout-manager="GridLayoutManager" row-count="9" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="726" height="381"/>
+      <xy x="20" y="20" width="726" height="409"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -225,7 +225,7 @@
           </grid>
         </constraints>
       </vspacer>
-      <grid id="3ace5" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="3ace5" layout-manager="GridLayoutManager" row-count="3" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="7" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -249,6 +249,20 @@
             <border type="none"/>
             <children/>
           </grid>
+          <component id="915cd" class="javax.swing.JTextArea" binding="dictionaryHelp">
+            <constraints>
+              <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="6" anchor="0" fill="3" indent="0" use-parent-layout="false">
+                <preferred-size width="150" height="50"/>
+              </grid>
+            </constraints>
+            <properties>
+              <editable value="false"/>
+              <lineWrap value="true"/>
+              <opaque value="false"/>
+              <text resource-bundle="randomness" key="settings.dictionary_help"/>
+              <wrapStyleWord value="true"/>
+            </properties>
+          </component>
         </children>
       </grid>
       <vspacer id="7cea5">

--- a/src/main/kotlin/com/fwdekker/randomness/word/WordSettingsComponent.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/word/WordSettingsComponent.kt
@@ -14,11 +14,14 @@ import com.fwdekker.randomness.word.WordScheme.Companion.DEFAULT_CAPITALIZATION
 import com.fwdekker.randomness.word.WordScheme.Companion.DEFAULT_ENCLOSURE
 import com.fwdekker.randomness.word.WordSettings.Companion.DEFAULT_SCHEMES
 import com.fwdekker.randomness.word.WordSettings.Companion.default
+import com.intellij.ui.components.JBLabel
+import com.intellij.util.ui.UIUtil
 import com.jgoodies.forms.factories.DefaultComponentFactory
 import java.util.ResourceBundle
 import javax.swing.ButtonGroup
 import javax.swing.JComponent
 import javax.swing.JPanel
+import javax.swing.JTextArea
 
 
 /**
@@ -45,12 +48,17 @@ class WordSettingsComponent(settings: WordSettings = default) : SettingsComponen
     private lateinit var dictionaryPanel: JPanel
     private lateinit var dictionarySeparator: JComponent
     private lateinit var dictionaryTable: DictionaryTable
+    private lateinit var dictionaryHelp: JTextArea
 
     override val rootPane get() = contentPane
 
 
     init {
         loadSettings()
+
+        dictionaryHelp.border = null
+        dictionaryHelp.font = JBLabel().font.deriveFont(UIUtil.getFontSize(UIUtil.FontSize.SMALL))
+        dictionaryHelp.isFocusable = false
 
         previewPanelHolder.updatePreviewOnUpdateOf(minLength, maxLength, capitalizationGroup, enclosureGroup)
         previewPanelHolder.updatePreviewOnUpdateOf(dictionaryTable)

--- a/src/main/resources/META-INF/change-notes.html
+++ b/src/main/resources/META-INF/change-notes.html
@@ -1,8 +1,12 @@
-Minimum IDE version now 2019.3.<br />
+<b>Breaking changes</b>
+<ul>
+    <li>Minimum IDE version now 2019.3.</li>
+</ul>
 <br />
 <b>New features</b>
 <ul>
-    <li>Change capitalization of integers base decimal+.</li>
+    <li>Change capitalization of integers base greater than 10.</li>
+    <li>Added in-app help info about dictionaries.</li>
 </ul>
 <br />
 <!--<b>Fixes</b>-->

--- a/src/main/resources/randomness.properties
+++ b/src/main/resources/randomness.properties
@@ -13,6 +13,7 @@ settings.capitalization.upper                    = UPPER
 settings.count                                   = &Count:
 settings.decimal_separator                       = Decimal separator:
 settings.dictionaries                            = Dictionaries
+settings.dictionary_help                         = Dictionary files (*.dic) contain one word per line. Lines starting with a # are ignored. Dictionary contents are refreshed after opening the settings or after restarting the IDE.
 settings.grouping_separator                      = Grouping separator:
 settings.maximum_length                          = Ma&ximum length:
 settings.maximum_value                           = Ma&ximum value:


### PR DESCRIPTION
Fixes #347.

Also slightly improves the appearance of the preview text by removing the border and making it unselectable.