### PR TITLE
Prevent symbol set setting truncation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 Felix W. Dekker
+Copyright (c) 2017 F.W. Dekker
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -132,5 +132,7 @@ In chronological order of contribution:
   [in several places](https://github.com/FWDekker/intellij-randomness/issues/365#issuecomment-805052007),
   [suggesting the removal of the integer range limit](https://github.com/FWDekker/intellij-randomness/issues/367), and
   [suggesting the byte preset](https://github.com/FWDekker/intellij-randomness/issues/368)!
+* Thanks to [Martin Kaspar van Laak](https://github.com/MartinKvL) for
+  [reporting that symbol sets didn't get saved](https://github.com/FWDekker/intellij-randomness/issues/382)!
 
 If I should add, remove, or change anything here, just open an issue or email me!

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group   = com.fwdekker
-version = 2.7.1
+version = 2.7.2-dev
 
 # Compatibility
 # * If latest is 20xx.y, then support at least [20xx-1].[y+1].

--- a/src/main/kotlin/com/fwdekker/randomness/string/StringSettings.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/string/StringSettings.kt
@@ -68,8 +68,10 @@ data class StringSettings(
  * @property maxLength The maximum length of the generated string, inclusive.
  * @property enclosure The string that encloses the generated string on both sides.
  * @property capitalization The capitalization mode of the generated string.
- * @property symbolSets The symbol sets that are available for generating strings.
+ * @property symbolSets The symbol sets that are available for generating strings. Emoji have been serialized for
+ * compatibility with JetBrains' serializer.
  * @property activeSymbolSets The symbol sets that are actually used for generating strings; a subset of [symbolSets].
+ * Emoji have been serialized for compatibility with JetBrains' serializer.
  * @property excludeLookAlikeSymbols Whether the symbols in [SymbolSet.lookAlikeCharacters] should be excluded.
  *
  * @see StringInsertAction
@@ -81,32 +83,30 @@ data class StringScheme(
     var maxLength: Int = DEFAULT_MAX_LENGTH,
     var enclosure: String = DEFAULT_ENCLOSURE,
     var capitalization: CapitalizationMode = DEFAULT_CAPITALIZATION,
-    @get:Transient
-    var symbolSets: Map<String, String> = DEFAULT_SYMBOL_SETS.toMap(),
-    @get:Transient
-    var activeSymbolSets: Map<String, String> = DEFAULT_ACTIVE_SYMBOL_SETS.toMap(),
+    @MapAnnotation(sortBeforeSave = false)
+    var serializedSymbolSets: Map<String, String> = DEFAULT_SYMBOL_SETS.toMap(),
+    @MapAnnotation(sortBeforeSave = false)
+    var serializedActiveSymbolSets: Map<String, String> = DEFAULT_ACTIVE_SYMBOL_SETS.toMap(),
     var excludeLookAlikeSymbols: Boolean = DEFAULT_EXCLUDE_LOOK_ALIKE_SYMBOLS
 ) : Scheme<StringScheme> {
     /**
-     * Same as [symbolSets], except that all emoji are serialized.
+     * Same as [symbolSets], except that serialized emoji have been deserialized.
      */
-    @get:MapAnnotation(sortBeforeSave = false)
-    @Suppress("unused") // Used by serializer
-    var serializedSymbolSets: Map<String, String>
-        get() = symbolSets.map { SymbolSet(it.key, EmojiParser.parseToAliases(it.value)) }.toMap()
+    var symbolSets: Map<String, String>
+        @Transient
+        get() = serializedSymbolSets.map { SymbolSet(it.key, EmojiParser.parseToUnicode(it.value)) }.toMap()
         set(value) {
-            symbolSets = value.map { SymbolSet(it.key, EmojiParser.parseToUnicode(it.value)) }.toMap()
+            serializedSymbolSets = value.map { SymbolSet(it.key, EmojiParser.parseToAliases(it.value)) }.toMap()
         }
 
     /**
-     * Same as [activeSymbolSets], except that all emoji are serialized.
+     * Same as [activeSymbolSets], except that serialized emoji have been deserialized.
      */
-    @get:MapAnnotation(sortBeforeSave = false)
-    @Suppress("unused") // Used by serializer
-    var serializedActiveSymbolSets: Map<String, String>
-        get() = activeSymbolSets.map { SymbolSet(it.key, EmojiParser.parseToAliases(it.value)) }.toMap()
+    var activeSymbolSets: Map<String, String>
+        @Transient
+        get() = serializedActiveSymbolSets.map { SymbolSet(it.key, EmojiParser.parseToUnicode(it.value)) }.toMap()
         set(value) {
-            activeSymbolSets = value.map { SymbolSet(it.key, EmojiParser.parseToUnicode(it.value)) }.toMap()
+            serializedActiveSymbolSets = value.map { SymbolSet(it.key, EmojiParser.parseToAliases(it.value)) }.toMap()
         }
 
     /**

--- a/src/main/kotlin/com/fwdekker/randomness/string/StringSettings.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/string/StringSettings.kt
@@ -68,10 +68,10 @@ data class StringSettings(
  * @property maxLength The maximum length of the generated string, inclusive.
  * @property enclosure The string that encloses the generated string on both sides.
  * @property capitalization The capitalization mode of the generated string.
- * @property symbolSets The symbol sets that are available for generating strings. Emoji have been serialized for
- * compatibility with JetBrains' serializer.
- * @property activeSymbolSets The symbol sets that are actually used for generating strings; a subset of [symbolSets].
- * Emoji have been serialized for compatibility with JetBrains' serializer.
+ * @property serializedSymbolSets The symbol sets that are available for generating strings. Emoji have been serialized
+ * for compatibility with JetBrains' serializer.
+ * @property serializedActiveSymbolSets The symbol sets that are actually used for generating strings; a subset of
+ * [symbolSets]. Emoji have been serialized for compatibility with JetBrains' serializer.
  * @property excludeLookAlikeSymbols Whether the symbols in [SymbolSet.lookAlikeCharacters] should be excluded.
  *
  * @see StringInsertAction

--- a/src/main/resources/META-INF/change-notes.html
+++ b/src/main/resources/META-INF/change-notes.html
@@ -1,36 +1,20 @@
-<b>Breaking changes</b>
+<!--<b>Breaking changes</b>
 <p>
-    Minimum IDE version has been increased to 2020.2.
-    (<a href="https://github.com/FWDekker/intellij-randomness/pull/375">#375</a>)
+    Placeholder.
+    (<a href="https://github.com/FWDekker/intellij-randomness/pull/num">#num</a>)
 </p>
-<br />
-<b>New features</b>
+<br />-->
+<!--<b>New features</b>
 <ul>
     <li>
-        Remove limit on difference between minimum and maximum integer.
-        (<a href="https://github.com/FWDekker/intellij-randomness/issues/367">#367</a>)
-    </li>
-    <li>
-        Add "byte" integer type to generate integers from -127 to 128.
-        (<a href="https://github.com/FWDekker/intellij-randomness/issues/368">#368</a>)
-    </li>
-    <li>
-        Input field widths now reflect the expected input sizes.
-        (<a href="https://github.com/FWDekker/intellij-randomness/issues/374">#374</a>)
-    </li>
-    <li>
-        Significantly improved performance when generating long strings.
-        (<a href="https://github.com/FWDekker/intellij-randomness/issues/373">#373</a>)
-    </li>
-    <li>
-        Generator timeout prevents IntelliJ from freezing when using excessively complex inputs.
-        (<a href="https://github.com/FWDekker/intellij-randomness/issues/373">#373</a>)
+        Placeholder.
+        (<a href="https://github.com/FWDekker/intellij-randomness/issues/num">#num</a>)
     </li>
 </ul>
-<br />
+<br />-->
 <b>Fixes</b>
 <p>
-    Prevent overflows when using a large range with integers.
+    Prevent symbol set settings from being truncated after restarting IDE.
     (<a href="https://github.com/FWDekker/intellij-randomness/issues/370">#370</a>)
 </p>
 <br />

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -2,7 +2,7 @@
     <id>com.fwdekker.randomness</id>
     <name>Randomness</name>
     <version>0.0.0</version>  <!-- Patched in from `gradle.properties` -->
-    <vendor email="felix@fwdekker.com" url="https://fwdekker.com/">FWDekker</vendor>
+    <vendor email="f@fwdekker.com" url="https://fwdekker.com/">FWDekker</vendor>
 
     <depends>com.intellij.modules.platform</depends>
 

--- a/src/test/kotlin/com/fwdekker/randomness/string/StringInsertActionTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/string/StringInsertActionTest.kt
@@ -36,7 +36,7 @@ class StringInsertActionTest : Spek({
                     maxLength = maxLength,
                     enclosure = enclosure,
                     capitalization = capitalization,
-                    activeSymbolSets = symbolSets.toMap()
+                    serializedActiveSymbolSets = symbolSets.toMap()
                 )
 
                 val insertRandomString = StringInsertAction(stringScheme)
@@ -51,7 +51,7 @@ class StringInsertActionTest : Spek({
                 maxLength = 1,
                 enclosure = "",
                 capitalization = CapitalizationMode.RETAIN,
-                activeSymbolSets = setOf(SymbolSet("emoji", "👩‍👩‍👧‍👧")).toMap()
+                serializedActiveSymbolSets = setOf(SymbolSet("emoji", "👩‍👩‍👧‍👧")).toMap()
             )
 
             assertThat(StringInsertAction(stringScheme).generateString()).isEqualTo(emoji)
@@ -67,7 +67,7 @@ class StringInsertActionTest : Spek({
         }
 
         it("throws an exception if no valid symbols are found") {
-            val action = StringInsertAction(StringScheme(activeSymbolSets = emptyMap()))
+            val action = StringInsertAction(StringScheme(serializedActiveSymbolSets = emptyMap()))
             Assertions.assertThatThrownBy { action.generateString() }
                 .isInstanceOf(DataGenerationException::class.java)
                 .hasMessage("No valid symbols found in active symbol sets.")

--- a/src/test/kotlin/com/fwdekker/randomness/string/StringSettingsTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/string/StringSettingsTest.kt
@@ -72,20 +72,23 @@ object StringSettingsTest : Spek({
         }
     }
 
-    describe("emoji serialization") {
+    describe("emoji compatibility") {
         it("serializes emoji") {
-            val symbolSets = listOf(SymbolSet("emoji", "💆")).toMap()
-            val scheme = StringScheme(symbolSets = symbolSets, activeSymbolSets = symbolSets)
+            val newSymbolSets = listOf(SymbolSet("emoji", "💆")).toMap()
+            val scheme = StringScheme().apply {
+                symbolSets = newSymbolSets
+                activeSymbolSets = newSymbolSets
+            }
 
             assertThat(scheme.serializedSymbolSets["emoji"]).isEqualTo(":massage:")
             assertThat(scheme.serializedActiveSymbolSets["emoji"]).isEqualTo(":massage:")
         }
 
         it("deserializes emoji") {
-            val symbolSets = listOf(SymbolSet("emoji", ":couple_with_heart_man_man:")).toMap()
+            val newSymbolSets = listOf(SymbolSet("emoji", ":couple_with_heart_man_man:")).toMap()
             val scheme = StringScheme().apply {
-                serializedSymbolSets = symbolSets
-                serializedActiveSymbolSets = symbolSets
+                serializedSymbolSets = newSymbolSets
+                serializedActiveSymbolSets = newSymbolSets
             }
 
             assertThat(scheme.symbolSets["emoji"]).isEqualTo("👨‍❤️‍👨")

--- a/src/test/kotlin/com/fwdekker/randomness/string/SymbolSetTableTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/string/SymbolSetTableTest.kt
@@ -60,7 +60,7 @@ object SymbolSetTableTest : Spek({
         }
     }
 
-    // TODO: Remove button not accessible from tests
+    // TODO: Remove button is not accessible from tests
     xdescribe("itemEditor") {
         it("removes a symbol set") {
         }

--- a/src/test/kotlin/com/fwdekker/randomness/ui/ActivityTableModelEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/ui/ActivityTableModelEditorTest.kt
@@ -23,7 +23,6 @@ object ActivityTableModelEditorTest : Spek({
         ideaFixture.setUp()
 
         val itemEditor = object : CollectionItemEditor<EditableDatum<String>> {
-            // TODO Do not instantiate instance of `EditableSymbolSet`
             override fun getItemClass() = EditableDatum(false, "")::class.java
 
             override fun clone(item: EditableDatum<String>, forInPlaceEditing: Boolean) =
@@ -120,7 +119,7 @@ object ActivityTableModelEditorTest : Spek({
         }
     }
 
-    // TODO: Copy functionality not accessible from tests
+    // TODO: Copy functionality is not accessible from tests
     xdescribe("copying") {
         it("copies a copyable element") {}
 

--- a/src/test/kotlin/com/fwdekker/randomness/ui/PreviewPanelTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/ui/PreviewPanelTest.kt
@@ -81,7 +81,6 @@ object PreviewPanelTest : Spek({
         xit("updates when an activity table is updated") {
             GuiActionRunner.execute {
                 val itemEditor = object : CollectionItemEditor<EditableDatum<String>> {
-                    // TODO Do not instantiate instance of `EditableSymbolSet`
                     override fun getItemClass() = EditableDatum(false, "")::class.java
 
                     override fun clone(item: EditableDatum<String>, forInPlaceEditing: Boolean) =

--- a/src/test/kotlin/com/fwdekker/randomness/word/DictionaryTableTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/word/DictionaryTableTest.kt
@@ -79,7 +79,7 @@ object DictionaryTableTest : Spek({
         }
     }
 
-    // TODO: Remove and copy buttons not accessible from tests
+    // TODO: Remove and copy buttons are not accessible from tests
     xdescribe("itemEditor") {
         describe("remove") {
             it("does not remove a bundled dictionary") {}


### PR DESCRIPTION
Fixes #382.

The issue was that I had added `serializedSymbolSets` and `serializedActiveSymbolSets` as variants of `symbolSets` and `activeSymbolSets` to ensure that emoji would not get lost when saving preferences. I then set the other variants of this field to be transient, but instead of making them abstractions over the serialized fields, I made them into separate fields. The result was that changes were stored only in the transient fields, but not the fields that were actually written to the preferences file.