### PR TITLE
Implement default focus after opening settings

### DIFF
--- a/src/main/kotlin/com/fwdekker/randomness/StateEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/StateEditor.kt
@@ -1,5 +1,6 @@
 package com.fwdekker.randomness
 
+import java.awt.Component
 import javax.swing.JPanel
 
 
@@ -17,6 +18,11 @@ abstract class StateEditor<S : State>(val originalState: S) {
      * The root component of the editor.
      */
     abstract val rootComponent: JPanel
+
+    /**
+     * The component that this editor prefers to be focused when the editor is focused.
+     */
+    open val preferredFocusedComponent: Component? = null
 
 
     /**

--- a/src/main/kotlin/com/fwdekker/randomness/array/ArraySchemeDecoratorEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/array/ArraySchemeDecoratorEditor.kt
@@ -26,6 +26,8 @@ import javax.swing.event.ChangeEvent
 @Suppress("LateinitUsage") // Initialized by scene builder
 class ArraySchemeDecoratorEditor(settings: ArraySchemeDecorator) : StateEditor<ArraySchemeDecorator>(settings) {
     override lateinit var rootComponent: JPanel private set
+    override val preferredFocusedComponent = countSpinner.editorComponent
+
     private lateinit var separator: JComponent
     private lateinit var enabledCheckBox: JCheckBox
     private lateinit var arrayDetailsPanel: JPanel

--- a/src/main/kotlin/com/fwdekker/randomness/decimal/DecimalSchemeEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/decimal/DecimalSchemeEditor.kt
@@ -27,6 +27,8 @@ import javax.swing.event.ChangeEvent
 @Suppress("LateinitUsage") // Initialized by scene builder
 class DecimalSchemeEditor(scheme: DecimalScheme = DecimalScheme()) : StateEditor<DecimalScheme>(scheme) {
     override lateinit var rootComponent: JPanel private set
+    override val preferredFocusedComponent = minValue.editorComponent
+
     private lateinit var minValue: JDoubleSpinner
     private lateinit var maxValue: JDoubleSpinner
     private lateinit var decimalCount: JIntSpinner

--- a/src/main/kotlin/com/fwdekker/randomness/integer/IntegerSchemeEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/integer/IntegerSchemeEditor.kt
@@ -26,6 +26,8 @@ import javax.swing.event.ChangeEvent
 @Suppress("LateinitUsage") // Initialized by scene builder
 class IntegerSchemeEditor(scheme: IntegerScheme = IntegerScheme()) : StateEditor<IntegerScheme>(scheme) {
     override lateinit var rootComponent: JPanel private set
+    override val preferredFocusedComponent = minValue.editorComponent
+
     private lateinit var minValue: JLongSpinner
     private lateinit var maxValue: JLongSpinner
     private lateinit var base: JIntSpinner

--- a/src/main/kotlin/com/fwdekker/randomness/literal/LiteralSchemeEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/literal/LiteralSchemeEditor.kt
@@ -15,6 +15,8 @@ import javax.swing.JTextField
 @Suppress("LateinitUsage") // Initialized by scene builder
 class LiteralSchemeEditor(scheme: LiteralScheme = LiteralScheme()) : StateEditor<LiteralScheme>(scheme) {
     override lateinit var rootComponent: JPanel private set
+    override val preferredFocusedComponent = literalInput
+
     private lateinit var literalInput: JTextField
     private lateinit var arrayDecoratorPanel: JPanel
     private lateinit var arrayDecoratorEditor: ArraySchemeDecoratorEditor

--- a/src/main/kotlin/com/fwdekker/randomness/string/StringSchemeEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/string/StringSchemeEditor.kt
@@ -31,6 +31,8 @@ import javax.swing.JPanel
 @Suppress("LateinitUsage") // Initialized by scene builder
 class StringSchemeEditor(scheme: StringScheme = StringScheme()) : StateEditor<StringScheme>(scheme) {
     override lateinit var rootComponent: JPanel private set
+    override val preferredFocusedComponent = minLength.editorComponent
+
     private lateinit var minLength: JIntSpinner
     private lateinit var maxLength: JIntSpinner
     private lateinit var enclosureGroup: ButtonGroup

--- a/src/main/kotlin/com/fwdekker/randomness/template/TemplateListEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/template/TemplateListEditor.kt
@@ -41,6 +41,7 @@ import java.util.Collections
 import java.util.Enumeration
 import javax.swing.JPanel
 import javax.swing.JTree
+import javax.swing.SwingUtilities
 import javax.swing.event.TreeModelEvent
 import javax.swing.event.TreeModelListener
 import javax.swing.tree.DefaultTreeModel
@@ -126,7 +127,10 @@ class TemplateListEditor(settings: SettingsState = SettingsState.default) : Stat
         }
         templateTree.emptyText.text = EMPTY_TEXT
         templateTree.addTreeSelectionListener {
-            schemeEditor?.also { schemeEditorPanel.remove(it.rootComponent) }
+            schemeEditor?.also {
+                schemeEditorPanel.remove(it.rootComponent)
+                schemeEditor = null
+            }
 
             val selectedNode = templateTree.getSelectedNode()
             val selectedObject = selectedNode?.state
@@ -301,7 +305,10 @@ class TemplateListEditor(settings: SettingsState = SettingsState.default) : Stat
             (templateTreeModel.root as TemplateListTreeNode)
                 .children().toList()
                 .firstOrNull { it.state.uuid == selection }
-                ?.also { templateTree.selectionPath = templateTree.getPathToRoot(it) }
+                ?.also {
+                    templateTree.selectionPath = templateTree.getPathToRoot(it)
+                    SwingUtilities.invokeLater { schemeEditor?.preferredFocusedComponent?.requestFocus() }
+                }
 
             queueSelection = null
         }

--- a/src/main/kotlin/com/fwdekker/randomness/template/TemplateNameEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/template/TemplateNameEditor.kt
@@ -15,6 +15,8 @@ import javax.swing.JPanel
  */
 class TemplateNameEditor(template: Template) : StateEditor<Template>(template) {
     override val rootComponent = JPanel(BorderLayout())
+    override val preferredFocusedComponent by lazy { nameInput }
+
     private val nameInput = JBTextField().also { it.name = "templateName" }
 
 

--- a/src/main/kotlin/com/fwdekker/randomness/template/TemplateReferenceEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/template/TemplateReferenceEditor.kt
@@ -20,6 +20,8 @@ import javax.swing.ListSelectionModel
  */
 class TemplateReferenceEditor(reference: TemplateReference) : StateEditor<TemplateReference>(reference) {
     override val rootComponent = JPanel(BorderLayout())
+    override val preferredFocusedComponent by lazy { templateList }
+
     private val templateListModel = DefaultListModel<Template>()
     private val templateList = JBList(templateListModel)
     private val arrayDecoratorEditor: ArraySchemeDecoratorEditor

--- a/src/main/kotlin/com/fwdekker/randomness/ui/ButtonGroup.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/ui/ButtonGroup.kt
@@ -36,4 +36,4 @@ fun ButtonGroup.setValue(value: Any?) {
  *
  * @return the buttons in this button group as a typed array
  */
-fun ButtonGroup.buttons() = elements.toList().toTypedArray()
+fun ButtonGroup.buttons(): Array<AbstractButton> = elements.toList().toTypedArray()

--- a/src/main/kotlin/com/fwdekker/randomness/ui/JNumberSpinners.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/ui/JNumberSpinners.kt
@@ -1,5 +1,6 @@
 package com.fwdekker.randomness.ui
 
+import java.awt.Component
 import java.awt.Dimension
 import java.text.DecimalFormatSymbols
 import java.util.Locale
@@ -46,6 +47,12 @@ abstract class JNumberSpinner<T>(value: T, minValue: T, maxValue: T, stepSize: T
         set(value) {
             numberModel.maximum = value
         }
+
+    /**
+     * The component that can be used to edit the spinner.
+     */
+    val editorComponent: Component
+        get() = editor.getComponent(0)
 
 
     /**

--- a/src/main/kotlin/com/fwdekker/randomness/uuid/UuidSchemeEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/uuid/UuidSchemeEditor.kt
@@ -4,6 +4,7 @@ import com.fwdekker.randomness.CapitalizationMode.Companion.getMode
 import com.fwdekker.randomness.StateEditor
 import com.fwdekker.randomness.array.ArraySchemeDecoratorEditor
 import com.fwdekker.randomness.ui.addChangeListenerTo
+import com.fwdekker.randomness.ui.buttons
 import com.fwdekker.randomness.ui.getValue
 import com.fwdekker.randomness.ui.setValue
 import com.fwdekker.randomness.uuid.UuidScheme.Companion.DEFAULT_CAPITALIZATION
@@ -22,6 +23,9 @@ import javax.swing.JPanel
 @Suppress("LateinitUsage") // Initialized by scene builder
 class UuidSchemeEditor(scheme: UuidScheme = UuidScheme()) : StateEditor<UuidScheme>(scheme) {
     override lateinit var rootComponent: JPanel private set
+    override val preferredFocusedComponent
+        get() = versionGroup.buttons().firstOrNull { it.isSelected }
+
     private lateinit var versionGroup: ButtonGroup
     private lateinit var enclosureGroup: ButtonGroup
     private lateinit var capitalizationGroup: ButtonGroup

--- a/src/main/kotlin/com/fwdekker/randomness/word/WordSchemeEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/word/WordSchemeEditor.kt
@@ -31,6 +31,8 @@ import javax.swing.JTextArea
 @Suppress("LateinitUsage") // Initialized by scene builder
 class WordSchemeEditor(scheme: WordScheme = WordScheme()) : StateEditor<WordScheme>(scheme) {
     override lateinit var rootComponent: JPanel private set
+    override val preferredFocusedComponent = minLength.editorComponent
+
     private lateinit var minLength: JIntSpinner
     private lateinit var maxLength: JIntSpinner
     private lateinit var capitalizationGroup: ButtonGroup


### PR DESCRIPTION
Fixes #357.

Apparently it suffices to request focus in a `SwingUtilities.invokeLater`. However, to ensure that users who just happen to scroll by Randomness settings don't get forced into the editor, the focus is only applied when the dialog is opened from the popup.