### PR TITLE
Add timeout for generating values

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,7 +56,7 @@ tasks {
     withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
         kotlinOptions {
             jvmTarget = properties("jvmVersion")
-            apiVersion = properties("kotlinVersion")
+            apiVersion = properties("kotlinApiVersion")
             languageVersion = properties("kotlinVersion")
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,9 +12,10 @@ pluginVerifierIdeVersions = IC-2020.2.4, IC-2020.3.4, IC-2021.1.1, CL-2021.1.1
 # Targets
 #   * `javaVersion` is the same as `jvmVersion`
 #   * Kotlin should also be updated in `plugins` block
-javaVersion   = 8
-jvmVersion    = 1.8
-kotlinVersion = 1.5
+javaVersion      = 8
+jvmVersion       = 1.8
+kotlinVersion    = 1.5
+kotlinApiVersion = 1.4
 
 # Dependencies
 #   Detekt and Dokka should also be updated in `plugins` block

--- a/src/main/kotlin/com/fwdekker/randomness/array/ArraySettingsComponent.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/array/ArraySettingsComponent.kt
@@ -23,7 +23,6 @@ import javax.swing.event.ChangeEvent
  * Component for settings of random array generation.
  *
  * @param settings the settings to edit in the component
- *
  * @see ArraySettingsAction
  */
 @Suppress("LateinitUsage") // Initialized by scene builder

--- a/src/main/kotlin/com/fwdekker/randomness/decimal/DecimalActions.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/decimal/DecimalActions.kt
@@ -46,13 +46,12 @@ class DecimalInsertAction(private val scheme: DecimalScheme = DecimalSettings.de
      * @param count the number of decimals to generate
      * @return random decimals between the minimum and maximum value, inclusive
      */
-    override fun generateStrings(count: Int) =
-        List(count) {
-            if (scheme.minValue > scheme.maxValue)
-                throw DataGenerationException("Minimum value is larger than maximum value.")
+    override fun generateStrings(count: Int): List<String> {
+        if (scheme.minValue > scheme.maxValue)
+            throw DataGenerationException("Minimum value is larger than maximum value.")
 
-            convertToString(random.nextDouble(scheme.minValue, scheme.maxValue.nextUp()))
-        }
+        return List(count) { convertToString(random.nextDouble(scheme.minValue, scheme.maxValue.nextUp())) }
+    }
 
 
     /**

--- a/src/main/kotlin/com/fwdekker/randomness/integer/IntegerActions.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/integer/IntegerActions.kt
@@ -46,13 +46,14 @@ class IntegerInsertAction(private val scheme: IntegerScheme = IntegerSettings.de
      * @param count the number of integers to generate
      * @return random integers between the minimum and maximum value, inclusive
      */
-    override fun generateStrings(count: Int) =
-        List(count) {
-            if (scheme.minValue > scheme.maxValue)
-                throw DataGenerationException("Minimum value is larger than maximum value.")
+    override fun generateStrings(count: Int): List<String> {
+        if (scheme.minValue > scheme.maxValue)
+            throw DataGenerationException("Minimum value is larger than maximum value.")
 
+        return List(count) {
             scheme.prefix + convertToString(randomLong(scheme.minValue, scheme.maxValue)) + scheme.suffix
         }
+    }
 
 
     /**

--- a/src/main/kotlin/com/fwdekker/randomness/string/StringActions.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/string/StringActions.kt
@@ -11,7 +11,6 @@ import com.fwdekker.randomness.DataSettingsAction
 import com.fwdekker.randomness.array.ArrayScheme
 import com.fwdekker.randomness.array.ArraySettings
 import com.fwdekker.randomness.array.ArraySettingsAction
-import com.vdurmont.emoji.EmojiParser
 import icons.RandomnessIcons
 
 
@@ -45,35 +44,21 @@ class StringInsertAction(private val scheme: StringScheme = StringSettings.defau
      * @param count the number of strings to generate
      * @return strings of random alphanumerical characters
      */
-    override fun generateStrings(count: Int) =
-        List(count) {
-            if (scheme.minLength > scheme.maxLength)
-                throw DataGenerationException("Minimum length is larger than maximum length.")
+    override fun generateStrings(count: Int): List<String> {
+        if (scheme.minLength > scheme.maxLength)
+            throw DataGenerationException("Minimum length is larger than maximum length.")
 
+        val symbols = scheme.activeSymbolSetList.sum(scheme.excludeLookAlikeSymbols)
+        if (symbols.isEmpty())
+            throw DataGenerationException("No valid symbols found in active symbol sets.")
+
+        return List(count) {
             val length = random.nextInt(scheme.minLength, scheme.maxLength + 1)
-
-            val text = List(length) { generateCharacter() }.joinToString("")
+            val text = List(length) { symbols.random(random) }.joinToString("")
             val capitalizedText = scheme.capitalization.transform(text)
 
             scheme.enclosure + capitalizedText + scheme.enclosure
         }
-
-
-    /**
-     * Returns a random character from the symbol sets in `settings`.
-     *
-     * @return a random character from the symbol sets in `settings`
-     * @throws DataGenerationException if a random character could not be generated
-     */
-    @Throws(DataGenerationException::class)
-    private fun generateCharacter(): String {
-        val symbolSet = scheme.activeSymbolSetList.sum(excludeLookAlikeSymbols = scheme.excludeLookAlikeSymbols)
-        if (symbolSet.isEmpty())
-            throw DataGenerationException("No valid symbols found in active symbol sets.")
-
-        val symbolList =
-            EmojiParser.extractEmojis(symbolSet) + EmojiParser.removeAllEmojis(symbolSet).map { it.toString() }
-        return symbolList[random.nextInt(symbolList.size)]
     }
 
 

--- a/src/main/kotlin/com/fwdekker/randomness/string/SymbolSet.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/string/SymbolSet.kt
@@ -92,21 +92,20 @@ fun Collection<SymbolSet>.toMap() = this.map { (name, symbols) -> name to symbol
 fun Map<String, String>.toSymbolSets() = this.map { (name, symbols) -> SymbolSet(name, symbols) }.toList()
 
 /**
- * Concatenates the symbols of all the symbol sets, removing duplicate characters.
+ * Combines the symbols of all the symbol sets, optionally removing duplicate characters.
  *
  * This method respects emoji sequences and will not remove duplicate characters if these characters are essential to
  * displaying the embedded emoji correctly.
  *
  * @param excludeLookAlikeSymbols whether to remove symbols that occur in [SymbolSet.lookAlikeCharacters]
- * @return the concatenation of all symbols of all the symbol sets, excluding duplicate characters
+ * @return a list of all symbols in all active symbol sets, optionally excluding duplicate characters
  */
-fun Iterable<SymbolSet>.sum(excludeLookAlikeSymbols: Boolean = false) =
+fun Iterable<SymbolSet>.sum(excludeLookAlikeSymbols: Boolean = false): List<String> =
     this.fold("") { acc, symbolSet -> acc + symbolSet.symbols }
         .let { Pair(EmojiParser.extractEmojis(it).distinct(), EmojiParser.removeAllEmojis(it).toList().distinct()) }
+        .let { (emoji, noEmoji) -> Pair(emoji, noEmoji.map { it.toString() }) }
         .let { (emoji, noEmoji) ->
-            emoji.joinToString("") +
-                (
-                    if (excludeLookAlikeSymbols) noEmoji.filterNot { it in SymbolSet.lookAlikeCharacters }
-                    else noEmoji
-                    ).joinToString("") // TODO: Fix this indenting :(
+            emoji +
+                if (excludeLookAlikeSymbols) noEmoji.filterNot { it in SymbolSet.lookAlikeCharacters }
+                else noEmoji
         }

--- a/src/main/kotlin/com/fwdekker/randomness/ui/PreviewPanel.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/ui/PreviewPanel.kt
@@ -87,9 +87,9 @@ class PreviewPanel(private val getGenerator: () -> DataInsertAction) {
     @Suppress("SwallowedException") // Alternative is to add coupling to SettingsComponent
     fun updatePreview() {
         try {
-            previewLabel.text = getGenerator().also { it.random = Random(seed) }.generateString()
+            previewLabel.text = getGenerator().also { it.random = Random(seed) }.generateStringTimely()
         } catch (e: DataGenerationException) {
-            // Ignore exception; invalid settings are handled by form validation
+            previewLabel.text = "Settings are invalid: ${e.message}"
         } catch (e: IllegalArgumentException) {
             // Ignore exception; invalid settings are handled by form validation
         }

--- a/src/main/kotlin/com/fwdekker/randomness/uuid/UuidActions.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/uuid/UuidActions.kt
@@ -67,8 +67,7 @@ class UuidInsertAction(private val scheme: UuidScheme = UuidSettings.default.cur
             else -> throw DataGenerationException("Unknown UUID version `${scheme.version}`.")
         }
 
-        return (0 until count)
-            .map { generator.generate().toString() }
+        return List(count) { generator.generate().toString() }
             .map { scheme.capitalization.transform(it) }
             .map {
                 if (scheme.addDashes) it

--- a/src/main/kotlin/com/fwdekker/randomness/word/WordActions.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/word/WordActions.kt
@@ -60,8 +60,7 @@ class WordInsertAction(private val scheme: WordScheme = WordSettings.default.cur
                 .toSet()
                 .ifEmpty { throw DataGenerationException("There are no words within the configured length range.") }
 
-        return (0 until count)
-            .map { words.random(random) }
+        return List(count) { words.random(random) }
             .map { scheme.capitalization.transform(it) }
             .map { scheme.enclosure + it + scheme.enclosure }
     }

--- a/src/main/resources/META-INF/change-notes.html
+++ b/src/main/resources/META-INF/change-notes.html
@@ -16,6 +16,12 @@
         Add byte-type integer.
         (<a href="https://github.com/FWDekker/intellij-randomness/issues/368">#368</a>)
     </li>
+    <li>
+        Timeout:
+        Stops if generating takes too long.
+        Also, significantly improved performance for generating long strings.
+        (<a href="https://github.com/FWDekker/intellij-randomness/issues/373">#373</a>)
+    </li>
 </ul>
 <br />
 <b>Fixes</b>

--- a/src/test/kotlin/com/fwdekker/randomness/string/SymbolSetTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/string/SymbolSetTest.kt
@@ -73,36 +73,43 @@ object SymbolSetTest : Spek({
 
         describe("sum") {
             it("does nothing when a symbol set is added to itself") {
-                assertThat(listOf(SymbolSet.SPECIAL, SymbolSet.SPECIAL).sum()).isEqualTo(SymbolSet.SPECIAL.symbols)
+                assertThat(listOf(SymbolSet.SPECIAL, SymbolSet.SPECIAL).sum())
+                    .isEqualTo(SymbolSet.SPECIAL.symbols.toList().map { it.toString() })
             }
 
             it("adds the symbols of three symbol sets together") {
                 assertThat(listOf(SymbolSet.DIGITS, SymbolSet.MINUS, SymbolSet.SPECIAL).sum())
-                    .isEqualTo("0123456789-!@#\$%^&*")
+                    .isEqualTo("0123456789-!@#\$%^&*".toList().map { it.toString() })
             }
 
             it("does not add symbols that are already in the accumulator") {
-                assertThat(listOf(SymbolSet("set1", "abc"), SymbolSet("set2", "cde")).sum()).isEqualTo("abcde")
+                assertThat(listOf(SymbolSet("set1", "abc"), SymbolSet("set2", "cde")).sum())
+                    .isEqualTo("abcde".toList().map { it.toString() })
             }
 
             it("does not add symbols that are duplicated in a symbol set") {
-                assertThat(listOf(SymbolSet("set1", "abc"), SymbolSet("set2", "ddeef")).sum()).isEqualTo("abcdef")
+                assertThat(listOf(SymbolSet("set1", "abc"), SymbolSet("set2", "ddeef")).sum())
+                    .isEqualTo("abcdef".toList().map { it.toString() })
             }
 
             it("removes look-alike symbols if the option is given") {
-                assertThat(listOf(SymbolSet("set", "a" + SymbolSet.lookAlikeCharacters)).sum(true)).isEqualTo("a")
+                assertThat(listOf(SymbolSet("set", "a" + SymbolSet.lookAlikeCharacters)).sum(true))
+                    .isEqualTo("a".toList().map { it.toString() })
             }
 
             it("retains emoji with modifiers") {
-                assertThat(listOf(SymbolSet("emoji", "a👨‍💼b")).sum()).isEqualTo("👨‍💼ab")
+                assertThat(listOf(SymbolSet("emoji", "a👨‍💼b")).sum())
+                    .isEqualTo(listOf("👨‍💼", "a", "b"))
             }
 
             it("retains duplicate characters in emoji") {
-                assertThat(listOf(SymbolSet("emoji", "🇦🇶🇦")).sum()).isEqualTo("🇦🇶🇦")
+                assertThat(listOf(SymbolSet("emoji", "🇦🇶🇦")).sum())
+                    .isEqualTo(listOf("🇦🇶", "🇦"))
             }
 
             it("removes duplicate emoji") {
-                assertThat(listOf(SymbolSet("emoji", "🇦🇶😀🇦🇶😀")).sum()).isEqualTo("🇦🇶😀")
+                assertThat(listOf(SymbolSet("emoji", "🇦🇶😀🇦🇶😀")).sum())
+                    .isEqualTo(listOf("🇦🇶", "😀"))
             }
         }
     }


### PR DESCRIPTION
Fixes #373.

I also fixed a warning about a mismatch between Kotlin 1.4 and 1.5, which was an important one because otherwise the compiled code wouldn't have run on IDEs that have Kotlin 1.4 bundled instead of the desired 1.3.

This PR also majorly improves the speed of generating strings, because it combines the symbol sets before it generates the characters instead of re-calculating it for each character; and then it re-uses the combined set for each string to be generated. 10 strings of length 99,999 are now generated almost instantly; before this PR this took several seconds. Additionally, it removes a step where all emoji were parsed to a string and then separated back into a list; now it just keeps them in the initial list form.

This PR also shifts around a bit of error checking in other generator methods to make sure those checks happen only once before all strings are generated instead of checking it again for each string.