### PR TITLE
Improve dictionary table support for drag and drop

### DIFF
--- a/src/main/kotlin/com/fwdekker/randomness/word/DictionaryTable.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/word/DictionaryTable.kt
@@ -81,7 +81,7 @@ class DictionaryTable : ActivityTableModelEditor<DictionaryReference>(
             override fun valueOf(item: EditableDictionary) = item.datum.filename
 
             override fun setValue(item: EditableDictionary, value: String) {
-                item.datum.filename = value
+                item.datum.filename = value.removePrefix("file://")
             }
 
             override fun isCellEditable(item: EditableDictionary) = !item.datum.isBundled

--- a/src/main/resources/META-INF/change-notes.html
+++ b/src/main/resources/META-INF/change-notes.html
@@ -12,6 +12,7 @@
     <li>Altered dictionary table column widths. (#354)</li>
     <li>Improve detection of updated dictionaries in settings screen. (#354)</li>
     <li>Detect invalid settings even when settings have not been changed. (#354)</li>
+    <li>Add improved support for drag-and-drop of dictionaries. (#350)</li>
 </ul>
 <br />
 <b>Fixes</b>


### PR DESCRIPTION
Fixes #350.

Implementing advanced drag and drop (e.g. drag files to table, files are then added as user dictionaries) was not possible because the IntelliJ classes do not support adding a custom `TransferHandler`. This would require hacking deeply into `ToolbarDecorator`, which does not seem feasible or at all stable. Instead, the only change introduced by this PR is that when a file is dragged onto the location editor, the `file://` at the start that may appear is removed. This slightly improves DnD support, but more advanced features were not possible.