### PR TITLE
Drop support for Java 8, fix modifier checks

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,19 +1,19 @@
 group   = com.fwdekker
-version = 2.7.2
+version = 2.7.3-dev
 
 # Compatibility
 # * If latest is 20xx.y, then support at least [20xx-1].[y+1].
 #   e.g., if latest is 2020.3, support at least 2019.4 (aka 2020.1).
 #   See also https://data.services.jetbrains.com/products?fields=name,releases.version,releases.build&code=IC,CL.
-pluginSinceBuild          = 202.0
-intellijVersion           = 2021.1
-pluginVerifierIdeVersions = IC-2020.2.4, IC-2020.3.4, IC-2021.1.1, CL-2021.1.1
+pluginSinceBuild          = 203.0
+intellijVersion           = 2021.2
+pluginVerifierIdeVersions = IC-2020.3.4, IC-2021.1.3, IC-2021.2, CL-2020.3.4, CL-2021.1.3, CL-2021.2
 
 # Targets
 # * `javaVersion` is the same as `jvmVersion`.
 # * Kotlin should also be updated in `plugins` block.
-javaVersion      = 8
-jvmVersion       = 1.8
+javaVersion      = 11
+jvmVersion       = 11
 kotlinVersion    = 1.5
 kotlinApiVersion = 1.5
 

--- a/src/main/kotlin/com/fwdekker/randomness/DataActions.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/DataActions.kt
@@ -16,7 +16,7 @@ import com.intellij.openapi.options.ShowSettingsUtil
 import com.intellij.openapi.project.DumbAwareAction
 import com.intellij.openapi.project.Project
 import icons.RandomnessIcons
-import java.awt.event.InputEvent
+import java.awt.event.ActionEvent
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
@@ -99,11 +99,11 @@ abstract class DataGroupAction(private val icon: Icon = RandomnessIcons.Data.Bas
      * @param event carries information on the invocation place
      */
     override fun actionPerformed(event: AnActionEvent) {
-        // alt behavior is handled by implementation of `actionPerformed`
-        val altPressed = event.modifiers and (InputEvent.ALT_MASK or InputEvent.ALT_DOWN_MASK) != 0
-        val ctrlPressed = event.modifiers and (InputEvent.CTRL_MASK or InputEvent.CTRL_DOWN_MASK) != 0
-        val shiftPressed = event.modifiers and (InputEvent.SHIFT_MASK or InputEvent.SHIFT_DOWN_MASK) != 0
+        val altPressed = event.modifiers and ActionEvent.ALT_MASK != 0
+        val ctrlPressed = event.modifiers and ActionEvent.CTRL_MASK != 0
+        val shiftPressed = event.modifiers and ActionEvent.SHIFT_MASK != 0
 
+        // alt behavior is handled by implementation of `actionPerformed`
         when {
             altPressed && ctrlPressed && shiftPressed -> quickSwitchArraySchemeAction.actionPerformed(event)
             altPressed && ctrlPressed -> quickSwitchSchemeAction.actionPerformed(event)

--- a/src/main/kotlin/com/fwdekker/randomness/PopupAction.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/PopupAction.kt
@@ -21,7 +21,6 @@ import com.intellij.openapi.ui.popup.JBPopupFactory
 import com.intellij.ui.popup.list.ListPopupImpl
 import icons.RandomnessIcons
 import java.awt.event.ActionEvent
-import java.awt.event.InputEvent
 
 
 /**
@@ -83,9 +82,9 @@ class PopupAction : AnAction() {
     @Suppress("ComplexMethod") // Cannot be simplified
     private fun captionModifier(event: ActionEvent?): String {
         val modifiers = event?.modifiers ?: 0
-        val altPressed = modifiers and (InputEvent.ALT_MASK or InputEvent.ALT_DOWN_MASK) != 0
-        val ctrlPressed = modifiers and (InputEvent.CTRL_MASK or InputEvent.CTRL_DOWN_MASK) != 0
-        val shiftPressed = modifiers and (InputEvent.SHIFT_MASK or InputEvent.SHIFT_DOWN_MASK) != 0
+        val altPressed = modifiers and ActionEvent.ALT_MASK != 0
+        val ctrlPressed = modifiers and ActionEvent.CTRL_MASK != 0
+        val shiftPressed = modifiers and ActionEvent.SHIFT_MASK != 0
 
         return when {
             altPressed && ctrlPressed && shiftPressed -> ALT_CTRL_SHIFT_TITLE

--- a/src/main/resources/META-INF/change-notes.html
+++ b/src/main/resources/META-INF/change-notes.html
@@ -1,9 +1,10 @@
-<!--<b>Breaking changes</b>
+<b>Breaking changes</b>
 <p>
-    Placeholder.
-    (<a href="https://github.com/FWDekker/intellij-randomness/pull/num">#num</a>)
+    Minimum IDE version has been increased to 2020.3.
+    (<a href="https://github.com/FWDekker/intellij-randomness/issues/358">#358</a>)
+    (<a href="https://github.com/FWDekker/intellij-randomness/pull/386">#386</a>)
 </p>
-<br />-->
+<br />
 <!--<b>New features</b>
 <ul>
     <li>
@@ -12,11 +13,11 @@
     </li>
 </ul>
 <br />-->
-<b>Fixes</b>
+<!--<b>Fixes</b>
 <p>
-    Prevent symbol set settings from being truncated after restarting IDE.
-    (<a href="https://github.com/FWDekker/intellij-randomness/issues/382">#382</a>)
+    Placeholder.
+    (<a href="https://github.com/FWDekker/intellij-randomness/issues/num">#num</a>)
 </p>
-<br />
+<br />-->
 Change notes of previous updates can be found on the
 <a href="https://plugins.jetbrains.com/plugin/9836-randomness/versions">plugin repository</a>.


### PR DESCRIPTION
Fixes #358.

With the release of 2021.2, Randomness can now move minimum support to 2020.3. That means that JDK 8 is no longer required for any of the supported IDEs, so support can be dropped.

No further dependencies were updated, because I don't really see the need to and the uds branch is where all that stuff is happening anyway.