### PR TITLE
Add randomLong function to prevent overflows

### DIFF
--- a/src/main/kotlin/com/fwdekker/randomness/decimal/DecimalSettingsComponent.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/decimal/DecimalSettingsComponent.kt
@@ -76,7 +76,7 @@ class DecimalSettingsComponent(settings: DecimalSettings = default) :
 
         minValue = JDoubleSpinner(description = "minimum value")
         maxValue = JDoubleSpinner(description = "maximum value")
-        valueRange = JSpinnerRange(minValue, maxValue, name = "value")
+        valueRange = JSpinnerRange(minValue, maxValue, MAX_VALUE_RANGE, name = "value")
 
         decimalCount = JIntSpinner(0, 0, description = "decimal count")
     }
@@ -120,5 +120,13 @@ class DecimalSettingsComponent(settings: DecimalSettings = default) :
             get() = DecimalScheme::class.java
 
         override fun createDefaultInstances() = DEFAULT_SCHEMES
+    }
+
+
+    companion object {
+        /**
+         * The maximum difference between the minimum and maximum values that can be generated.
+         */
+        private const val MAX_VALUE_RANGE = 1E53
     }
 }

--- a/src/main/kotlin/com/fwdekker/randomness/integer/IntegerActions.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/integer/IntegerActions.kt
@@ -51,9 +51,21 @@ class IntegerInsertAction(private val scheme: IntegerScheme = IntegerSettings.de
             if (scheme.minValue > scheme.maxValue)
                 throw DataGenerationException("Minimum value is larger than maximum value.")
 
-            scheme.prefix + convertToString(random.nextLong(scheme.minValue, scheme.maxValue + 1)) + scheme.suffix
+            scheme.prefix + convertToString(randomLong(scheme.minValue, scheme.maxValue)) + scheme.suffix
         }
 
+
+    /**
+     * Returns a random long in the given inclusive range without causing overflow.
+     *
+     * @param from inclusive lower bound
+     * @param until inclusive upper bound
+     * @return a random long in the given inclusive
+     */
+    private fun randomLong(from: Long, until: Long) =
+        if (from == Long.MIN_VALUE && until == Long.MAX_VALUE) random.nextLong()
+        else if (until == Long.MAX_VALUE) random.nextLong(from - 1, until) + 1
+        else random.nextLong(from, until + 1)
 
     /**
      * Returns a nicely formatted representation of an integer.

--- a/src/main/kotlin/com/fwdekker/randomness/ui/JSpinnerRange.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/ui/JSpinnerRange.kt
@@ -15,7 +15,7 @@ import javax.swing.JSpinner
 class JSpinnerRange(
     private val min: JSpinner,
     private val max: JSpinner,
-    private val maxRange: Double = DEFAULT_MAX_RANGE,
+    private val maxRange: Double? = null,
     name: String? = null
 ) {
     /**
@@ -37,7 +37,8 @@ class JSpinnerRange(
 
 
     init {
-        require(maxRange >= 0) { "maxRange must be a positive number." }
+        if (maxRange != null)
+            require(maxRange >= 0) { "maxRange must be a positive number." }
 
         min.addChangeListener { if (minValue > maxValue) max.value = minValue }
         max.addChangeListener { if (maxValue < minValue) min.value = maxValue }
@@ -52,16 +53,11 @@ class JSpinnerRange(
      */
     fun validateValue() =
         when {
-            minValue > maxValue -> ValidationInfo("The maximum$name should not be smaller than the minimum$name.", max)
-            maxValue - minValue > maxRange -> ValidationInfo("The$name range should not exceed $maxRange.", max)
-            else -> null
+            minValue > maxValue ->
+                ValidationInfo("The maximum$name should not be smaller than the minimum$name.", max)
+            maxRange != null && maxValue - minValue > maxRange ->
+                ValidationInfo("The$name range should not exceed $maxRange.", max)
+            else ->
+                null
         }
-
-
-    companion object {
-        /**
-         * The maximum span that can be expressed.
-         */
-        private const val DEFAULT_MAX_RANGE = 1E53
-    }
 }

--- a/src/test/kotlin/com/fwdekker/randomness/integer/IntegerInsertActionTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/integer/IntegerInsertActionTest.kt
@@ -19,7 +19,9 @@ class IntegerInsertActionTest : Spek({
             Pair(1L, 1L) to "1",
             Pair(-5L, -5L) to "-5",
             Pair(488L, 488L) to "488",
-            Pair(-876L, -876L) to "-876"
+            Pair(-876L, -876L) to "-876",
+            Pair(Long.MIN_VALUE, Long.MIN_VALUE) to Long.MIN_VALUE.toString(),
+            Pair(Long.MAX_VALUE, Long.MAX_VALUE) to Long.MAX_VALUE.toString(),
         ).forEach { (minValue, maxValue), expectedString ->
             it("generates $expectedString") {
                 val integerScheme = IntegerScheme(minValue = minValue, maxValue = maxValue)
@@ -31,11 +33,23 @@ class IntegerInsertActionTest : Spek({
             }
         }
 
-        it("throws an exception of the minimum is larger than the maximum") {
+        it("throws an exception if the minimum is larger than the maximum") {
             val action = IntegerInsertAction(IntegerScheme(minValue = 65, maxValue = 24))
             Assertions.assertThatThrownBy { action.generateString() }
                 .isInstanceOf(DataGenerationException::class.java)
                 .hasMessage("Minimum value is larger than maximum value.")
+        }
+
+        it("generates a random value at maximum range size") {
+            val integerScheme = IntegerScheme(minValue = Long.MIN_VALUE, maxValue = Long.MAX_VALUE)
+
+            val insertRandomInteger = IntegerInsertAction(integerScheme)
+            val randomString = insertRandomInteger.generateString()
+
+            // Passes with extremely high probability (p = 1 - (2/(2^64))
+            assertThat(randomString)
+                .isNotEqualTo(Long.MIN_VALUE.toString())
+                .isNotEqualTo(Long.MAX_VALUE.toString())
         }
     }
 

--- a/src/test/kotlin/com/fwdekker/randomness/ui/JSpinnerRangeTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/ui/JSpinnerRangeTest.kt
@@ -43,11 +43,11 @@ object JSpinnerRangeTest : Spek({
         }
 
         it("returns validation information if the default range is exceeded") {
-            val range = JSpinnerRange(createJSpinner(-1E53), createJSpinner(1E53))
+            val range = JSpinnerRange(createJSpinner(-546.51), createJSpinner(454.86), 786.15)
 
             val info = range.validateValue()
             assertThat(info).isNotNull()
-            assertThat(info?.message).isEqualTo("The range should not exceed 1.0E53.")
+            assertThat(info?.message).isEqualTo("The range should not exceed 786.15.")
         }
 
         it("returns validation information if a custom range is exceeded") {


### PR DESCRIPTION
Adds a simple wrapper `randomLong` around `random.nextLong` that generates a random number in an inclusive range, regardless of the range between the `from` and `until`.

Removes the need for a maximum value range in integer settings.

Fixes #367 and fixes #370.