### PR TITLE
Bump IDE dependency to build 201

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -110,5 +110,7 @@ dokka {
 
 // Compatibility checks
 runPluginVerifier {
-    ideVersions = ["IC-2019.3.5", "IC-2020.3", "CL-2020.3"]
+    // If latest is 20xx.y, then support at least [20xx-1].[y+1].
+    // e.g., if latest is 2020.3, support at least 2019.4 (aka 2020.1)
+    ideVersions = ["IC-2020.1.4", "IC-2020.2.4", "IC-2020.3.1", "CL-2020.3"]
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -6,7 +6,7 @@
 
     <depends>com.intellij.modules.platform</depends>
 
-    <idea-version since-build="193.0" />
+    <idea-version since-build="201.0" />
 
     <extensions defaultExtensionNs="com.intellij">
         <errorHandler implementation="com.fwdekker.randomness.ErrorReporter"/>

--- a/src/test/kotlin/com/fwdekker/randomness/word/DictionaryTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/word/DictionaryTest.kt
@@ -6,8 +6,14 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.fail
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
-import java.io.IOException
-import java.lang.IllegalArgumentException
+
+
+/**
+ * Returns `true` if the current operating system is Windows.
+ *
+ * @return `true` if the current operating system is Windows
+ */
+fun isWindows() = System.getProperty("os.name").toLowerCase().contains("win")
 
 
 /**
@@ -160,6 +166,8 @@ object DictionaryTest : Spek({
             }
 
             it("fails if the file exists but cannot be accessed") {
+                if (isWindows()) return@it // setReadable does not work in Windows
+
                 val dictionaryFile = tempFileHelper.createFile("ladder\nkempt\npork", ".dic")
                     .also { it.setReadable(false) }
                 val dictionary = UserDictionary.cache.get(dictionaryFile.absolutePath, false)
@@ -317,6 +325,8 @@ object DictionaryReferenceTest : Spek({
 
     describe("validation") {
         it("fails for an invalid dictionary") {
+            if (isWindows()) return@it // setReadable does not work in Windows
+
             val dictionaryFile = tempFileHelper.createFile("contents\n", ".dic")
                 .also { it.setReadable(false) }
             val dictionary = UserDictionary.cache.get(dictionaryFile.absolutePath, false)
@@ -326,6 +336,8 @@ object DictionaryReferenceTest : Spek({
         }
 
         it("no longer fails for a now-valid dictionary") {
+            if (isWindows()) return@it // setReadable does not work in Windows
+
             val dictionaryFile = tempFileHelper.createFile("contents\n", ".dic")
                 .also { it.setReadable(false) }
             val dictionary = UserDictionary.cache.get(dictionaryFile.absolutePath, false)


### PR DESCRIPTION
Updates minimum IDE version from 193 to 201. This is because the plugin verifier detected that `.children` in `RandomConfigurable` does not work in build 193 when compiled for 203 (even though it works for 193 when compiled for 193) and because some `label` functions using the Kotlin UI DSL in `RandomConfigurable` also didn't work.

Additionally, this PR
* disables a few tests on Windows machines that do not work there,
* adds more IDE versions to check for the compatibility verifier,
* and clarifies the build compatibility rule from #209 with a line in `build.gradle`.