### PR TITLE
Clean up some code

### DIFF
--- a/src/main/kotlin/com/fwdekker/randomness/SettingsState.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/SettingsState.kt
@@ -14,9 +14,9 @@ import com.fwdekker.randomness.word.DictionarySettings
  * @property dictionarySettings The dictionary settings.
  */
 data class SettingsState(
-    var templateList: TemplateList = TemplateList(mutableListOf()),
-    var symbolSetSettings: SymbolSetSettings = SymbolSetSettings(mutableMapOf()),
-    var dictionarySettings: DictionarySettings = DictionarySettings(mutableSetOf())
+    var templateList: TemplateList = TemplateList(emptyList()),
+    var symbolSetSettings: SymbolSetSettings = SymbolSetSettings(emptyMap()),
+    var dictionarySettings: DictionarySettings = DictionarySettings(emptySet())
 ) : State() {
     override fun doValidate() =
         templateList.doValidate() ?: symbolSetSettings.doValidate() ?: dictionarySettings.doValidate()

--- a/src/main/kotlin/com/fwdekker/randomness/SettingsState.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/SettingsState.kt
@@ -16,7 +16,7 @@ import com.fwdekker.randomness.word.DictionarySettings
 data class SettingsState(
     var templateList: TemplateList = TemplateList(mutableListOf()),
     var symbolSetSettings: SymbolSetSettings = SymbolSetSettings(mutableMapOf()),
-    var dictionarySettings: DictionarySettings = DictionarySettings(mutableListOf())
+    var dictionarySettings: DictionarySettings = DictionarySettings(mutableSetOf())
 ) : State() {
     override fun doValidate() =
         templateList.doValidate() ?: symbolSetSettings.doValidate() ?: dictionarySettings.doValidate()

--- a/src/main/kotlin/com/fwdekker/randomness/SettingsState.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/SettingsState.kt
@@ -16,7 +16,7 @@ import com.fwdekker.randomness.word.DictionarySettings
 data class SettingsState(
     var templateList: TemplateList = TemplateList(mutableListOf()),
     var symbolSetSettings: SymbolSetSettings = SymbolSetSettings(mutableMapOf()),
-    var dictionarySettings: DictionarySettings = DictionarySettings(mutableSetOf())
+    var dictionarySettings: DictionarySettings = DictionarySettings(mutableListOf())
 ) : State() {
     override fun doValidate() =
         templateList.doValidate() ?: symbolSetSettings.doValidate() ?: dictionarySettings.doValidate()

--- a/src/main/kotlin/com/fwdekker/randomness/SettingsState.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/SettingsState.kt
@@ -21,12 +21,12 @@ data class SettingsState(
     override fun doValidate() =
         templateList.doValidate() ?: symbolSetSettings.doValidate() ?: dictionarySettings.doValidate()
 
-    override fun copyFrom(state: State) {
-        require(state is SettingsState) { "Cannot copy from different type." }
+    override fun copyFrom(other: State) {
+        require(other is SettingsState) { "Cannot copy from different type." }
 
-        templateList.copyFrom(state.templateList)
-        symbolSetSettings.copyFrom(state.symbolSetSettings)
-        dictionarySettings.copyFrom(state.dictionarySettings)
+        templateList.copyFrom(other.templateList)
+        symbolSetSettings.copyFrom(other.symbolSetSettings)
+        dictionarySettings.copyFrom(other.dictionarySettings)
     }
 
     override fun deepCopy(retainUuid: Boolean) =

--- a/src/main/kotlin/com/fwdekker/randomness/State.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/State.kt
@@ -27,12 +27,13 @@ abstract class State {
     /**
      * Copies the given state into this state.
      *
-     * Works by copying all references in a [deepCopy] of [state] into `this`. Note that fields marked with [Transient]
-     * are not copied at all unless the field is defined in the constructor, in which case it is shallow-copied.
+     * Works by copying all references in a [deepCopy] of [other] into `this`. Note that fields marked with [Transient]
+     * are not copied at all, unless the field is defined in the constructor, in which case it is shallow-copied.
+     * Implementations are additionally allowed, but not required, to deep-copy [Settings] fields.
      *
-     * @param state the state to copy into this state; should be a (sub)class of this state
+     * @param other the state to copy into this state; should be a (sub)class of this state
      */
-    open fun copyFrom(state: State) = XmlSerializerUtil.copyBean(state.deepCopy(retainUuid = true), this)
+    open fun copyFrom(other: State) = XmlSerializerUtil.copyBean(other.deepCopy(retainUuid = true), this)
 
     /**
      * Returns a deep copy of this state.

--- a/src/main/kotlin/com/fwdekker/randomness/string/StringScheme.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/string/StringScheme.kt
@@ -26,14 +26,14 @@ data class StringScheme(
     var maxLength: Int = DEFAULT_MAX_LENGTH,
     var enclosure: String = DEFAULT_ENCLOSURE,
     var capitalization: CapitalizationMode = DEFAULT_CAPITALIZATION,
-    var activeSymbolSets: MutableSet<String> = DEFAULT_ACTIVE_SYMBOL_SETS.toMutableSet(),
+    var activeSymbolSets: Set<String> = DEFAULT_ACTIVE_SYMBOL_SETS.toMutableSet(),
     var excludeLookAlikeSymbols: Boolean = DEFAULT_EXCLUDE_LOOK_ALIKE_SYMBOLS,
     override var decorator: ArraySchemeDecorator = ArraySchemeDecorator()
 ) : Scheme() {
     /**
      * Persistent storage of available symbol sets.
      */
-    @Transient
+    @get:Transient
     var symbolSetSettings: Box<SymbolSetSettings> = Box({ SymbolSetSettings.default })
 
     @Transient
@@ -104,7 +104,7 @@ data class StringScheme(
 
     override fun deepCopy(retainUuid: Boolean) =
         copy(
-            activeSymbolSets = activeSymbolSets.toMutableSet(),
+            activeSymbolSets = activeSymbolSets.toSet(),
             decorator = decorator.deepCopy(retainUuid)
         ).also {
             if (retainUuid) it.uuid = this.uuid

--- a/src/main/kotlin/com/fwdekker/randomness/string/StringScheme.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/string/StringScheme.kt
@@ -4,6 +4,7 @@ import com.fwdekker.randomness.Box
 import com.fwdekker.randomness.CapitalizationMode
 import com.fwdekker.randomness.Scheme
 import com.fwdekker.randomness.SettingsState
+import com.fwdekker.randomness.State
 import com.fwdekker.randomness.array.ArraySchemeDecorator
 import com.intellij.util.xmlb.annotations.Transient
 import icons.RandomnessIcons
@@ -90,14 +91,26 @@ data class StringScheme(
         }
     }
 
-    override fun deepCopy(retainUuid: Boolean) =
-        copy(decorator = decorator.deepCopy(retainUuid))
-            .also {
-                if (retainUuid) it.uuid = this.uuid
+    override fun copyFrom(other: State) {
+        require(other is StringScheme) { "Cannot copy from different type." }
 
-                it.symbolSetSettings = symbolSetSettings.copy()
-                it.activeSymbolSets = activeSymbolSets.toMutableSet()
-            }
+        (+symbolSetSettings).also {
+            it.copyFrom(+other.symbolSetSettings)
+
+            super.copyFrom(other)
+            symbolSetSettings += it
+        }
+    }
+
+    override fun deepCopy(retainUuid: Boolean) =
+        copy(
+            activeSymbolSets = activeSymbolSets.toMutableSet(),
+            decorator = decorator.deepCopy(retainUuid)
+        ).also {
+            if (retainUuid) it.uuid = this.uuid
+
+            it.symbolSetSettings += (+symbolSetSettings).deepCopy(retainUuid = retainUuid)
+        }
 
 
     /**

--- a/src/main/kotlin/com/fwdekker/randomness/string/StringSchemeEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/string/StringSchemeEditor.kt
@@ -101,7 +101,7 @@ class StringSchemeEditor(scheme: StringScheme = StringScheme()) : StateEditor<St
             enclosure = enclosureGroup.getValue() ?: DEFAULT_ENCLOSURE,
             capitalization = capitalizationGroup.getValue()?.let(::getMode) ?: DEFAULT_CAPITALIZATION,
             excludeLookAlikeSymbols = excludeLookAlikeSymbolsCheckBox.isSelected,
-            activeSymbolSets = symbolSetTable.activeData.map { symbolSet -> symbolSet.name }.toMutableSet(),
+            activeSymbolSets = symbolSetTable.activeData.map { symbolSet -> symbolSet.name }.toSet(),
             decorator = arrayDecoratorEditor.readState()
         ).also {
             it.uuid = originalState.uuid

--- a/src/main/kotlin/com/fwdekker/randomness/string/StringSchemeEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/string/StringSchemeEditor.kt
@@ -25,7 +25,6 @@ import javax.swing.JPanel
  * Component for editing random string settings.
  *
  * @param scheme the scheme to edit in the component
- *
  * @see SymbolSetTable
  */
 @Suppress("LateinitUsage") // Initialized by scene builder
@@ -87,16 +86,16 @@ class StringSchemeEditor(scheme: StringScheme = StringScheme()) : StateEditor<St
         capitalizationGroup.setValue(state.capitalization)
         excludeLookAlikeSymbolsCheckBox.isSelected = state.excludeLookAlikeSymbols
 
-        symbolSetTable.data = state.symbolSetSettings.symbolSetList
+        symbolSetTable.data =
+            (+state.symbolSetSettings).symbolSetList
         symbolSetTable.activeData =
-            state.symbolSetSettings.symbolSetList.filter { symbolSet -> symbolSet.name in state.activeSymbolSets }
+            (+state.symbolSetSettings).symbolSetList.filter { symbolSet -> symbolSet.name in state.activeSymbolSets }
 
         arrayDecoratorEditor.loadState(state.decorator)
     }
 
     override fun readState() =
         StringScheme(
-            symbolSetSettings = originalState.symbolSetSettings,
             minLength = minLength.value,
             maxLength = maxLength.value,
             enclosure = enclosureGroup.getValue() ?: DEFAULT_ENCLOSURE,
@@ -106,7 +105,8 @@ class StringSchemeEditor(scheme: StringScheme = StringScheme()) : StateEditor<St
         ).also {
             it.uuid = originalState.uuid
 
-            it.symbolSetSettings.symbolSetList = symbolSetTable.data.toSet()
+            it.symbolSetSettings = originalState.symbolSetSettings.copy()
+            (+it.symbolSetSettings).symbolSetList = symbolSetTable.data.toSet()
             it.activeSymbolSets = symbolSetTable.activeData.map { symbolSet -> symbolSet.name }.toMutableSet()
         }
 

--- a/src/main/kotlin/com/fwdekker/randomness/string/StringSchemeEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/string/StringSchemeEditor.kt
@@ -110,6 +110,16 @@ class StringSchemeEditor(scheme: StringScheme = StringScheme()) : StateEditor<St
             it.activeSymbolSets = symbolSetTable.activeData.map { symbolSet -> symbolSet.name }.toMutableSet()
         }
 
+
+    override fun doValidate(): String? {
+        val symbolSets = symbolSetTable.data.map { it.name }
+        val duplicate = symbolSets.firstOrNull { symbolSet -> symbolSets.count { it == symbolSet } > 1 }
+
+        return if (duplicate != null) "Multiple symbol sets with name '$duplicate'."
+        else super.doValidate()
+    }
+
+
     override fun addChangeListener(listener: () -> Unit) =
         addChangeListenerTo(
             minLength, maxLength, enclosureGroup, capitalizationGroup, symbolSetTable, arrayDecoratorEditor,

--- a/src/main/kotlin/com/fwdekker/randomness/string/StringSchemeEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/string/StringSchemeEditor.kt
@@ -101,14 +101,19 @@ class StringSchemeEditor(scheme: StringScheme = StringScheme()) : StateEditor<St
             enclosure = enclosureGroup.getValue() ?: DEFAULT_ENCLOSURE,
             capitalization = capitalizationGroup.getValue()?.let(::getMode) ?: DEFAULT_CAPITALIZATION,
             excludeLookAlikeSymbols = excludeLookAlikeSymbolsCheckBox.isSelected,
+            activeSymbolSets = symbolSetTable.activeData.map { symbolSet -> symbolSet.name }.toMutableSet(),
             decorator = arrayDecoratorEditor.readState()
         ).also {
             it.uuid = originalState.uuid
 
-            it.symbolSetSettings = originalState.symbolSetSettings.copy()
+            it.symbolSetSettings += (+originalState.symbolSetSettings).deepCopy(retainUuid = true)
             (+it.symbolSetSettings).symbolSetList = symbolSetTable.data.toSet()
-            it.activeSymbolSets = symbolSetTable.activeData.map { symbolSet -> symbolSet.name }.toMutableSet()
         }
+
+    override fun applyState() {
+        super.applyState()
+        (+originalState.symbolSetSettings).copyFrom(+readState().symbolSetSettings)
+    }
 
 
     override fun doValidate(): String? {

--- a/src/main/kotlin/com/fwdekker/randomness/string/SymbolSetSettings.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/string/SymbolSetSettings.kt
@@ -24,7 +24,7 @@ import com.vdurmont.emoji.EmojiParser
 )
 data class SymbolSetSettings(
     @MapAnnotation(sortBeforeSave = false)
-    var serializedSymbolSets: MutableMap<String, String> = DEFAULT_SYMBOL_SETS.toMutableMap(),
+    var serializedSymbolSets: Map<String, String> = DEFAULT_SYMBOL_SETS.toMutableMap(),
     @Suppress("unused") // At least two fields are required for serialization to work
     private val placeholder: String = ""
 ) : PersistentStateComponent<SymbolSetSettings>, Settings() {
@@ -35,8 +35,7 @@ data class SymbolSetSettings(
     var symbolSets: Map<String, String>
         get() = serializedSymbolSets.map { SymbolSet(it.key, EmojiParser.parseToUnicode(it.value)) }.toMap()
         set(value) {
-            serializedSymbolSets =
-                value.map { SymbolSet(it.key, EmojiParser.parseToAliases(it.value)) }.toMap().toMutableMap()
+            serializedSymbolSets = value.map { SymbolSet(it.key, EmojiParser.parseToAliases(it.value)) }.toMap()
         }
 
     /**
@@ -77,7 +76,7 @@ data class SymbolSetSettings(
     }
 
     override fun deepCopy(retainUuid: Boolean) =
-        copy(serializedSymbolSets = serializedSymbolSets.toMutableMap())
+        copy(serializedSymbolSets = serializedSymbolSets.toMap())
             .also { if (retainUuid) it.uuid = uuid }
 
 

--- a/src/main/kotlin/com/fwdekker/randomness/template/Template.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/template/Template.kt
@@ -33,7 +33,7 @@ data class Template(
             TemplateReference::class,
         ]
     )
-    var schemes: MutableList<Scheme> = DEFAULT_SCHEMES.toMutableList(),
+    var schemes: List<Scheme> = DEFAULT_SCHEMES.toMutableList(),
     override var decorator: ArraySchemeDecorator? = null
 ) : Scheme() {
     override val icons: RandomnessIcons
@@ -64,7 +64,7 @@ data class Template(
         else schemes.firstNotNullOfOrNull { scheme -> scheme.doValidate()?.let { "${scheme.name} > $it" } }
 
     override fun deepCopy(retainUuid: Boolean) =
-        copy(schemes = schemes.map { it.deepCopy(retainUuid) }.toMutableList(), decorator = decorator)
+        copy(schemes = schemes.map { it.deepCopy(retainUuid) }, decorator = decorator)
             .also { if (retainUuid) it.uuid = this.uuid }
 
 

--- a/src/main/kotlin/com/fwdekker/randomness/template/TemplateList.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/template/TemplateList.kt
@@ -19,7 +19,7 @@ import com.intellij.util.xmlb.annotations.MapAnnotation
  */
 data class TemplateList(
     @MapAnnotation(sortBeforeSave = false)
-    var templates: MutableList<Template> = DEFAULT_TEMPLATES.toMutableList()
+    var templates: List<Template> = DEFAULT_TEMPLATES.toMutableList()
 ) : Settings() {
     /**
      * Sets the [SettingsState] for each template in this list and returns this instance.
@@ -73,7 +73,7 @@ data class TemplateList(
     }
 
     override fun deepCopy(retainUuid: Boolean) =
-        TemplateList(templates.map { it.deepCopy(retainUuid) }.toMutableList())
+        TemplateList(templates.map { it.deepCopy(retainUuid) })
             .also { if (retainUuid) it.uuid = this.uuid }
 
 
@@ -86,11 +86,11 @@ data class TemplateList(
          */
         val DEFAULT_TEMPLATES: List<Template>
             get() = listOf(
-                Template("Integer", mutableListOf(IntegerScheme())),
-                Template("Decimal", mutableListOf(DecimalScheme())),
-                Template("String", mutableListOf(StringScheme())),
-                Template("Word", mutableListOf(WordScheme())),
-                Template("UUID", mutableListOf(UuidScheme()))
+                Template("Integer", listOf(IntegerScheme())),
+                Template("Decimal", listOf(DecimalScheme())),
+                Template("String", listOf(StringScheme())),
+                Template("Word", listOf(WordScheme())),
+                Template("UUID", listOf(UuidScheme()))
             )
 
 
@@ -101,6 +101,6 @@ data class TemplateList(
          * @param name the name of the template
          */
         fun from(vararg schemes: Scheme, name: String = Template.DEFAULT_NAME) =
-            TemplateList(mutableListOf(Template(name, schemes.toMutableList())))
+            TemplateList(listOf(Template(name, schemes.toList())))
     }
 }

--- a/src/main/kotlin/com/fwdekker/randomness/template/TemplateListEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/template/TemplateListEditor.kt
@@ -69,7 +69,7 @@ class TemplateListEditor(settings: SettingsState = SettingsState.default) : Stat
     override val rootComponent = JPanel(BorderLayout())
     private var dictionarySettings: DictionarySettings = DictionarySettings()
     private var symbolSetSettings: SymbolSetSettings = SymbolSetSettings()
-    private val templateTreeModel = DefaultTreeModel(TemplateListTreeNode(TemplateList(mutableListOf())))
+    private val templateTreeModel = DefaultTreeModel(TemplateListTreeNode(TemplateList(emptyList())))
     private val templateTree = Tree(templateTreeModel)
     private var schemeEditorPanel = JPanel(BorderLayout())
     private var schemeEditor: StateEditor<*>? = null
@@ -713,7 +713,7 @@ private class TemplateListTreeNode(override val state: TemplateList) : StateTree
     override var entries: List<Template>
         get() = state.templates
         set(value) {
-            state.templates = value.toMutableList()
+            state.templates = value.toList()
         }
 
 
@@ -742,7 +742,7 @@ private class TemplateTreeNode(override val state: Template) : StateTreeListNode
     override var entries: List<Scheme>
         get() = state.schemes
         set(value) {
-            state.schemes = value.toMutableList()
+            state.schemes = value.toList()
         }
 
 

--- a/src/main/kotlin/com/fwdekker/randomness/template/TemplateNameEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/template/TemplateNameEditor.kt
@@ -35,7 +35,7 @@ class TemplateNameEditor(template: Template) : StateEditor<Template>(template) {
     override fun readState() =
         Template(
             name = nameInput.text.trim(),
-            schemes = originalState.schemes.map { it.deepCopy(retainUuid = true) }.toMutableList(),
+            schemes = originalState.schemes.map { it.deepCopy(retainUuid = true) },
             decorator = originalState.decorator
         ).also { it.uuid = originalState.uuid }
 

--- a/src/main/kotlin/com/fwdekker/randomness/template/TemplateReference.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/template/TemplateReference.kt
@@ -69,11 +69,11 @@ data class TemplateReference(
         else null
     }
 
-    override fun copyFrom(state: State) {
-        require(state is TemplateReference) { "Cannot copy from different type." }
+    override fun copyFrom(other: State) {
+        require(other is TemplateReference) { "Cannot copy from different type." }
 
-        super.copyFrom(state)
-        templateList = state.templateList.copy()
+        super.copyFrom(other)
+        templateList = other.templateList.copy()
     }
 
     override fun deepCopy(retainUuid: Boolean) =

--- a/src/main/kotlin/com/fwdekker/randomness/word/DictionarySettings.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/word/DictionarySettings.kt
@@ -19,7 +19,7 @@ import com.intellij.util.xmlb.annotations.XCollection
 )
 data class DictionarySettings(
     @get:XCollection(elementTypes = [BundledDictionary::class, UserDictionary::class])
-    var dictionaries: MutableSet<Dictionary> = DEFAULT_DICTIONARIES.toMutableSet(),
+    var dictionaries: Set<Dictionary> = DEFAULT_DICTIONARIES.toMutableSet(),
 ) : PersistentStateComponent<DictionarySettings>, Settings() {
     /**
      * Returns this instance.
@@ -50,7 +50,7 @@ data class DictionarySettings(
     }
 
     override fun deepCopy(retainUuid: Boolean) =
-        copy(dictionaries = dictionaries.map { it.deepCopy() }.toMutableSet())
+        copy(dictionaries = dictionaries.map { it.deepCopy() }.toSet())
             .also { if (retainUuid) it.uuid = uuid }
 
 

--- a/src/main/kotlin/com/fwdekker/randomness/word/DictionarySettings.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/word/DictionarySettings.kt
@@ -5,47 +5,22 @@ import com.intellij.openapi.components.PersistentStateComponent
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
 import com.intellij.openapi.components.service
-import com.intellij.util.xmlb.annotations.MapAnnotation
-import com.intellij.util.xmlb.annotations.Transient
+import com.intellij.util.xmlb.annotations.XCollection
 
 
 /**
  * The user-configurable persistent collection of all [Dictionaries][Dictionary] available to the user.
  *
- * @property bundledDictionaryFiles The list of all dictionary files provided by the plugin.
- * @property userDictionaryFiles The list of all dictionary files registered by the user.
+ * @property dictionaries The list of all dictionaries configured by the user.
  */
 @State(
     name = "com.fwdekker.randomness.word.DictionarySettings",
     storages = [Storage("\$APP_CONFIG\$/randomness.xml")]
 )
 data class DictionarySettings(
-    @MapAnnotation(sortBeforeSave = false)
-    var bundledDictionaryFiles: MutableSet<String> = DEFAULT_BUNDLED_DICTIONARY_FILES.toMutableSet(),
-    @MapAnnotation(sortBeforeSave = false)
-    var userDictionaryFiles: MutableSet<String> = DEFAULT_USER_DICTIONARY_FILES.toMutableSet()
+    @get:XCollection(elementTypes = [BundledDictionary::class, UserDictionary::class])
+    var dictionaries: MutableList<Dictionary> = DEFAULT_DICTIONARIES.toMutableList(),
 ) : PersistentStateComponent<DictionarySettings>, Settings() {
-    /**
-     * A view of the filenames of the files in [bundledDictionaryFiles].
-     */
-    var bundledDictionaries: Set<DictionaryReference>
-        @Transient
-        get() = bundledDictionaryFiles.map { DictionaryReference(true, it) }.toSet()
-        set(value) {
-            bundledDictionaryFiles = value.map { it.filename }.toMutableSet()
-        }
-
-    /**
-     * A view of the filenames of the files in [userDictionaryFiles].
-     */
-    var userDictionaries: Set<DictionaryReference>
-        @Transient
-        get() = userDictionaryFiles.map { DictionaryReference(false, it) }.toSet()
-        set(value) {
-            userDictionaryFiles = value.map { it.filename }.toMutableSet()
-        }
-
-
     /**
      * Returns this instance.
      *
@@ -62,27 +37,28 @@ data class DictionarySettings(
 
 
     override fun doValidate(): String? {
-        BundledDictionary.cache.clear()
-        UserDictionary.cache.clear()
+        UserDictionary.clearCache()
 
-        return (bundledDictionaries + userDictionaries)
-            .associateWith { dictionary ->
-                try {
-                    dictionary.words
-                } catch (e: InvalidDictionaryException) {
-                    return "Dictionary '$dictionary' is invalid: ${e.message}"
-                }
+        val duplicate = dictionaries.firstOrNull { dictionary -> dictionaries.count { it == dictionary } > 1 }
+        val invalid = dictionaries.firstNotNullOfOrNull {
+            try {
+                if (it.words.isEmpty()) return@firstNotNullOfOrNull "Dictionary '$it' is empty."
+                else null
+            } catch (e: InvalidDictionaryException) {
+                return@firstNotNullOfOrNull "Dictionary '$it' is invalid: ${e.message}"
             }
-            .toList()
-            .firstOrNull { it.second.isEmpty() }
-            ?.let { "Dictionary '${it.first.filename}' is empty." }
+        }
+
+        return when {
+            duplicate != null -> "Duplicate dictionary '$duplicate'."
+            invalid != null -> invalid
+            else -> null
+        }
     }
 
     override fun deepCopy(retainUuid: Boolean) =
-        copy(
-            bundledDictionaryFiles = bundledDictionaryFiles.toMutableSet(),
-            userDictionaryFiles = userDictionaryFiles.toMutableSet(),
-        ).also { if (retainUuid) it.uuid = uuid }
+        copy(dictionaries = dictionaries.map { it.deepCopy() }.toMutableList())
+            .also { if (retainUuid) it.uuid = uuid }
 
 
     /**
@@ -90,16 +66,10 @@ data class DictionarySettings(
      */
     companion object {
         /**
-         * The default value of the [bundledDictionaryFiles][bundledDictionaryFiles] field.
+         * The default value of the [dictionaries] field.
          */
-        val DEFAULT_BUNDLED_DICTIONARY_FILES: Set<String>
-            get() = setOf(BundledDictionary.SIMPLE_DICTIONARY)
-
-        /**
-         * The default value of the [userDictionaryFiles][userDictionaryFiles] field.
-         */
-        val DEFAULT_USER_DICTIONARY_FILES: Set<String>
-            get() = setOf()
+        val DEFAULT_DICTIONARIES: List<Dictionary>
+            get() = listOf(BundledDictionary(BundledDictionary.SIMPLE_DICTIONARY))
 
         /**
          * The persistent `DictionarySettings` instance.

--- a/src/main/kotlin/com/fwdekker/randomness/word/WordScheme.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/word/WordScheme.kt
@@ -27,13 +27,13 @@ data class WordScheme(
     var enclosure: String = DEFAULT_ENCLOSURE,
     var capitalization: CapitalizationMode = DEFAULT_CAPITALIZATION,
     @get:XCollection(elementTypes = [BundledDictionary::class, UserDictionary::class])
-    var activeDictionaries: MutableSet<Dictionary> = DEFAULT_ACTIVE_DICTIONARIES.toMutableSet(),
+    var activeDictionaries: Set<Dictionary> = DEFAULT_ACTIVE_DICTIONARIES.toMutableSet(),
     override var decorator: ArraySchemeDecorator = ArraySchemeDecorator()
 ) : Scheme() {
     /**
      * Persistent storage of available dictionaries.
      */
-    @Transient
+    @get:Transient
     var dictionarySettings: Box<DictionarySettings> = Box({ DictionarySettings.default })
 
     @Transient
@@ -104,7 +104,7 @@ data class WordScheme(
 
     override fun deepCopy(retainUuid: Boolean) =
         copy(
-            activeDictionaries = activeDictionaries.map { it.deepCopy() }.toMutableSet(),
+            activeDictionaries = activeDictionaries.map { it.deepCopy() }.toSet(),
             decorator = decorator.deepCopy(retainUuid)
         ).also {
             if (retainUuid) it.uuid = this.uuid

--- a/src/main/kotlin/com/fwdekker/randomness/word/WordScheme.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/word/WordScheme.kt
@@ -28,7 +28,7 @@ data class WordScheme(
     var enclosure: String = DEFAULT_ENCLOSURE,
     var capitalization: CapitalizationMode = DEFAULT_CAPITALIZATION,
     @get:XCollection(elementTypes = [BundledDictionary::class, UserDictionary::class])
-    var activeDictionaries: MutableList<Dictionary> = DEFAULT_ACTIVE_DICTIONARIES.toMutableList(),
+    var activeDictionaries: MutableSet<Dictionary> = DEFAULT_ACTIVE_DICTIONARIES.toMutableSet(),
     override var decorator: ArraySchemeDecorator = ArraySchemeDecorator()
 ) : Scheme() {
     @Transient
@@ -90,7 +90,7 @@ data class WordScheme(
             .also {
                 if (retainUuid) it.uuid = this.uuid
 
-                it.activeDictionaries = activeDictionaries.map(Dictionary::deepCopy).toMutableList()
+                it.activeDictionaries = activeDictionaries.map(Dictionary::deepCopy).toMutableSet()
             }
 
 
@@ -131,7 +131,7 @@ data class WordScheme(
         /**
          * The default value of the [activeDictionaries] field.
          */
-        val DEFAULT_ACTIVE_DICTIONARIES: List<Dictionary>
-            get() = listOf(BundledDictionary(BundledDictionary.SIMPLE_DICTIONARY))
+        val DEFAULT_ACTIVE_DICTIONARIES: Set<Dictionary>
+            get() = setOf(BundledDictionary(BundledDictionary.SIMPLE_DICTIONARY))
     }
 }

--- a/src/main/kotlin/com/fwdekker/randomness/word/WordSchemeEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/word/WordSchemeEditor.kt
@@ -82,7 +82,8 @@ class WordSchemeEditor(scheme: WordScheme = WordScheme()) : StateEditor<WordSche
         maxLength.value = state.maxLength
         enclosureGroup.setValue(state.enclosure)
         capitalizationGroup.setValue(state.capitalization)
-        dictionaryTable.data = state.dictionarySettings.dictionaries
+        dictionaryTable.data =
+            (+state.dictionarySettings).dictionaries
         dictionaryTable.activeData =
             state.activeDictionaries.filter { dictionary -> dictionary in dictionaryTable.data }
         arrayDecoratorEditor.loadState(state.decorator)
@@ -90,7 +91,6 @@ class WordSchemeEditor(scheme: WordScheme = WordScheme()) : StateEditor<WordSche
 
     override fun readState() =
         WordScheme(
-            dictionarySettings = originalState.dictionarySettings,
             minLength = minLength.value,
             maxLength = maxLength.value,
             enclosure = enclosureGroup.getValue() ?: DEFAULT_ENCLOSURE,
@@ -99,10 +99,9 @@ class WordSchemeEditor(scheme: WordScheme = WordScheme()) : StateEditor<WordSche
         ).also {
             it.uuid = originalState.uuid
 
-            it.dictionarySettings.dictionaries =
-                dictionaryTable.data.toMutableSet()
-            it.activeDictionaries =
-                dictionaryTable.activeData.filter { file -> file in it.dictionarySettings.dictionaries }.toMutableSet()
+            it.dictionarySettings = originalState.dictionarySettings.copy()
+            (+it.dictionarySettings).dictionaries = dictionaryTable.data.toMutableSet()
+            it.activeDictionaries = dictionaryTable.activeData.toMutableSet()
 
             UserDictionary.clearCache()
         }

--- a/src/main/kotlin/com/fwdekker/randomness/word/WordSchemeEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/word/WordSchemeEditor.kt
@@ -95,13 +95,13 @@ class WordSchemeEditor(scheme: WordScheme = WordScheme()) : StateEditor<WordSche
             maxLength = maxLength.value,
             enclosure = enclosureGroup.getValue() ?: DEFAULT_ENCLOSURE,
             capitalization = capitalizationGroup.getValue()?.let { getMode(it) } ?: DEFAULT_CAPITALIZATION,
-            activeDictionaries = dictionaryTable.activeData.toMutableSet(),
+            activeDictionaries = dictionaryTable.activeData.toSet(),
             decorator = arrayDecoratorEditor.readState()
         ).also {
             it.uuid = originalState.uuid
 
             it.dictionarySettings += (+originalState.dictionarySettings).deepCopy(retainUuid = true)
-            (+it.dictionarySettings).dictionaries = dictionaryTable.data.toMutableSet()
+            (+it.dictionarySettings).dictionaries = dictionaryTable.data.toSet()
 
             UserDictionary.clearCache()
         }

--- a/src/main/kotlin/com/fwdekker/randomness/word/WordSchemeEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/word/WordSchemeEditor.kt
@@ -100,12 +100,21 @@ class WordSchemeEditor(scheme: WordScheme = WordScheme()) : StateEditor<WordSche
             it.uuid = originalState.uuid
 
             it.dictionarySettings.dictionaries =
-                dictionaryTable.data.toMutableList()
+                dictionaryTable.data.toMutableSet()
             it.activeDictionaries =
-                dictionaryTable.activeData.filter { file -> file in it.dictionarySettings.dictionaries }.toMutableList()
+                dictionaryTable.activeData.filter { file -> file in it.dictionarySettings.dictionaries }.toMutableSet()
 
             UserDictionary.clearCache()
         }
+
+
+    override fun doValidate(): String? {
+        val dictionaries = dictionaryTable.data
+        val duplicate = dictionaries.firstOrNull { dictionary -> dictionaries.count { it == dictionary } > 1 }
+
+        return if (duplicate != null) "Duplicate dictionary '$duplicate'."
+        else super.doValidate()
+    }
 
 
     override fun addChangeListener(listener: () -> Unit) =

--- a/src/main/kotlin/com/fwdekker/randomness/word/WordSchemeEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/word/WordSchemeEditor.kt
@@ -82,11 +82,9 @@ class WordSchemeEditor(scheme: WordScheme = WordScheme()) : StateEditor<WordSche
         maxLength.value = state.maxLength
         enclosureGroup.setValue(state.enclosure)
         capitalizationGroup.setValue(state.capitalization)
-        dictionaryTable.data =
-            state.dictionarySettings.bundledDictionaries + state.dictionarySettings.userDictionaries
+        dictionaryTable.data = state.dictionarySettings.dictionaries
         dictionaryTable.activeData =
-            (state.activeBundledDictionaries + state.activeUserDictionaries)
-                .filter { dictionary -> dictionary in dictionaryTable.data }
+            state.activeDictionaries.filter { dictionary -> dictionary in dictionaryTable.data }
         arrayDecoratorEditor.loadState(state.decorator)
     }
 
@@ -101,17 +99,12 @@ class WordSchemeEditor(scheme: WordScheme = WordScheme()) : StateEditor<WordSche
         ).also {
             it.uuid = originalState.uuid
 
-            it.dictionarySettings.bundledDictionaries = dictionaryTable.data
-                .filter { file -> file.isBundled }.toSet()
-            it.activeBundledDictionaries = dictionaryTable.activeData
-                .filter { file -> file.isBundled && file in it.dictionarySettings.bundledDictionaries }.toSet()
-            it.dictionarySettings.userDictionaries = dictionaryTable.data
-                .filter { file -> !file.isBundled }.toSet()
-            it.activeUserDictionaries = dictionaryTable.activeData
-                .filter { file -> !file.isBundled && file in it.dictionarySettings.userDictionaries }.toSet()
+            it.dictionarySettings.dictionaries =
+                dictionaryTable.data.toMutableList()
+            it.activeDictionaries =
+                dictionaryTable.activeData.filter { file -> file in it.dictionarySettings.dictionaries }.toMutableList()
 
-            BundledDictionary.cache.clear()
-            UserDictionary.cache.clear()
+            UserDictionary.clearCache()
         }
 
 

--- a/src/main/kotlin/com/fwdekker/randomness/word/WordSchemeEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/word/WordSchemeEditor.kt
@@ -94,17 +94,22 @@ class WordSchemeEditor(scheme: WordScheme = WordScheme()) : StateEditor<WordSche
             minLength = minLength.value,
             maxLength = maxLength.value,
             enclosure = enclosureGroup.getValue() ?: DEFAULT_ENCLOSURE,
-            capitalization = capitalizationGroup.getValue()?.let(::getMode) ?: DEFAULT_CAPITALIZATION,
+            capitalization = capitalizationGroup.getValue()?.let { getMode(it) } ?: DEFAULT_CAPITALIZATION,
+            activeDictionaries = dictionaryTable.activeData.toMutableSet(),
             decorator = arrayDecoratorEditor.readState()
         ).also {
             it.uuid = originalState.uuid
 
-            it.dictionarySettings = originalState.dictionarySettings.copy()
+            it.dictionarySettings += (+originalState.dictionarySettings).deepCopy(retainUuid = true)
             (+it.dictionarySettings).dictionaries = dictionaryTable.data.toMutableSet()
-            it.activeDictionaries = dictionaryTable.activeData.toMutableSet()
 
             UserDictionary.clearCache()
         }
+
+    override fun applyState() {
+        super.applyState()
+        (+originalState.dictionarySettings).copyFrom(+readState().dictionarySettings)
+    }
 
 
     override fun doValidate(): String? {

--- a/src/test/kotlin/com/fwdekker/randomness/StateEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/StateEditorTest.kt
@@ -15,7 +15,7 @@ import org.spekframework.spek2.style.specification.describe
 object StateEditorTest : Spek({
     lateinit var frame: FrameFixture
 
-    lateinit var scheme: DummyScheme
+    lateinit var state: DummyScheme
     lateinit var editor: DummySchemeEditor
 
 
@@ -24,8 +24,8 @@ object StateEditorTest : Spek({
     }
 
     beforeEachTest {
-        scheme = DummyScheme.from("ashamed", "bathe")
-        editor = GuiActionRunner.execute<DummySchemeEditor> { DummySchemeEditor(scheme) }
+        state = DummyScheme.from("ashamed", "bathe")
+        editor = GuiActionRunner.execute<DummySchemeEditor> { DummySchemeEditor(state) }
         frame = Containers.showInFrame(editor.rootComponent)
     }
 
@@ -34,40 +34,40 @@ object StateEditorTest : Spek({
     }
 
 
-    describe("loadScheme") {
-        it("writes the given scheme into the original scheme") {
-            val newScheme = DummyScheme.from("satisfy", "faint")
+    describe("loadState") {
+        it("writes the given state into the original state") {
+            val newState = DummyScheme.from("satisfy", "faint")
 
-            GuiActionRunner.execute { editor.loadState(newScheme) }
+            GuiActionRunner.execute { editor.loadState(newState) }
 
-            assertThat(scheme.literals).containsExactly("satisfy", "faint")
-            assertThat(scheme).isNotSameAs(newScheme)
+            assertThat(state.literals).containsExactly("satisfy", "faint")
+            assertThat(state).isNotSameAs(newState)
         }
     }
 
-    describe("readScheme") {
-        it("returns an identical copy of the original scheme") {
-            val readScheme = editor.readState()
+    describe("readState") {
+        it("returns an identical copy of the original state") {
+            val readState = editor.readState()
 
-            assertThat(readScheme.literals).containsExactly("ashamed", "bathe")
-            assertThat(readScheme).isNotSameAs(scheme)
+            assertThat(readState.literals).containsExactly("ashamed", "bathe")
+            assertThat(readState).isNotSameAs(state)
         }
 
-        it("returns a copy that reflects changes in the editor without adusting the original scheme") {
+        it("returns a copy that reflects changes in the editor without adusting the original state") {
             GuiActionRunner.execute { frame.textBox("literals").target().text = "reflect,cover" }
 
-            assertThat(scheme.literals).containsExactly("ashamed", "bathe")
+            assertThat(state.literals).containsExactly("ashamed", "bathe")
             assertThat(editor.readState().literals).containsExactly("reflect", "cover")
         }
     }
 
-    describe("applyScheme") {
-        it("writes changes into the original scheme") {
+    describe("applyState") {
+        it("writes changes into the original state") {
             GuiActionRunner.execute { frame.textBox("literals").target().text = "puzzle,once" }
 
             editor.applyState()
 
-            assertThat(scheme.literals).containsExactly("puzzle", "once")
+            assertThat(state.literals).containsExactly("puzzle", "once")
         }
     }
 
@@ -108,22 +108,22 @@ object StateEditorTest : Spek({
             assertThat(editor.isModified()).isFalse()
         }
 
-        it("ensures that applying the scheme does not affect the original scheme") {
+        it("ensures that applying the state does not affect the original state") {
             GuiActionRunner.execute { frame.textBox("literals").target().text = "father" }
 
             GuiActionRunner.execute { editor.reset() }
             editor.applyState()
 
-            assertThat(scheme.literals).containsExactly("ashamed", "bathe")
+            assertThat(state.literals).containsExactly("ashamed", "bathe")
         }
     }
 
     describe("doValidate") {
-        it("returns null if the scheme is valid") {
+        it("returns null if the state is valid") {
             assertThat(editor.doValidate()).isNull()
         }
 
-        it("returns an error message if the scheme is invalid") {
+        it("returns an error message if the state is invalid") {
             GuiActionRunner.execute { frame.textBox("literals").target().text = DummyScheme.INVALID_OUTPUT }
 
             assertThat(editor.doValidate()).isEqualTo("Invalid input!")

--- a/src/test/kotlin/com/fwdekker/randomness/TempFileHelper.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/TempFileHelper.kt
@@ -26,11 +26,11 @@ internal class TempFileHelper {
      */
     fun createFile(contents: String = "", extension: String? = null): File =
         try {
-            val dictionaryFile = File.createTempFile("intellij-randomness", extension)
-            files.add(dictionaryFile)
-            dictionaryFile.writeText(contents)
+            val file = File.createTempFile("intellij-randomness", extension)
+            files.add(file)
+            file.writeText(contents)
 
-            dictionaryFile
+            file
         } catch (e: IOException) {
             fail("Could not set up dictionary file.", e)
         }

--- a/src/test/kotlin/com/fwdekker/randomness/array/ArraySchemeDecoratorEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/array/ArraySchemeDecoratorEditorTest.kt
@@ -56,7 +56,7 @@ object ArraySchemeDecoratorEditorTest : Spek({
     }
 
 
-    describe("loadScheme") {
+    describe("loadState") {
         it("loads the scheme's enabled state") {
             GuiActionRunner.execute { editor.loadState(ArraySchemeDecorator(enabled = true)) }
 
@@ -95,7 +95,7 @@ object ArraySchemeDecoratorEditorTest : Spek({
         }
     }
 
-    describe("readScheme") {
+    describe("readState") {
         describe("defaults") {
             it("returns default brackets if no brackets are selected") {
                 GuiActionRunner.execute {

--- a/src/test/kotlin/com/fwdekker/randomness/decimal/DecimalSchemeEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/decimal/DecimalSchemeEditorTest.kt
@@ -44,7 +44,7 @@ object DecimalSchemeEditorTest : Spek({
     }
 
 
-    describe("loadScheme") {
+    describe("loadState") {
         it("loads the scheme's minimum value") {
             GuiActionRunner.execute { editor.loadState(DecimalScheme(minValue = 157.61, maxValue = 637.03)) }
 
@@ -98,7 +98,7 @@ object DecimalSchemeEditorTest : Spek({
         }
     }
 
-    describe("readScheme") {
+    describe("readState") {
         describe("defaults") {
             it("returns default grouping separator if no grouping separator is selected") {
                 GuiActionRunner.execute { editor.loadState(DecimalScheme(groupingSeparator = "unsupported")) }

--- a/src/test/kotlin/com/fwdekker/randomness/integer/IntegerSchemeEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/integer/IntegerSchemeEditorTest.kt
@@ -63,7 +63,7 @@ object IntegerSchemeEditorTest : Spek({
     }
 
 
-    describe("loadScheme") {
+    describe("loadState") {
         it("loads the scheme's minimum value") {
             GuiActionRunner.execute { editor.loadState(IntegerScheme(minValue = 145L, maxValue = 341L)) }
 
@@ -111,7 +111,7 @@ object IntegerSchemeEditorTest : Spek({
         }
     }
 
-    describe("readScheme") {
+    describe("readState") {
         describe("defaults") {
             it("returns default brackets if no brackets are selected") {
                 GuiActionRunner.execute { editor.loadState(IntegerScheme(groupingSeparator = "unsupported")) }

--- a/src/test/kotlin/com/fwdekker/randomness/literal/LiteralSchemeEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/literal/LiteralSchemeEditorTest.kt
@@ -34,7 +34,7 @@ object LiteralSchemeEditorTest : Spek({
     }
 
 
-    describe("loadScheme") {
+    describe("loadState") {
         it("loads the scheme's literal") {
             GuiActionRunner.execute { editor.loadState(LiteralScheme(literal = "scrape")) }
 
@@ -42,7 +42,7 @@ object LiteralSchemeEditorTest : Spek({
         }
     }
 
-    describe("readScheme") {
+    describe("readState") {
         it("returns the original state if no editor changes are made") {
             assertThat(editor.readState()).isEqualTo(editor.originalState)
         }

--- a/src/test/kotlin/com/fwdekker/randomness/string/StringSchemeEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/string/StringSchemeEditorTest.kt
@@ -105,7 +105,7 @@ object StringSchemeEditorTest : Spek({
             GuiActionRunner.execute {
                 val settings = SymbolSetSettings()
                 settings.symbolSetList = allSymbolSets
-                val newScheme = StringScheme(activeSymbolSets = activeSymbolSets.map { it.name }.toMutableSet())
+                val newScheme = StringScheme(activeSymbolSets = activeSymbolSets.map { it.name }.toSet())
                 newScheme.symbolSetSettings += settings
 
                 editor.loadState(newScheme)

--- a/src/test/kotlin/com/fwdekker/randomness/string/StringSchemeEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/string/StringSchemeEditorTest.kt
@@ -194,6 +194,18 @@ object StringSchemeEditorTest : Spek({
     }
 
 
+    describe("doValidate") {
+        it("is invalid if multiple symbol sets with the same name have been defined") {
+            GuiActionRunner.execute {
+                symbolSetTable.listTableModel.addRow(EditableDatum(active = true, SymbolSet("earth", "P3ogL")))
+                symbolSetTable.listTableModel.addRow(EditableDatum(active = true, SymbolSet("earth", "lNp5dG8k")))
+            }
+
+            assertThat(editor.doValidate()).isEqualTo("Multiple symbol sets with name 'earth'.")
+        }
+    }
+
+
     describe("addChangeListener") {
         it("invokes the listener if a field changes") {
             var listenerInvoked = false

--- a/src/test/kotlin/com/fwdekker/randomness/string/StringSchemeEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/string/StringSchemeEditorTest.kt
@@ -182,14 +182,46 @@ object StringSchemeEditorTest : Spek({
                 .isEqualTo(editor.originalState)
                 .isNotSameAs(editor.originalState)
             assertThat(+readState.symbolSetSettings)
-                .isSameAs(+editor.originalState.symbolSetSettings)
+                .isEqualTo(+editor.originalState.symbolSetSettings)
+                .isNotSameAs(+editor.originalState.symbolSetSettings)
             assertThat(readState.decorator)
                 .isEqualTo(editor.originalState.decorator)
                 .isNotSameAs(editor.originalState.decorator)
         }
 
+        it("returns a scheme with a deep copy of the symbol set settings") {
+            GuiActionRunner.execute {
+                repeat(symbolSetTable.items.size) { symbolSetTable.listTableModel.removeRow(0) }
+                symbolSetTable.listTableModel.addRow(EditableDatum(active = true, SymbolSet("feel", "5vG6eeU")))
+            }
+
+            assertThat((+editor.readState().symbolSetSettings).symbolSetList)
+                .containsExactly(SymbolSet("feel", "5vG6eeU"))
+            assertThat(symbolSetSettings.symbolSetList)
+                .doesNotContain(SymbolSet("feel", "5vG6eeU"))
+        }
+
         it("retains the scheme's UUID") {
             assertThat(editor.readState().uuid).isEqualTo(editor.originalState.uuid)
+        }
+    }
+
+    describe("applyState") {
+        it("does not change the target's reference to the symbol set settings") {
+            GuiActionRunner.execute { editor.applyState() }
+
+            assertThat(+scheme.symbolSetSettings).isSameAs(symbolSetSettings)
+        }
+
+        it("copies the changes from the table into the original state's symbol set settings") {
+            GuiActionRunner.execute {
+                repeat(symbolSetTable.items.size) { symbolSetTable.listTableModel.removeRow(0) }
+                symbolSetTable.listTableModel.addRow(EditableDatum(active = true, SymbolSet("excess", "uWX4POU")))
+            }
+
+            GuiActionRunner.execute { editor.applyState() }
+
+            assertThat(symbolSetSettings.symbolSetList).containsExactly(SymbolSet("excess", "uWX4POU"))
         }
     }
 

--- a/src/test/kotlin/com/fwdekker/randomness/string/StringSchemeEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/string/StringSchemeEditorTest.kt
@@ -68,7 +68,7 @@ object StringSchemeEditorTest : Spek({
     }
 
 
-    describe("loadScheme") {
+    describe("loadState") {
         it("loads the scheme's minimum length") {
             GuiActionRunner.execute { editor.loadState(StringScheme(minLength = 144, maxLength = 163)) }
 
@@ -124,7 +124,7 @@ object StringSchemeEditorTest : Spek({
         }
     }
 
-    describe("readScheme") {
+    describe("readState") {
         describe("defaults") {
             it("returns default enclosure if no enclosure is selected") {
                 GuiActionRunner.execute { editor.loadState(StringScheme(enclosure = "unsupported")) }

--- a/src/test/kotlin/com/fwdekker/randomness/string/StringSchemeEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/string/StringSchemeEditorTest.kt
@@ -38,7 +38,7 @@ object StringSchemeEditorTest : Spek({
         ideaFixture.setUp()
 
         symbolSetSettings = SymbolSetSettings()
-        scheme = StringScheme(symbolSetSettings)
+        scheme = StringScheme().also { it.symbolSetSettings += symbolSetSettings }
         editor = GuiActionRunner.execute<StringSchemeEditor> { StringSchemeEditor(scheme) }
         frame = showInFrame(editor.rootComponent)
 
@@ -103,12 +103,12 @@ object StringSchemeEditorTest : Spek({
             val activeSymbolSets = listOf(SymbolSet.ALPHABET, SymbolSet.HEXADECIMAL)
 
             GuiActionRunner.execute {
-                editor.loadState(
-                    StringScheme(
-                        SymbolSetSettings().also { it.symbolSetList = allSymbolSets },
-                        activeSymbolSets = activeSymbolSets.map { it.name }.toMutableSet()
-                    )
-                )
+                val settings = SymbolSetSettings()
+                settings.symbolSetList = allSymbolSets
+                val newScheme = StringScheme(activeSymbolSets = activeSymbolSets.map { it.name }.toMutableSet())
+                newScheme.symbolSetSettings += settings
+
+                editor.loadState(newScheme)
             }
 
             assertThat(symbolSetTable.items.map { it.datum })
@@ -181,8 +181,8 @@ object StringSchemeEditorTest : Spek({
             assertThat(readState)
                 .isEqualTo(editor.originalState)
                 .isNotSameAs(editor.originalState)
-            assertThat(readState.symbolSetSettings)
-                .isSameAs(editor.originalState.symbolSetSettings)
+            assertThat(+readState.symbolSetSettings)
+                .isSameAs(+editor.originalState.symbolSetSettings)
             assertThat(readState.decorator)
                 .isEqualTo(editor.originalState.decorator)
                 .isNotSameAs(editor.originalState.decorator)

--- a/src/test/kotlin/com/fwdekker/randomness/string/StringSchemeTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/string/StringSchemeTest.kt
@@ -19,8 +19,8 @@ object StringSchemeTest : Spek({
 
 
     beforeEachTest {
-        symbolSetSettings = SymbolSetSettings(mutableMapOf("steam" to "bH2"))
-        stringScheme = StringScheme(activeSymbolSets = mutableSetOf("steam"))
+        symbolSetSettings = SymbolSetSettings(mapOf("steam" to "bH2"))
+        stringScheme = StringScheme(activeSymbolSets = setOf("steam"))
         stringScheme.symbolSetSettings += symbolSetSettings
     }
 
@@ -56,7 +56,7 @@ object StringSchemeTest : Spek({
                     stringScheme.maxLength = maxLength
                     stringScheme.enclosure = enclosure
                     stringScheme.capitalization = capitalization
-                    stringScheme.activeSymbolSets = symbolSets.values.toMutableSet()
+                    stringScheme.activeSymbolSets = symbolSets.values.toSet()
 
                     assertThat(stringScheme.generateStrings()).containsExactly(expectedString)
                 }
@@ -71,7 +71,7 @@ object StringSchemeTest : Spek({
                 stringScheme.maxLength = 1
                 stringScheme.enclosure = ""
                 stringScheme.capitalization = CapitalizationMode.RETAIN
-                stringScheme.activeSymbolSets = symbolSets.keys.toMutableSet()
+                stringScheme.activeSymbolSets = symbolSets.keys.toSet()
 
                 assertThat(stringScheme.generateStrings()).containsExactly(emoji)
             }
@@ -112,28 +112,28 @@ object StringSchemeTest : Spek({
 
         describe("symbol sets") {
             it("fails if the symbol set settings are invalid") {
-                symbolSetSettings.symbolSets = mutableMapOf()
-                stringScheme.activeSymbolSets = mutableSetOf()
+                symbolSetSettings.symbolSets = emptyMap()
+                stringScheme.activeSymbolSets = emptySet()
 
                 assertThat(stringScheme.doValidate()).isEqualTo("Add at least one symbol set.")
             }
 
             it("fails if an undefined symbol set is selected") {
-                symbolSetSettings.symbolSets = mutableMapOf("name" to "symbols")
-                stringScheme.activeSymbolSets = mutableSetOf("unknown")
+                symbolSetSettings.symbolSets = mapOf("name" to "symbols")
+                stringScheme.activeSymbolSets = setOf("unknown")
 
                 assertThat(stringScheme.doValidate()).isEqualTo("Unknown symbol set `unknown`.")
             }
 
             it("fails if no symbol sets are active") {
-                stringScheme.activeSymbolSets = mutableSetOf()
+                stringScheme.activeSymbolSets = emptySet()
 
                 assertThat(stringScheme.doValidate()).isEqualTo("Activate at least one symbol set.")
             }
 
             it("fails if only look-alike symbols are selected and look-alike symbols are excluded") {
-                symbolSetSettings.symbolSets = mutableMapOf("Look-alike" to "l01")
-                stringScheme.activeSymbolSets = mutableSetOf("Look-alike")
+                symbolSetSettings.symbolSets = mapOf("Look-alike" to "l01")
+                stringScheme.activeSymbolSets = setOf("Look-alike")
                 stringScheme.excludeLookAlikeSymbols = true
 
                 assertThat(stringScheme.doValidate()).isEqualTo(
@@ -173,10 +173,10 @@ object StringSchemeTest : Spek({
         }
 
         it("creates an independent copy of the symbol set settings") {
-            (+stringScheme.symbolSetSettings).symbolSets = mutableMapOf("formal" to "feXw8M")
+            (+stringScheme.symbolSetSettings).symbolSets = mapOf("formal" to "feXw8M")
 
             val copy = stringScheme.deepCopy()
-            (+copy.symbolSetSettings).symbolSets = mutableMapOf("absent" to "9hDt")
+            (+copy.symbolSetSettings).symbolSets = mapOf("absent" to "9hDt")
 
             assertThat((+stringScheme.symbolSetSettings).symbolSets).containsOnlyKeys("formal")
         }
@@ -191,7 +191,7 @@ object StringSchemeTest : Spek({
             stringScheme.minLength = 730
             stringScheme.maxLength = 891
             stringScheme.enclosure = "Qh7"
-            stringScheme.activeSymbolSets = mutableSetOf(SymbolSet.BRACKETS.name)
+            stringScheme.activeSymbolSets = setOf(SymbolSet.BRACKETS.name)
             stringScheme.excludeLookAlikeSymbols = true
             stringScheme.decorator.count = 249
 
@@ -217,12 +217,12 @@ object StringSchemeTest : Spek({
         }
 
         it("writes a deep copy of the given scheme's symbol set settings into the target") {
-            val otherSettings = SymbolSetSettings(mutableMapOf("sew" to "2eNco"))
+            val otherSettings = SymbolSetSettings(mapOf("sew" to "2eNco"))
             val otherScheme = StringScheme()
             otherScheme.symbolSetSettings += otherSettings
 
             stringScheme.copyFrom(otherScheme)
-            (+otherScheme.symbolSetSettings).symbolSets = mutableMapOf("wife" to "4g5X0")
+            (+otherScheme.symbolSetSettings).symbolSets = mapOf("wife" to "4g5X0")
 
             assertThat((+stringScheme.symbolSetSettings).symbolSets).containsOnlyKeys("sew")
         }

--- a/src/test/kotlin/com/fwdekker/randomness/string/StringSchemeTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/string/StringSchemeTest.kt
@@ -17,7 +17,8 @@ object StringSchemeTest : Spek({
 
 
     beforeEachTest {
-        stringScheme = StringScheme(SymbolSetSettings())
+        stringScheme = StringScheme()
+        stringScheme.symbolSetSettings += SymbolSetSettings()
     }
 
 
@@ -47,7 +48,7 @@ object StringSchemeTest : Spek({
                 Param(466, 466, "z", CapitalizationMode.LOWER, mapOf("x" to "x")) to "z${"x".repeat(466)}z"
             ).forEach { (minLength, maxLength, enclosure, capitalization, symbolSets), expectedString ->
                 it("generates a formatted string") {
-                    stringScheme.symbolSetSettings = SymbolSetSettings().also { it.symbolSets = symbolSets }
+                    stringScheme.symbolSetSettings += SymbolSetSettings().also { it.symbolSets = symbolSets }
                     stringScheme.minLength = minLength
                     stringScheme.maxLength = maxLength
                     stringScheme.enclosure = enclosure
@@ -62,7 +63,7 @@ object StringSchemeTest : Spek({
                 val emoji = "👩‍👩‍👧‍👧"
                 val symbolSets = mapOf("emoji" to emoji)
 
-                stringScheme.symbolSetSettings = SymbolSetSettings().also { it.symbolSets = symbolSets }
+                stringScheme.symbolSetSettings += SymbolSetSettings().also { it.symbolSets = symbolSets }
                 stringScheme.minLength = 1
                 stringScheme.maxLength = 1
                 stringScheme.enclosure = ""
@@ -75,19 +76,19 @@ object StringSchemeTest : Spek({
     }
 
     describe("setSettingsState") {
-        it("overwrites the constructor's symbol set settings") {
-            val newSettings = SettingsState(symbolSetSettings = SymbolSetSettings())
+        it("overwrites the default symbol set settings") {
+            val newSettings = SymbolSetSettings()
 
-            stringScheme.setSettingsState(newSettings)
+            stringScheme.setSettingsState(SettingsState(symbolSetSettings = newSettings))
 
-            assertThat(stringScheme.symbolSetSettings).isSameAs(newSettings.symbolSetSettings)
+            assertThat(+stringScheme.symbolSetSettings).isSameAs(newSettings)
         }
     }
 
 
     describe("doValidate") {
         it("passes for the default settings") {
-            assertThat(StringScheme(SymbolSetSettings()).doValidate()).isNull()
+            assertThat(stringScheme.doValidate()).isNull()
         }
 
         describe("length range") {
@@ -108,14 +109,14 @@ object StringSchemeTest : Spek({
 
         describe("symbol sets") {
             it("fails if the symbol set settings are invalid") {
-                stringScheme.symbolSetSettings = SymbolSetSettings(mutableMapOf())
+                stringScheme.symbolSetSettings += SymbolSetSettings(mutableMapOf())
                 stringScheme.activeSymbolSets = mutableSetOf()
 
                 assertThat(stringScheme.doValidate()).isEqualTo("Add at least one symbol set.")
             }
 
             it("fails if an undefined symbol set is selected") {
-                stringScheme.symbolSetSettings = SymbolSetSettings(mutableMapOf("name" to "symbols"))
+                stringScheme.symbolSetSettings += SymbolSetSettings(mutableMapOf("name" to "symbols"))
                 stringScheme.activeSymbolSets = mutableSetOf("unknown")
 
                 assertThat(stringScheme.doValidate()).isEqualTo("Unknown symbol set `unknown`.")
@@ -128,7 +129,7 @@ object StringSchemeTest : Spek({
             }
 
             it("fails if only look-alike symbols are selected and look-alike symbols are excluded") {
-                stringScheme.symbolSetSettings = SymbolSetSettings(mutableMapOf("Look-alike" to "l01"))
+                stringScheme.symbolSetSettings += SymbolSetSettings(mutableMapOf("Look-alike" to "l01"))
                 stringScheme.activeSymbolSets = mutableSetOf("Look-alike")
                 stringScheme.excludeLookAlikeSymbols = true
 
@@ -162,7 +163,7 @@ object StringSchemeTest : Spek({
         }
 
         it("retains the reference to the symbol set settings") {
-            assertThat(stringScheme.deepCopy().symbolSetSettings).isSameAs(stringScheme.symbolSetSettings)
+            assertThat(+stringScheme.deepCopy().symbolSetSettings).isSameAs(+stringScheme.symbolSetSettings)
         }
     }
 
@@ -177,23 +178,18 @@ object StringSchemeTest : Spek({
             stringScheme.excludeLookAlikeSymbols = true
             stringScheme.decorator.count = 249
 
-            val newScheme = StringScheme(SymbolSetSettings())
+            val newScheme = StringScheme()
+            newScheme.symbolSetSettings += SymbolSetSettings()
             newScheme.copyFrom(stringScheme)
 
             assertThat(newScheme)
                 .isEqualTo(stringScheme)
                 .isNotSameAs(stringScheme)
+            assertThat(+newScheme.symbolSetSettings)
+                .isSameAs(+stringScheme.symbolSetSettings)
             assertThat(newScheme.decorator)
                 .isEqualTo(stringScheme.decorator)
                 .isNotSameAs(stringScheme.decorator)
-        }
-
-        it("retains the reference to the symbol set settings") {
-            val newSettings = SymbolSetSettings()
-
-            stringScheme.copyFrom(StringScheme(newSettings))
-
-            assertThat(stringScheme.symbolSetSettings).isSameAs(newSettings)
         }
     }
 })

--- a/src/test/kotlin/com/fwdekker/randomness/string/SymbolSetSettingsTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/string/SymbolSetSettingsTest.kt
@@ -17,7 +17,7 @@ object SymbolSetSettingsTest : Spek({
         }
 
         it("deserializes emoji") {
-            val settings = SymbolSetSettings(mutableMapOf("emoji" to ":couple_with_heart_man_man:"))
+            val settings = SymbolSetSettings(mapOf("emoji" to ":couple_with_heart_man_man:"))
 
             assertThat(settings.symbolSets["emoji"]).isEqualTo("👨‍❤️‍👨")
         }
@@ -30,16 +30,16 @@ object SymbolSetSettingsTest : Spek({
         }
 
         it("fails if no symbol sets are defined") {
-            assertThat(SymbolSetSettings(mutableMapOf()).doValidate()).isEqualTo("Add at least one symbol set.")
+            assertThat(SymbolSetSettings(emptyMap()).doValidate()).isEqualTo("Add at least one symbol set.")
         }
 
         it("fails if a symbol set does not have a name") {
-            assertThat(SymbolSetSettings(mutableMapOf("" to "hAA76o")).doValidate())
+            assertThat(SymbolSetSettings(mapOf("" to "hAA76o")).doValidate())
                 .isEqualTo("All symbol sets should have a name.")
         }
 
         it("fails if a symbol set has no symbols") {
-            assertThat(SymbolSetSettings(mutableMapOf("value" to "")).doValidate())
+            assertThat(SymbolSetSettings(mapOf("value" to "")).doValidate())
                 .isEqualTo("Symbol set `value` should contain at least one symbol.")
         }
     }

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateActionTests.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateActionTests.kt
@@ -36,7 +36,7 @@ class TemplateGroupActionTest : Spek({
     describe("update") {
         describe("icon") {
             it("uses a default icon if the template's icons are null") {
-                template.schemes = mutableListOf(DummyScheme().also { it.icons = null })
+                template.schemes = listOf(DummyScheme().also { it.icons = null })
 
                 val event = TestActionEvent(groupAction)
                 groupAction.update(event)
@@ -45,7 +45,7 @@ class TemplateGroupActionTest : Spek({
             }
 
             it("uses the template's icon") {
-                template.schemes = mutableListOf(DummyScheme().also { it.icons = RandomnessIcons.Word })
+                template.schemes = listOf(DummyScheme().also { it.icons = RandomnessIcons.Word })
 
                 val event = TestActionEvent(groupAction)
                 groupAction.update(event)
@@ -130,7 +130,7 @@ object TemplateSettingsActionTest : Spek({
             }
 
             it("uses a default icon if the template's icons are null") {
-                template.schemes = mutableListOf(DummyScheme().also { it.icons = null })
+                template.schemes = listOf(DummyScheme().also { it.icons = null })
 
                 val event = TestActionEvent(settingsAction)
                 settingsAction.update(event)
@@ -139,7 +139,7 @@ object TemplateSettingsActionTest : Spek({
             }
 
             it("uses the template's icons if the template is not null") {
-                template.schemes = mutableListOf(DummyScheme().also { it.icons = RandomnessIcons.Word })
+                template.schemes = listOf(DummyScheme().also { it.icons = RandomnessIcons.Word })
 
                 val event = TestActionEvent(settingsAction)
                 settingsAction.update(event)

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateListEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateListEditorTest.kt
@@ -44,6 +44,12 @@ object TemplateListEditorTest : Spek({
     lateinit var settingsState: SettingsState
     lateinit var editor: TemplateListEditor
 
+    @Suppress("UNCHECKED_CAST") // Use with care
+    val symbolSetTable = { (frame.table().target() as TableView<EditableDatum<SymbolSet>>).listTableModel }
+
+    @Suppress("UNCHECKED_CAST") // Use with care
+    val dictionaryTable = { (frame.table().target() as TableView<EditableDatum<Dictionary>>).listTableModel }
+
 
     beforeGroup {
         FailOnThreadViolationRepaintManager.install()
@@ -402,25 +408,21 @@ object TemplateListEditorTest : Spek({
                 frame.textBox("previewLabel").requireEmpty()
             }
 
-            @Suppress("UNCHECKED_CAST") // I checked it myself!
             it("does not change the original symbol sets when a string scheme is changed") {
                 GuiActionRunner.execute {
                     frame.tree().target().setSelectionRow(7)
-                    (frame.table().target() as TableView<EditableDatum<SymbolSet>>).listTableModel
-                        .addRow(EditableDatum(active = true, SymbolSet("ancient", "Fq9ohzV8")))
+                    symbolSetTable().addRow(EditableDatum(active = true, SymbolSet("ancient", "Fq9ohzV8")))
                 }
 
                 assertThat(editor.originalState.symbolSetSettings.symbolSets).doesNotContainKey("ancient")
             }
 
-            @Suppress("UNCHECKED_CAST") // I checked it myself!
             it("does not change the original dictionaries when a word scheme is changed") {
                 val dictionary = UserDictionary("nest")
 
                 GuiActionRunner.execute {
                     frame.tree().target().setSelectionRow(5)
-                    (frame.table().target() as TableView<EditableDatum<Dictionary>>).listTableModel
-                        .addRow(EditableDatum(active = true, dictionary))
+                    dictionaryTable().addRow(EditableDatum(active = true, dictionary))
                 }
 
                 assertThat(editor.originalState.dictionarySettings.dictionaries).doesNotContain(dictionary)
@@ -748,7 +750,6 @@ object TemplateListEditorTest : Spek({
         }
 
         describe("settingsState") {
-            @Suppress("UNCHECKED_CAST") // I checked it myself!
             it("retains changes to symbol sets between different string schemes") {
                 GuiActionRunner.execute {
                     editor.loadState(
@@ -761,8 +762,7 @@ object TemplateListEditorTest : Spek({
 
                 GuiActionRunner.execute {
                     frame.tree().target().setSelectionRow(1)
-                    (frame.table().target() as TableView<EditableDatum<SymbolSet>>).listTableModel
-                        .addRow(EditableDatum(active = true, SymbolSet("finger", "Xg24tQ")))
+                    symbolSetTable().addRow(EditableDatum(active = true, SymbolSet("finger", "Xg24tQ")))
 
                     frame.tree().target().setSelectionRow(2)
                 }
@@ -770,7 +770,6 @@ object TemplateListEditorTest : Spek({
                 frame.table().requireCellValue(row(1).column(1), "finger")
             }
 
-            @Suppress("UNCHECKED_CAST") // I checked it myself!
             it("retains changes to dictionaries between different word schemes") {
                 GuiActionRunner.execute {
                     editor.loadState(
@@ -783,8 +782,7 @@ object TemplateListEditorTest : Spek({
 
                 GuiActionRunner.execute {
                     frame.tree().target().setSelectionRow(1)
-                    (frame.table().target() as TableView<EditableDatum<Dictionary>>).listTableModel
-                        .addRow(EditableDatum(active = true, UserDictionary("rank")))
+                    dictionaryTable().addRow(EditableDatum(active = true, UserDictionary("rank")))
 
                     frame.tree().target().setSelectionRow(2)
                 }
@@ -795,12 +793,10 @@ object TemplateListEditorTest : Spek({
     }
 
     describe("applyScheme") {
-        @Suppress("UNCHECKED_CAST") // I checked it myself!
         it("applies changes to symbol sets") {
             GuiActionRunner.execute {
                 frame.tree().target().setSelectionRow(7)
-                (frame.table().target() as TableView<EditableDatum<SymbolSet>>).listTableModel
-                    .addRow(EditableDatum(active = true, SymbolSet("thumb", "4Tch7x7")))
+                symbolSetTable().addRow(EditableDatum(active = true, SymbolSet("thumb", "4Tch7x7")))
             }
 
             GuiActionRunner.execute { editor.applyState() }
@@ -808,12 +804,10 @@ object TemplateListEditorTest : Spek({
             assertThat(editor.originalState.symbolSetSettings.symbolSets).containsKey("thumb")
         }
 
-        @Suppress("UNCHECKED_CAST") // I checked it myself!
         it("does not apply changes to symbol sets after a reset") {
             GuiActionRunner.execute {
                 frame.tree().target().setSelectionRow(7)
-                (frame.table().target() as TableView<EditableDatum<SymbolSet>>).listTableModel
-                    .addRow(EditableDatum(active = true, SymbolSet("tell", "9Zchc3qs")))
+                symbolSetTable().addRow(EditableDatum(active = true, SymbolSet("tell", "9Zchc3qs")))
             }
 
             GuiActionRunner.execute { editor.reset() }
@@ -821,14 +815,12 @@ object TemplateListEditorTest : Spek({
             assertThat(editor.originalState.symbolSetSettings.symbolSets).doesNotContainKey("tell")
         }
 
-        @Suppress("UNCHECKED_CAST") // I checked it myself!
         it("applies changes to dictionaries") {
             val dictionary = UserDictionary("basis")
 
             GuiActionRunner.execute {
                 frame.tree().target().setSelectionRow(5)
-                (frame.table().target() as TableView<EditableDatum<Dictionary>>).listTableModel
-                    .addRow(EditableDatum(active = true, dictionary))
+                dictionaryTable().addRow(EditableDatum(active = true, dictionary))
             }
 
             GuiActionRunner.execute { editor.applyState() }
@@ -836,14 +828,12 @@ object TemplateListEditorTest : Spek({
             assertThat(editor.originalState.dictionarySettings.dictionaries).contains(dictionary)
         }
 
-        @Suppress("UNCHECKED_CAST") // I checked it myself!
         it("does not apply changes to dictionaries after a reset") {
             val dictionary = UserDictionary("guide")
 
             GuiActionRunner.execute {
                 frame.tree().target().setSelectionRow(5)
-                (frame.table().target() as TableView<EditableDatum<Dictionary>>).listTableModel
-                    .addRow(EditableDatum(active = true, dictionary))
+                dictionaryTable().addRow(EditableDatum(active = true, dictionary))
             }
 
             GuiActionRunner.execute { editor.reset() }

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateListEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateListEditorTest.kt
@@ -1,6 +1,5 @@
 package com.fwdekker.randomness.template
 
-import com.fwdekker.randomness.Scheme
 import com.fwdekker.randomness.SettingsState
 import com.fwdekker.randomness.clickActionButton
 import com.fwdekker.randomness.decimal.DecimalScheme
@@ -62,21 +61,21 @@ object TemplateListEditorTest : Spek({
         val symbolSetSettings = SymbolSetSettings()
         val dictionarySettings = DictionarySettings()
         val templateList = TemplateList(
-            mutableListOf(
+            listOf(
                 Template(
                     "Further",
-                    mutableListOf(IntegerScheme(), IntegerScheme(minValue = 7))
+                    listOf(IntegerScheme(), IntegerScheme(minValue = 7))
                 ),
                 Template(
                     "Enclose",
-                    mutableListOf(
+                    listOf(
                         LiteralScheme("else"),
                         WordScheme().also { it.dictionarySettings += dictionarySettings }
                     )
                 ),
                 Template(
                     "Student",
-                    mutableListOf(
+                    listOf(
                         StringScheme().also { it.symbolSetSettings += symbolSetSettings },
                         LiteralScheme("dog"),
                         IntegerScheme()
@@ -186,7 +185,7 @@ object TemplateListEditorTest : Spek({
                 }
 
                 it("sets the added scheme's settings") {
-                    val oldSettings = TemplateList(mutableListOf())
+                    val oldSettings = TemplateList(emptyList())
                     val newScheme = TemplateReference().apply { setSettingsState(SettingsState(oldSettings)) }
 
                     GuiActionRunner.execute { editor.addScheme(newScheme) }
@@ -444,9 +443,9 @@ object TemplateListEditorTest : Spek({
 
         it("selects the first template if it does not have any schemes") {
             GuiActionRunner.execute {
-                val templates = mutableListOf(
-                    Template("Flame", mutableListOf()),
-                    Template("Pen", mutableListOf(IntegerScheme()))
+                val templates = listOf(
+                    Template("Flame", emptyList()),
+                    Template("Pen", listOf(IntegerScheme()))
                 )
                 editor.loadState(SettingsState(TemplateList(templates)))
             }
@@ -455,7 +454,7 @@ object TemplateListEditorTest : Spek({
         }
 
         it("does nothing if no templates or schemes are loaded") {
-            GuiActionRunner.execute { editor.loadState(SettingsState(TemplateList(mutableListOf()))) }
+            GuiActionRunner.execute { editor.loadState(SettingsState(TemplateList(emptyList()))) }
 
             frame.tree().requireNoSelection()
         }
@@ -494,7 +493,7 @@ object TemplateListEditorTest : Spek({
 
     describe("loadScheme") {
         it("loads the list's templates") {
-            val templates = SettingsState(TemplateList(mutableListOf(Template(name = "Limb"), Template(name = "Pot"))))
+            val templates = SettingsState(TemplateList(listOf(Template(name = "Limb"), Template(name = "Pot"))))
 
             GuiActionRunner.execute { editor.loadState(templates) }
 
@@ -503,13 +502,13 @@ object TemplateListEditorTest : Spek({
         }
 
         it("loads the list's templates' schemes") {
-            val schemes: List<MutableList<Scheme>> = listOf(
-                mutableListOf(IntegerScheme()),
-                mutableListOf(),
-                mutableListOf(LiteralScheme(), DecimalScheme())
+            val schemes = listOf(
+                listOf(IntegerScheme()),
+                emptyList(),
+                listOf(LiteralScheme(), DecimalScheme())
             )
             val templates = TemplateList(
-                mutableListOf(
+                listOf(
                     Template("Prevent", schemes[0]),
                     Template("Being", schemes[1]),
                     Template("Coward", schemes[2])
@@ -522,7 +521,7 @@ object TemplateListEditorTest : Spek({
         }
 
         it("loads an empty tree if no templates are loaded") {
-            GuiActionRunner.execute { editor.loadState(SettingsState(TemplateList(mutableListOf()))) }
+            GuiActionRunner.execute { editor.loadState(SettingsState(TemplateList(emptyList()))) }
 
             assertThat(editor.readState().templateList.templates).isEmpty()
         }
@@ -549,7 +548,7 @@ object TemplateListEditorTest : Spek({
             }
 
             it("returns the list with a template and all its children added") {
-                val template = Template("Danger", mutableListOf(LiteralScheme("Ill"), IntegerScheme(), StringScheme()))
+                val template = Template("Danger", listOf(LiteralScheme("Ill"), IntegerScheme(), StringScheme()))
 
                 GuiActionRunner.execute { editor.addScheme(template) }
 
@@ -607,7 +606,7 @@ object TemplateListEditorTest : Spek({
             }
 
             it("returns a list of the single template if a first template is added") {
-                GuiActionRunner.execute { editor.loadState(SettingsState(TemplateList(mutableListOf()))) }
+                GuiActionRunner.execute { editor.loadState(SettingsState(TemplateList(emptyList()))) }
 
                 GuiActionRunner.execute { editor.addScheme(Template(name = "Seem")) }
 
@@ -677,7 +676,7 @@ object TemplateListEditorTest : Spek({
 
             it("returns a list of the single scheme if a first scheme is added to a template") {
                 GuiActionRunner.execute {
-                    editor.loadState(SettingsState(TemplateList(mutableListOf(Template(schemes = mutableListOf())))))
+                    editor.loadState(SettingsState(TemplateList(listOf(Template(schemes = emptyList())))))
                 }
 
                 GuiActionRunner.execute {
@@ -762,7 +761,7 @@ object TemplateListEditorTest : Spek({
                     editor.loadState(
                         SettingsState(
                             templateList = TemplateList.from(StringScheme(), StringScheme()),
-                            symbolSetSettings = SymbolSetSettings(mutableMapOf("pocket" to "0MLnYk5"))
+                            symbolSetSettings = SymbolSetSettings(mapOf("pocket" to "0MLnYk5"))
                         )
                     )
                 }

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateListEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateListEditorTest.kt
@@ -491,7 +491,7 @@ object TemplateListEditorTest : Spek({
     }
 
 
-    describe("loadScheme") {
+    describe("loadState") {
         it("loads the list's templates") {
             val templates = SettingsState(TemplateList(listOf(Template(name = "Limb"), Template(name = "Pot"))))
 
@@ -527,7 +527,7 @@ object TemplateListEditorTest : Spek({
         }
     }
 
-    describe("readScheme") {
+    describe("readState") {
         describe("no changes made") {
             it("returns the original state if no editor changes are made") {
                 assertThat(editor.readState()).isEqualTo(editor.originalState)
@@ -798,7 +798,7 @@ object TemplateListEditorTest : Spek({
         }
     }
 
-    describe("applyScheme") {
+    describe("applyState") {
         it("applies changes to symbol sets") {
             GuiActionRunner.execute {
                 frame.tree().target().setSelectionRow(7)

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateListEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateListEditorTest.kt
@@ -11,8 +11,9 @@ import com.fwdekker.randomness.string.SymbolSet
 import com.fwdekker.randomness.string.SymbolSetSettings
 import com.fwdekker.randomness.ui.EditableDatum
 import com.fwdekker.randomness.uuid.UuidScheme
-import com.fwdekker.randomness.word.DictionaryReference
+import com.fwdekker.randomness.word.Dictionary
 import com.fwdekker.randomness.word.DictionarySettings
+import com.fwdekker.randomness.word.UserDictionary
 import com.fwdekker.randomness.word.WordScheme
 import com.intellij.testFramework.fixtures.IdeaTestFixture
 import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
@@ -414,13 +415,15 @@ object TemplateListEditorTest : Spek({
 
             @Suppress("UNCHECKED_CAST") // I checked it myself!
             it("does not change the original dictionaries when a word scheme is changed") {
+                val dictionary = UserDictionary("nest")
+
                 GuiActionRunner.execute {
                     frame.tree().target().setSelectionRow(5)
-                    (frame.table().target() as TableView<EditableDatum<DictionaryReference>>).listTableModel
-                        .addRow(EditableDatum(active = true, DictionaryReference(isBundled = false, "nest")))
+                    (frame.table().target() as TableView<EditableDatum<Dictionary>>).listTableModel
+                        .addRow(EditableDatum(active = true, dictionary))
                 }
 
-                assertThat(editor.originalState.dictionarySettings.userDictionaryFiles).doesNotContain("nest")
+                assertThat(editor.originalState.dictionarySettings.dictionaries).doesNotContain(dictionary)
             }
         }
     }
@@ -780,8 +783,8 @@ object TemplateListEditorTest : Spek({
 
                 GuiActionRunner.execute {
                     frame.tree().target().setSelectionRow(1)
-                    (frame.table().target() as TableView<EditableDatum<DictionaryReference>>).listTableModel
-                        .addRow(EditableDatum(active = true, DictionaryReference(isBundled = false, "rank")))
+                    (frame.table().target() as TableView<EditableDatum<Dictionary>>).listTableModel
+                        .addRow(EditableDatum(active = true, UserDictionary("rank")))
 
                     frame.tree().target().setSelectionRow(2)
                 }
@@ -820,28 +823,32 @@ object TemplateListEditorTest : Spek({
 
         @Suppress("UNCHECKED_CAST") // I checked it myself!
         it("applies changes to dictionaries") {
+            val dictionary = UserDictionary("basis")
+
             GuiActionRunner.execute {
                 frame.tree().target().setSelectionRow(5)
-                (frame.table().target() as TableView<EditableDatum<DictionaryReference>>).listTableModel
-                    .addRow(EditableDatum(active = true, DictionaryReference(isBundled = false, "basis")))
+                (frame.table().target() as TableView<EditableDatum<Dictionary>>).listTableModel
+                    .addRow(EditableDatum(active = true, dictionary))
             }
 
             GuiActionRunner.execute { editor.applyState() }
 
-            assertThat(editor.originalState.dictionarySettings.userDictionaryFiles).contains("basis")
+            assertThat(editor.originalState.dictionarySettings.dictionaries).contains(dictionary)
         }
 
         @Suppress("UNCHECKED_CAST") // I checked it myself!
         it("does not apply changes to dictionaries after a reset") {
+            val dictionary = UserDictionary("guide")
+
             GuiActionRunner.execute {
                 frame.tree().target().setSelectionRow(5)
-                (frame.table().target() as TableView<EditableDatum<DictionaryReference>>).listTableModel
-                    .addRow(EditableDatum(active = true, DictionaryReference(isBundled = false, "guide")))
+                (frame.table().target() as TableView<EditableDatum<Dictionary>>).listTableModel
+                    .addRow(EditableDatum(active = true, dictionary))
             }
 
             GuiActionRunner.execute { editor.reset() }
 
-            assertThat(editor.originalState.dictionarySettings.userDictionaryFiles).doesNotContain("guide")
+            assertThat(editor.originalState.dictionarySettings.dictionaries).doesNotContain(dictionary)
         }
     }
 

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateListEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateListEditorTest.kt
@@ -69,11 +69,18 @@ object TemplateListEditorTest : Spek({
                 ),
                 Template(
                     "Enclose",
-                    mutableListOf(LiteralScheme("else"), WordScheme(dictionarySettings))
+                    mutableListOf(
+                        LiteralScheme("else"),
+                        WordScheme().also { it.dictionarySettings += dictionarySettings }
+                    )
                 ),
                 Template(
                     "Student",
-                    mutableListOf(StringScheme(symbolSetSettings), LiteralScheme("dog"), IntegerScheme())
+                    mutableListOf(
+                        StringScheme().also { it.symbolSetSettings += symbolSetSettings },
+                        LiteralScheme("dog"),
+                        IntegerScheme()
+                    )
                 )
             )
         )
@@ -196,7 +203,7 @@ object TemplateListEditorTest : Spek({
                     assertThat(editor.readState().templateList.templates[1].schemes)
                         .containsExactly(
                             LiteralScheme("else"),
-                            WordScheme(settingsState.dictionarySettings),
+                            WordScheme().also { it.dictionarySettings += settingsState.dictionarySettings },
                             UuidScheme()
                         )
                 }

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateListTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateListTest.kt
@@ -30,13 +30,13 @@ object TemplateListTest : Spek({
         }
 
         it("overwrites the settings of contained schemes") {
-            val newSettings = SettingsState(symbolSetSettings = SymbolSetSettings())
-            val stringScheme = StringScheme(SymbolSetSettings())
+            val newSettings = SymbolSetSettings()
+            val stringScheme = StringScheme()
             templateList.templates = mutableListOf(Template(schemes = mutableListOf(stringScheme)))
 
-            templateList.applySettingsState(newSettings)
+            templateList.applySettingsState(SettingsState(symbolSetSettings = newSettings))
 
-            assertThat(stringScheme.symbolSetSettings).isSameAs(newSettings.symbolSetSettings)
+            assertThat(+stringScheme.symbolSetSettings).isSameAs(newSettings)
         }
     }
 

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateListTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateListTest.kt
@@ -20,7 +20,7 @@ object TemplateListTest : Spek({
 
 
     beforeEachTest {
-        templateList = TemplateList(mutableListOf())
+        templateList = TemplateList(emptyList())
     }
 
 
@@ -32,7 +32,7 @@ object TemplateListTest : Spek({
         it("overwrites the settings of contained schemes") {
             val newSettings = SymbolSetSettings()
             val stringScheme = StringScheme()
-            templateList.templates = mutableListOf(Template(schemes = mutableListOf(stringScheme)))
+            templateList.templates = listOf(Template(schemes = listOf(stringScheme)))
 
             templateList.applySettingsState(SettingsState(symbolSetSettings = newSettings))
 
@@ -42,29 +42,29 @@ object TemplateListTest : Spek({
 
     describe("findRecursionFrom") {
         it("returns null if the reference refers to `null`") {
-            val reference = TemplateReference().also { it.templateList = Box({ TemplateList(mutableListOf()) }) }
+            val reference = TemplateReference().also { it.templateList = Box({ TemplateList(emptyList()) }) }
 
-            assertThat(TemplateList(mutableListOf()).findRecursionFrom(reference)).isNull()
+            assertThat(TemplateList(emptyList()).findRecursionFrom(reference)).isNull()
         }
 
         it("returns null if the reference refers to a template not in this list") {
             val otherList = TemplateList.from(DummyScheme())
             val reference = TemplateReference(otherList.templates[0].uuid).also { it.templateList = Box({ otherList }) }
 
-            assertThat(TemplateList(mutableListOf()).findRecursionFrom(reference)).isNull()
+            assertThat(TemplateList(emptyList()).findRecursionFrom(reference)).isNull()
         }
 
         it("returns null if the recursion occurs only in another part of the list") {
             val otherTemplate = Template(name = "roast")
 
             val goodReference = TemplateReference(otherTemplate.uuid).also { it.templateList = Box({ templateList }) }
-            val goodTemplate = Template("act", mutableListOf(goodReference))
+            val goodTemplate = Template("act", listOf(goodReference))
 
             val badReference = TemplateReference().also { it.templateList = Box({ templateList }) }
-            val badTemplate = Template("sour", mutableListOf(badReference))
+            val badTemplate = Template("sour", listOf(badReference))
             badReference.templateUuid = badTemplate.uuid
 
-            templateList.templates = mutableListOf(otherTemplate, goodTemplate, badTemplate)
+            templateList.templates = listOf(otherTemplate, goodTemplate, badTemplate)
 
             assertThat(templateList.findRecursionFrom(goodReference)).isNull()
         }
@@ -80,17 +80,17 @@ object TemplateListTest : Spek({
 
         it("returns a longer path if the reference consists of a chain") {
             val reference1 = TemplateReference().also { it.templateList = Box({ templateList }) }
-            val template1 = Template("drop", mutableListOf(reference1))
+            val template1 = Template("drop", listOf(reference1))
 
             val reference2 = TemplateReference(template1.uuid).also { it.templateList = Box({ templateList }) }
-            val template2 = Template("salesman", mutableListOf(reference2))
+            val template2 = Template("salesman", listOf(reference2))
 
             val reference3 = TemplateReference(template2.uuid).also { it.templateList = Box({ templateList }) }
-            val template3 = Template("almost", mutableListOf(reference3))
+            val template3 = Template("almost", listOf(reference3))
 
             reference1.templateUuid = template3.uuid
 
-            templateList.templates = mutableListOf(template1, template2, template3)
+            templateList.templates = listOf(template1, template2, template3)
 
             assertThat(templateList.findRecursionFrom(reference2))
                 .containsExactly(template2, template1, template3, template2)
@@ -111,27 +111,26 @@ object TemplateListTest : Spek({
         }
 
         it("passes for a template list without templates") {
-            assertThat(TemplateList(templates = mutableListOf()).doValidate()).isNull()
+            assertThat(TemplateList(templates = emptyList()).doValidate()).isNull()
         }
 
         it("fails if the single template is invalid") {
-            templateList.templates =
-                mutableListOf(Template("Gold", mutableListOf(DummyScheme.from(DummyScheme.INVALID_OUTPUT))))
+            templateList.templates = listOf(Template("Gold", listOf(DummyScheme.from(DummyScheme.INVALID_OUTPUT))))
 
             assertThat(templateList.doValidate()).startsWith("Gold > Dummy > ")
         }
 
         it("fails if multiple templates have the same name") {
             templateList.templates =
-                mutableListOf(Template(name = "Solution"), Template(name = "Leg"), Template(name = "Solution"))
+                listOf(Template(name = "Solution"), Template(name = "Leg"), Template(name = "Solution"))
 
             assertThat(templateList.doValidate()).isEqualTo("There are multiple templates with the name 'Solution'.")
         }
 
         it("fails if one of multiple templates is invalid") {
-            templateList.templates = mutableListOf(
+            templateList.templates = listOf(
                 Template(name = "Moment"),
-                Template(name = "View", schemes = mutableListOf(DummyScheme.from(DummyScheme.INVALID_OUTPUT))),
+                Template(name = "View", schemes = listOf(DummyScheme.from(DummyScheme.INVALID_OUTPUT))),
                 Template(name = "Ahead"),
                 Template(name = "Honesty")
             )
@@ -142,7 +141,7 @@ object TemplateListTest : Spek({
 
     describe("deepCopy") {
         it("creates an independent copy") {
-            templateList.templates = mutableListOf(Template(schemes = mutableListOf(LiteralScheme("refuse"))))
+            templateList.templates = listOf(Template(schemes = listOf(LiteralScheme("refuse"))))
 
             val copy = templateList.deepCopy()
             (copy.templates.first().schemes.first() as LiteralScheme).literal = "cheer"
@@ -153,9 +152,9 @@ object TemplateListTest : Spek({
 
     describe("copyFrom") {
         it("copies state from another instance") {
-            templateList.templates = mutableListOf(Template(name = "Desert"), Template(name = "Care"))
+            templateList.templates = listOf(Template(name = "Desert"), Template(name = "Care"))
 
-            val newTemplateList = TemplateList(mutableListOf())
+            val newTemplateList = TemplateList(emptyList())
             newTemplateList.copyFrom(templateList)
 
             assertThat(newTemplateList)

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateNameEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateNameEditorTest.kt
@@ -90,7 +90,7 @@ object TemplateNameEditorTest : Spek({
         }
 
         it("retains the scheme's schemes") {
-            GuiActionRunner.execute { editor.loadState(Template(schemes = mutableListOf(LiteralScheme()))) }
+            GuiActionRunner.execute { editor.loadState(Template(schemes = listOf(LiteralScheme()))) }
 
             assertThat(editor.readState().schemes).containsExactlyElementsOf(editor.originalState.schemes)
         }

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateNameEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateNameEditorTest.kt
@@ -50,7 +50,7 @@ object TemplateNameEditorTest : Spek({
     }
 
 
-    describe("loadScheme") {
+    describe("loadState") {
         it("loads the template's name") {
             GuiActionRunner.execute { editor.loadState(Template(name = "Tin")) }
 
@@ -58,7 +58,7 @@ object TemplateNameEditorTest : Spek({
         }
     }
 
-    describe("readScheme") {
+    describe("readState") {
         it("returns the original state if no editor changes are made") {
             assertThat(editor.readState()).isEqualTo(editor.originalState)
         }

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateReferenceEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateReferenceEditorTest.kt
@@ -30,10 +30,10 @@ object TemplateReferenceEditorTest : Spek({
 
     beforeEachTest {
         templateList = TemplateList(
-            mutableListOf(
-                Template("cup", mutableListOf(DummyScheme())),
-                Template("instead", mutableListOf(TemplateReference())),
-                Template("gun", mutableListOf(DummyScheme()))
+            listOf(
+                Template("cup", listOf(DummyScheme())),
+                Template("instead", listOf(TemplateReference())),
+                Template("gun", listOf(DummyScheme()))
             )
         )
 

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateReferenceEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateReferenceEditorTest.kt
@@ -50,7 +50,7 @@ object TemplateReferenceEditorTest : Spek({
     }
 
 
-    describe("loadScheme") {
+    describe("loadState") {
         it("selects the referenced template") {
             GuiActionRunner.execute {
                 editor.loadState(
@@ -77,7 +77,7 @@ object TemplateReferenceEditorTest : Spek({
         }
     }
 
-    describe("readScheme") {
+    describe("readState") {
         it("returns the original state if no editor changes are made") {
             assertThat(editor.readState()).isEqualTo(editor.originalState)
         }

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateReferenceTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateReferenceTest.kt
@@ -29,14 +29,14 @@ object TemplateReferenceTest : Spek({
 
     describe("parent") {
         it("fails if the parent is not in the given template list") {
-            templateList.templates = mutableListOf()
+            templateList.templates = emptyList()
 
             assertThatThrownBy { reference.parent }.isNotNull()
         }
 
         it("returns the template in the template list that contains the reference") {
-            val template = Template("widow", mutableListOf(reference))
-            templateList.templates = mutableListOf(Template("variety", mutableListOf(TemplateReference())), template)
+            val template = Template("widow", listOf(reference))
+            templateList.templates = listOf(Template("variety", listOf(TemplateReference())), template)
 
             assertThat(reference.parent).isEqualTo(template)
         }
@@ -51,7 +51,7 @@ object TemplateReferenceTest : Spek({
             }
 
             it("returns null if there is no template with the given UUID in the template list") {
-                templateList.templates = mutableListOf(Template("oppose", mutableListOf(DummyScheme())))
+                templateList.templates = listOf(Template("oppose", listOf(DummyScheme())))
 
                 reference.templateUuid = "7a9b9822-c99e-41dc-8e6a-220ca4dec181"
 
@@ -59,8 +59,8 @@ object TemplateReferenceTest : Spek({
             }
 
             it("returns the template with the given UUID if it is in the template list") {
-                val template = Template("supply", mutableListOf(DummyScheme()))
-                templateList.templates = mutableListOf(template)
+                val template = Template("supply", listOf(DummyScheme()))
+                templateList.templates = listOf(template)
 
                 reference.templateUuid = template.uuid
 
@@ -70,8 +70,8 @@ object TemplateReferenceTest : Spek({
 
         describe("set") {
             it("sets the template UUID") {
-                val template = Template("hotel", mutableListOf(DummyScheme()))
-                templateList.templates = mutableListOf(template)
+                val template = Template("hotel", listOf(DummyScheme()))
+                templateList.templates = listOf(template)
 
                 reference.template = template
 
@@ -94,8 +94,8 @@ object TemplateReferenceTest : Spek({
         }
 
         it("surrounds the target template's name with square brackets") {
-            val template = Template("milk", mutableListOf(DummyScheme()))
-            templateList.templates = mutableListOf(template)
+            val template = Template("milk", listOf(DummyScheme()))
+            templateList.templates = listOf(template)
 
             reference.templateUuid = template.uuid
 
@@ -111,8 +111,8 @@ object TemplateReferenceTest : Spek({
         }
 
         it("returns the template's icons") {
-            val template = Template("milk", mutableListOf(IntegerScheme()))
-            templateList.templates = mutableListOf(template)
+            val template = Template("milk", listOf(IntegerScheme()))
+            templateList.templates = listOf(template)
 
             reference.templateUuid = template.uuid
 
@@ -129,7 +129,7 @@ object TemplateReferenceTest : Spek({
         }
 
         it("returns the referenced template's value") {
-            templateList.templates = mutableListOf(Template(schemes = mutableListOf(DummyScheme.from("bus"))))
+            templateList.templates = listOf(Template(schemes = listOf(DummyScheme.from("bus"))))
 
             reference.templateUuid = templateList.templates.single().uuid
 
@@ -138,11 +138,8 @@ object TemplateReferenceTest : Spek({
         }
 
         it("returns an array of strings if the referenced scheme returns an array of schemes") {
-            templateList.templates = mutableListOf(
-                Template(
-                    schemes = mutableListOf(DummyScheme.from("bus").also { it.decorator.enabled = true })
-                )
-            )
+            templateList.templates =
+                listOf(Template(schemes = listOf(DummyScheme.from("bus").also { it.decorator.enabled = true })))
 
             reference.templateUuid = templateList.templates.single().uuid
 
@@ -153,7 +150,7 @@ object TemplateReferenceTest : Spek({
 
     describe("setSettingsState") {
         it("overwrites the known list of templates") {
-            val newSettings = SettingsState(templateList = TemplateList(mutableListOf()))
+            val newSettings = SettingsState(templateList = TemplateList(emptyList()))
 
             reference.setSettingsState(newSettings)
 
@@ -164,8 +161,8 @@ object TemplateReferenceTest : Spek({
 
     describe("doValidate") {
         it("passes for valid settings") {
-            val template = Template(schemes = mutableListOf(DummyScheme()))
-            templateList.templates = mutableListOf(template)
+            val template = Template(schemes = listOf(DummyScheme()))
+            templateList.templates = listOf(template)
 
             reference.templateUuid = template.uuid
 
@@ -179,8 +176,8 @@ object TemplateReferenceTest : Spek({
         }
 
         it("fails if the template cannot be found in the list") {
-            val template = Template(schemes = mutableListOf(DummyScheme()))
-            templateList.templates = mutableListOf(template)
+            val template = Template(schemes = listOf(DummyScheme()))
+            templateList.templates = listOf(template)
 
             reference.templateUuid = "ca27e68d-11be-4679-af92-4f5f13c69772"
 
@@ -189,13 +186,13 @@ object TemplateReferenceTest : Spek({
 
         it("fails if the reference is recursive") {
             val otherReference = TemplateReference().also { it.templateList += templateList }
-            val otherTemplate = Template("Ray", mutableListOf(otherReference))
+            val otherTemplate = Template("Ray", listOf(otherReference))
             reference.template = otherTemplate
-            val template = Template("Various", mutableListOf(reference))
+            val template = Template("Various", listOf(reference))
 
             otherReference.template = template
             reference.template = otherTemplate
-            templateList.templates = mutableListOf(template, otherTemplate)
+            templateList.templates = listOf(template, otherTemplate)
 
             assertThat(reference.doValidate()).isEqualTo("Found recursion: (Various → Ray → Various)")
         }
@@ -228,10 +225,10 @@ object TemplateReferenceTest : Spek({
         }
 
         it("creates a shallow copy of the template list") {
-            (+reference.templateList).templates = mutableListOf(Template(schemes = mutableListOf(reference)))
+            (+reference.templateList).templates = listOf(Template(schemes = listOf(reference)))
 
             val copy = reference.deepCopy()
-            (+copy.templateList).templates = mutableListOf(Template(schemes = mutableListOf(copy, DummyScheme())))
+            (+copy.templateList).templates = listOf(Template(schemes = listOf(copy, DummyScheme())))
 
             assertThat((+reference.templateList).templates[0].schemes).hasSize(2)
         }
@@ -260,7 +257,7 @@ object TemplateReferenceTest : Spek({
         }
 
         it("updates the target's reference to the template list") {
-            reference.copyFrom(TemplateReference().also { it.templateList += TemplateList(mutableListOf()) })
+            reference.copyFrom(TemplateReference().also { it.templateList += TemplateList(emptyList()) })
 
             assertThat(+reference.templateList).isNotSameAs(templateList)
         }
@@ -271,7 +268,7 @@ object TemplateReferenceTest : Spek({
             otherScheme.templateList += otherList
 
             reference.copyFrom(otherScheme)
-            (+otherScheme.templateList).templates = mutableListOf(Template(name = "Realize"))
+            (+otherScheme.templateList).templates = listOf(Template(name = "Realize"))
 
             assertThat((+reference.templateList).templates).containsExactly(Template(name = "Realize"))
         }

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateReferenceTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateReferenceTest.kt
@@ -209,17 +209,11 @@ object TemplateReferenceTest : Spek({
             assertThat(newScheme)
                 .isEqualTo(reference)
                 .isNotSameAs(reference)
+            assertThat(+newScheme.templateList)
+                .isSameAs(+reference.templateList)
             assertThat(newScheme.decorator)
                 .isEqualTo(reference.decorator)
                 .isNotSameAs(reference.decorator)
-        }
-
-        it("retains the reference to the template list") {
-            val newList = TemplateList.from(IntegerScheme(minValue = 9))
-
-            reference.copyFrom(TemplateReference().also { it.templateList = Box({ newList }) })
-
-            assertThat(+reference.templateList).isSameAs(newList)
         }
     }
 })

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateTest.kt
@@ -30,26 +30,26 @@ object TemplateTest : Spek({
     describe("icons") {
         it("returns the single scheme's icons if the single scheme has icons") {
             val scheme = IntegerScheme()
-            template.schemes = mutableListOf(scheme)
+            template.schemes = listOf(scheme)
 
             assertThat(template.icons).isEqualTo(scheme.icons)
         }
 
         it("returns the default icons if the single scheme has no icons") {
             val scheme = DummyScheme()
-            template.schemes = mutableListOf(scheme)
+            template.schemes = listOf(scheme)
 
             assertThat(template.icons).isEqualTo(RandomnessIcons.Data)
         }
 
         it("returns the default icons if no scheme is present") {
-            template.schemes = mutableListOf()
+            template.schemes = emptyList()
 
             assertThat(template.icons).isEqualTo(RandomnessIcons.Data)
         }
 
         it("returns the default icons if multiple schemes are present") {
-            template.schemes = mutableListOf(DummyScheme(), DummyScheme())
+            template.schemes = listOf(DummyScheme(), DummyScheme())
 
             assertThat(template.icons).isEqualTo(RandomnessIcons.Data)
         }
@@ -58,13 +58,13 @@ object TemplateTest : Spek({
 
     describe("generateStrings") {
         it("throws an exception if the template is invalid") {
-            template.schemes = mutableListOf(DummyScheme.from(DummyScheme.INVALID_OUTPUT))
+            template.schemes = listOf(DummyScheme.from(DummyScheme.INVALID_OUTPUT))
 
             assertThatThrownBy { template.generateStrings() }.isInstanceOf(DataGenerationException::class.java)
         }
 
         it("generates empty strings if it contains no schemes") {
-            template.schemes = mutableListOf()
+            template.schemes = emptyList()
 
             assertThat(template.generateStrings()).containsExactly("")
         }
@@ -73,7 +73,7 @@ object TemplateTest : Spek({
             val random = { Random(78) }
 
             val scheme = IntegerScheme()
-            template.schemes = mutableListOf(scheme)
+            template.schemes = listOf(scheme)
 
             val schemeOutput = scheme.also { it.random = random() }.generateStrings(3)
             val templateOutput = template.also { it.random = random() }.generateStrings(3)
@@ -91,7 +91,7 @@ object TemplateTest : Spek({
             val schemeC = IntegerScheme(minValue = 125, maxValue = 607)
                 .also { it.random = schemeB.random }
 
-            template.schemes = mutableListOf(schemeA, schemeB, schemeC)
+            template.schemes = listOf(schemeA, schemeB, schemeC)
             template.random = random()
 
             val outputsA = schemeA.generateStrings(3)
@@ -107,7 +107,7 @@ object TemplateTest : Spek({
         it("overwrites the symbol set settings of the contained schemes") {
             val newSettings = SymbolSetSettings()
             val stringScheme = StringScheme()
-            template.schemes = mutableListOf(stringScheme)
+            template.schemes = listOf(stringScheme)
 
             template.setSettingsState(SettingsState(symbolSetSettings = newSettings))
 
@@ -122,7 +122,7 @@ object TemplateTest : Spek({
         }
 
         it("passes for a template without schemes") {
-            template.schemes = mutableListOf()
+            template.schemes = emptyList()
 
             assertThat(template.doValidate()).isNull()
         }
@@ -134,13 +134,13 @@ object TemplateTest : Spek({
         }
 
         it("fails if the single scheme is invalid") {
-            template.schemes = mutableListOf(DummyScheme.from(DummyScheme.INVALID_OUTPUT))
+            template.schemes = listOf(DummyScheme.from(DummyScheme.INVALID_OUTPUT))
 
             assertThat(template.doValidate()).isEqualTo("Dummy > Invalid input!")
         }
 
         it("fails if one of multiple schemes is invalid") {
-            template.schemes = mutableListOf(
+            template.schemes = listOf(
                 DummyScheme(),
                 DummyScheme(),
                 DummyScheme.from(DummyScheme.INVALID_OUTPUT),
@@ -153,7 +153,7 @@ object TemplateTest : Spek({
 
     describe("deepCopy") {
         it("creates an independent copy") {
-            template.schemes = mutableListOf(LiteralScheme("rubber"))
+            template.schemes = listOf(LiteralScheme("rubber"))
 
             val copy = template.deepCopy()
             (copy.schemes.first() as LiteralScheme).literal = "ribbon"
@@ -165,7 +165,7 @@ object TemplateTest : Spek({
     describe("copyFrom") {
         it("copies state from another instance") {
             template.name = "become"
-            template.schemes = mutableListOf(LiteralScheme("quarrel"))
+            template.schemes = listOf(LiteralScheme("quarrel"))
 
             val newTemplate = Template()
             newTemplate.copyFrom(template)

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateTest.kt
@@ -105,13 +105,13 @@ object TemplateTest : Spek({
 
     describe("setSettingsState") {
         it("overwrites the symbol set settings of the contained schemes") {
-            val newSettings = SettingsState(symbolSetSettings = SymbolSetSettings())
-            val stringScheme = StringScheme(SymbolSetSettings())
+            val newSettings = SymbolSetSettings()
+            val stringScheme = StringScheme()
             template.schemes = mutableListOf(stringScheme)
 
-            template.setSettingsState(newSettings)
+            template.setSettingsState(SettingsState(symbolSetSettings = newSettings))
 
-            assertThat(stringScheme.symbolSetSettings).isSameAs(newSettings.symbolSetSettings)
+            assertThat(+stringScheme.symbolSetSettings).isSameAs(newSettings)
         }
     }
 

--- a/src/test/kotlin/com/fwdekker/randomness/ui/ActivityTableModelEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/ui/ActivityTableModelEditorTest.kt
@@ -57,7 +57,7 @@ object ActivityTableModelEditorTest : Spek({
         it("removes entries from the underlying model") {
             GuiActionRunner.execute {
                 stringTable.data = listOf("bucket")
-                stringTable.data = listOf()
+                stringTable.data = emptyList()
             }
 
             assertThat(stringTable.model.items).isEmpty()

--- a/src/test/kotlin/com/fwdekker/randomness/uuid/UuidSchemeEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/uuid/UuidSchemeEditorTest.kt
@@ -35,7 +35,7 @@ object UuidSchemeEditorTest : Spek({
     }
 
 
-    describe("loadScheme") {
+    describe("loadState") {
         it("loads the scheme's version") {
             GuiActionRunner.execute { editor.loadState(UuidScheme(version = 4)) }
 
@@ -66,7 +66,7 @@ object UuidSchemeEditorTest : Spek({
         }
     }
 
-    describe("readScheme") {
+    describe("readState") {
         describe("defaults") {
             it("returns default version if no version is selected") {
                 GuiActionRunner.execute { editor.loadState(UuidScheme(version = 967)) }

--- a/src/test/kotlin/com/fwdekker/randomness/word/DictionarySettingsTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/word/DictionarySettingsTest.kt
@@ -10,39 +10,92 @@ import org.spekframework.spek2.style.specification.describe
  * Unit tests for [DictionarySettings].
  */
 object DictionarySettingsTest : Spek({
+    val tempFileHelper = TempFileHelper()
+
+
+    afterGroup {
+        tempFileHelper.cleanUp()
+    }
+
+
     describe("doValidate") {
-        val tempFileHelper = TempFileHelper()
-
-
-        afterGroup {
-            tempFileHelper.cleanUp()
-        }
-
-
         it("passes for the default settings") {
             assertThat(DictionarySettings().doValidate()).isNull()
         }
 
         it("fails if a dictionary of a now-deleted file is given") {
-            val dictionaryFile = tempFileHelper.createFile("noon\nreason\n", ".dic").also { it.delete() }
+            val file = tempFileHelper.createFile("noon\nreason\n", ".dic").also { it.delete() }
 
-            val settings = DictionarySettings(userDictionaryFiles = mutableSetOf(dictionaryFile.absolutePath))
+            val settings = DictionarySettings(mutableListOf(UserDictionary(file.absolutePath)))
 
             assertThat(settings.doValidate()).matches("Dictionary '.*\\.dic' is invalid: File not found\\.")
         }
 
         it("fails if one of the dictionaries is invalid") {
-            val settings = DictionarySettings(userDictionaryFiles = mutableSetOf("does_not_exist.dic"))
+            val settings = DictionarySettings(mutableListOf(UserDictionary("does_not_exist.dic")))
 
             assertThat(settings.doValidate()).isEqualTo("Dictionary 'does_not_exist.dic' is invalid: File not found.")
         }
 
         it("fails if one the dictionaries is empty") {
-            val dictionaryFile = tempFileHelper.createFile("", ".dic")
+            val file = tempFileHelper.createFile("", ".dic")
 
-            val settings = DictionarySettings(userDictionaryFiles = mutableSetOf(dictionaryFile.absolutePath))
+            val settings = DictionarySettings(mutableListOf(UserDictionary(file.absolutePath)))
 
             assertThat(settings.doValidate()).matches("Dictionary '.*\\.dic' is empty\\.")
+        }
+
+        it("fails if one of the dictionaries becomes invalid") {
+            val file = tempFileHelper.createFile("rapid\ncloth", ".dic")
+            val dictionary = UserDictionary(file.absolutePath)
+
+            val settings = DictionarySettings(mutableListOf(dictionary))
+            dictionary.words // Force cache load
+            file.writeText("")
+
+            assertThat(settings.doValidate()).matches("Dictionary '.*\\.dic' is empty\\.")
+        }
+
+        it("fails if a duplicate dictionary is given") {
+            val file = tempFileHelper.createFile("degree\ncapital", ".dic")
+            val dictionary1 = UserDictionary(file.absolutePath)
+            val dictionary2 = UserDictionary(file.absolutePath)
+
+            val settings = DictionarySettings(mutableListOf(dictionary1, dictionary2))
+
+            assertThat(settings.doValidate()).matches("Duplicate dictionary '.*\\.dic'\\.")
+        }
+    }
+
+    describe("deepCopy") {
+        it("retains the UUID if desired") {
+            val settings = DictionarySettings()
+
+            assertThat(settings.deepCopy(retainUuid = true).uuid).isEqualTo(settings.uuid)
+        }
+
+        it("generates a new UUID if desired") {
+            val settings = DictionarySettings()
+
+            assertThat(settings.deepCopy(retainUuid = false).uuid).isNotEqualTo(settings.uuid)
+        }
+
+        it("contains an independent list of dictionaries") {
+            val settings = DictionarySettings(mutableListOf(BundledDictionary("wait.dic")))
+
+            val copy = settings.deepCopy()
+            copy.dictionaries.add(BundledDictionary("upright.dic"))
+
+            assertThat(settings.dictionaries).hasSize(1)
+        }
+
+        it("contains a list of independent dictionaries") {
+            val settings = DictionarySettings(mutableListOf(BundledDictionary("wait.dic")))
+
+            val copy = settings.deepCopy()
+            (copy.dictionaries[0] as BundledDictionary).filename = "defense.dic"
+
+            assertThat((settings.dictionaries[0] as BundledDictionary).filename).isEqualTo("wait.dic")
         }
     }
 })

--- a/src/test/kotlin/com/fwdekker/randomness/word/DictionarySettingsTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/word/DictionarySettingsTest.kt
@@ -26,13 +26,13 @@ object DictionarySettingsTest : Spek({
         it("fails if a dictionary of a now-deleted file is given") {
             val file = tempFileHelper.createFile("noon\nreason\n", ".dic").also { it.delete() }
 
-            val settings = DictionarySettings(mutableListOf(UserDictionary(file.absolutePath)))
+            val settings = DictionarySettings(mutableSetOf(UserDictionary(file.absolutePath)))
 
             assertThat(settings.doValidate()).matches("Dictionary '.*\\.dic' is invalid: File not found\\.")
         }
 
         it("fails if one of the dictionaries is invalid") {
-            val settings = DictionarySettings(mutableListOf(UserDictionary("does_not_exist.dic")))
+            val settings = DictionarySettings(mutableSetOf(UserDictionary("does_not_exist.dic")))
 
             assertThat(settings.doValidate()).isEqualTo("Dictionary 'does_not_exist.dic' is invalid: File not found.")
         }
@@ -40,7 +40,7 @@ object DictionarySettingsTest : Spek({
         it("fails if one the dictionaries is empty") {
             val file = tempFileHelper.createFile("", ".dic")
 
-            val settings = DictionarySettings(mutableListOf(UserDictionary(file.absolutePath)))
+            val settings = DictionarySettings(mutableSetOf(UserDictionary(file.absolutePath)))
 
             assertThat(settings.doValidate()).matches("Dictionary '.*\\.dic' is empty\\.")
         }
@@ -49,21 +49,11 @@ object DictionarySettingsTest : Spek({
             val file = tempFileHelper.createFile("rapid\ncloth", ".dic")
             val dictionary = UserDictionary(file.absolutePath)
 
-            val settings = DictionarySettings(mutableListOf(dictionary))
+            val settings = DictionarySettings(mutableSetOf(dictionary))
             dictionary.words // Force cache load
             file.writeText("")
 
             assertThat(settings.doValidate()).matches("Dictionary '.*\\.dic' is empty\\.")
-        }
-
-        it("fails if a duplicate dictionary is given") {
-            val file = tempFileHelper.createFile("degree\ncapital", ".dic")
-            val dictionary1 = UserDictionary(file.absolutePath)
-            val dictionary2 = UserDictionary(file.absolutePath)
-
-            val settings = DictionarySettings(mutableListOf(dictionary1, dictionary2))
-
-            assertThat(settings.doValidate()).matches("Duplicate dictionary '.*\\.dic'\\.")
         }
     }
 
@@ -81,7 +71,7 @@ object DictionarySettingsTest : Spek({
         }
 
         it("contains an independent list of dictionaries") {
-            val settings = DictionarySettings(mutableListOf(BundledDictionary("wait.dic")))
+            val settings = DictionarySettings(mutableSetOf(BundledDictionary("wait.dic")))
 
             val copy = settings.deepCopy()
             copy.dictionaries.add(BundledDictionary("upright.dic"))
@@ -90,12 +80,12 @@ object DictionarySettingsTest : Spek({
         }
 
         it("contains a list of independent dictionaries") {
-            val settings = DictionarySettings(mutableListOf(BundledDictionary("wait.dic")))
+            val settings = DictionarySettings(mutableSetOf(BundledDictionary("wait.dic")))
 
             val copy = settings.deepCopy()
-            (copy.dictionaries[0] as BundledDictionary).filename = "defense.dic"
+            (copy.dictionaries.first() as BundledDictionary).filename = "defense.dic"
 
-            assertThat((settings.dictionaries[0] as BundledDictionary).filename).isEqualTo("wait.dic")
+            assertThat((settings.dictionaries.first() as BundledDictionary).filename).isEqualTo("wait.dic")
         }
     }
 })

--- a/src/test/kotlin/com/fwdekker/randomness/word/DictionarySettingsTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/word/DictionarySettingsTest.kt
@@ -26,13 +26,13 @@ object DictionarySettingsTest : Spek({
         it("fails if a dictionary of a now-deleted file is given") {
             val file = tempFileHelper.createFile("noon\nreason\n", ".dic").also { it.delete() }
 
-            val settings = DictionarySettings(mutableSetOf(UserDictionary(file.absolutePath)))
+            val settings = DictionarySettings(setOf(UserDictionary(file.absolutePath)))
 
             assertThat(settings.doValidate()).matches("Dictionary '.*\\.dic' is invalid: File not found\\.")
         }
 
         it("fails if one of the dictionaries is invalid") {
-            val settings = DictionarySettings(mutableSetOf(UserDictionary("does_not_exist.dic")))
+            val settings = DictionarySettings(setOf(UserDictionary("does_not_exist.dic")))
 
             assertThat(settings.doValidate()).isEqualTo("Dictionary 'does_not_exist.dic' is invalid: File not found.")
         }
@@ -40,7 +40,7 @@ object DictionarySettingsTest : Spek({
         it("fails if one the dictionaries is empty") {
             val file = tempFileHelper.createFile("", ".dic")
 
-            val settings = DictionarySettings(mutableSetOf(UserDictionary(file.absolutePath)))
+            val settings = DictionarySettings(setOf(UserDictionary(file.absolutePath)))
 
             assertThat(settings.doValidate()).matches("Dictionary '.*\\.dic' is empty\\.")
         }
@@ -49,7 +49,7 @@ object DictionarySettingsTest : Spek({
             val file = tempFileHelper.createFile("rapid\ncloth", ".dic")
             val dictionary = UserDictionary(file.absolutePath)
 
-            val settings = DictionarySettings(mutableSetOf(dictionary))
+            val settings = DictionarySettings(setOf(dictionary))
             dictionary.words // Force cache load
             file.writeText("")
 
@@ -71,16 +71,16 @@ object DictionarySettingsTest : Spek({
         }
 
         it("contains an independent list of dictionaries") {
-            val settings = DictionarySettings(mutableSetOf(BundledDictionary("wait.dic")))
+            val settings = DictionarySettings(setOf(BundledDictionary("wait.dic")))
 
             val copy = settings.deepCopy()
-            copy.dictionaries.add(BundledDictionary("upright.dic"))
+            copy.dictionaries = setOf(BundledDictionary("upright.dic"))
 
-            assertThat(settings.dictionaries).hasSize(1)
+            assertThat(settings.dictionaries).containsExactly(BundledDictionary("wait.dic"))
         }
 
         it("contains a list of independent dictionaries") {
-            val settings = DictionarySettings(mutableSetOf(BundledDictionary("wait.dic")))
+            val settings = DictionarySettings(setOf(BundledDictionary("wait.dic")))
 
             val copy = settings.deepCopy()
             (copy.dictionaries.first() as BundledDictionary).filename = "defense.dic"

--- a/src/test/kotlin/com/fwdekker/randomness/word/DictionaryTableTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/word/DictionaryTableTest.kt
@@ -37,51 +37,50 @@ object DictionaryTableTest : Spek({
 
     describe("type column") {
         it("displays 'bundled' for bundled dictionaries") {
-            val dictionary = DictionaryReference(true, "dictionary.dic")
+            val dictionary = BundledDictionary("dictionary.dic")
             GuiActionRunner.execute { dictionaryTable.data = listOf(dictionary) }
 
             assertThat(dictionaryTable.model.getValueAt(0, 1)).isEqualTo("bundled")
         }
 
         it("displays 'user' for user dictionaries") {
-            val dictionary = DictionaryReference(false, "dictionary.dic")
+            val dictionary = UserDictionary("dictionary.dic")
             GuiActionRunner.execute { dictionaryTable.data = listOf(dictionary) }
 
-            assertThat(dictionaryTable.model.getValueAt(0, 1)).isEqualTo("user")
+            assertThat(dictionaryTable.model.getValueAt(0, 1)).isEqualTo("custom")
         }
     }
 
     describe("location column") {
         it("displays the location of a bundled dictionary") {
-            val dictionary = DictionaryReference(true, "dictionary.dic")
+            val dictionary = BundledDictionary("dictionary.dic")
             GuiActionRunner.execute { dictionaryTable.data = listOf(dictionary) }
 
             assertThat(dictionaryTable.model.getValueAt(0, 2)).isEqualTo("dictionary.dic")
         }
 
         it("displays the location of a user dictionary") {
-            val dictionary = DictionaryReference(false, "dictionary.dic")
+            val dictionary = UserDictionary("dictionary.dic")
             GuiActionRunner.execute { dictionaryTable.data = listOf(dictionary) }
 
             assertThat(dictionaryTable.model.getValueAt(0, 2)).isEqualTo("dictionary.dic")
         }
 
         it("cannot edit the location of a bundled dictionary") {
-            val oldDictionary = DictionaryReference(true, "dictionary.dic")
+            val oldDictionary = BundledDictionary("dictionary.dic")
             GuiActionRunner.execute { dictionaryTable.data = listOf(oldDictionary) }
 
             assertThat(dictionaryTable.model.isCellEditable(0, 2)).isFalse()
         }
 
         it("changes the location of a user dictionary") {
-            val oldDictionary = DictionaryReference(false, "dictionary.dic")
+            val oldDictionary = UserDictionary("dictionary.dic")
             GuiActionRunner.execute { dictionaryTable.data = listOf(oldDictionary) }
 
             GuiActionRunner.execute { dictionaryTable.model.setValueAt("new_dictionary.dic", 0, 2) }
 
             val newDictionary = dictionaryTable.data.first()
-            assertThat(newDictionary.isBundled).isFalse()
-            assertThat(newDictionary.filename).isEqualTo("new_dictionary.dic")
+            assertThat((newDictionary as UserDictionary).filename).isEqualTo("new_dictionary.dic")
         }
     }
 
@@ -89,7 +88,7 @@ object DictionaryTableTest : Spek({
     describe("itemEditor") {
         describe("remove") {
             it("does not remove a bundled dictionary") {
-                val bundledDictionary = DictionaryReference(true, "dictionary.dic")
+                val bundledDictionary = BundledDictionary("dictionary.dic")
                 GuiActionRunner.execute { dictionaryTable.data = listOf(bundledDictionary) }
 
                 GuiActionRunner.execute {
@@ -101,7 +100,7 @@ object DictionaryTableTest : Spek({
             }
 
             it("removes a user dictionary") {
-                val userDictionary = DictionaryReference(false, "dictionary.dic")
+                val userDictionary = UserDictionary("dictionary.dic")
                 GuiActionRunner.execute { dictionaryTable.data = listOf(userDictionary) }
 
                 GuiActionRunner.execute {

--- a/src/test/kotlin/com/fwdekker/randomness/word/DictionaryTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/word/DictionaryTest.kt
@@ -2,7 +2,6 @@ package com.fwdekker.randomness.word
 
 import com.fwdekker.randomness.TempFileHelper
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.assertThatCode
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.fail
 import org.spekframework.spek2.Spek
@@ -11,39 +10,27 @@ import java.util.Locale
 
 
 /**
- * Returns `true` if the current operating system is Windows.
+ * Returns true if the current operating system is Windows.
  *
- * @return `true` if the current operating system is Windows
+ * @return true if the current operating system is Windows
  */
-fun isWindows() = System.getProperty("os.name").lowercase(Locale.getDefault()).contains("win")
+private fun isWindows() = System.getProperty("os.name").lowercase(Locale.getDefault()).contains("win")
 
 
 /**
  * Unit tests for [Dictionaries][Dictionary].
  */
 object DictionaryTest : Spek({
+    beforeEachTest {
+        BundledDictionary.clearCache()
+        UserDictionary.clearCache()
+    }
+
+
     describe("BundledDictionary") {
-        describe("validation") {
-            it("passes if the file exists") {
-                val dictionary = BundledDictionary.cache.get("dictionaries/simple.dic", false)
-
-                assertThat(dictionary.isValid()).isTrue()
-                assertThatCode { dictionary.validate() }.doesNotThrowAnyException()
-            }
-
-            it("fails if the file does not exist") {
-                val dictionary = BundledDictionary.cache.get("does_not_exist.dic", false)
-
-                assertThat(dictionary.isValid()).isFalse()
-                assertThatThrownBy { dictionary.validate() }
-                    .isInstanceOf(InvalidDictionaryException::class.java)
-                    .hasMessage("File not found.")
-            }
-        }
-
         describe("words") {
             it("fails if the file does not exist") {
-                val dictionary = BundledDictionary.cache.get("does_not_exist.dic", false)
+                val dictionary = BundledDictionary("does_not_exist.dic")
 
                 assertThatThrownBy { dictionary.words }
                     .isInstanceOf(InvalidDictionaryException::class.java)
@@ -51,31 +38,31 @@ object DictionaryTest : Spek({
             }
 
             it("is an empty list if the dictionary is empty") {
-                val dictionary = BundledDictionary.cache.get("dictionaries/empty.dic", false)
+                val dictionary = BundledDictionary("dictionaries/empty.dic")
 
                 assertThat(dictionary.words).isEmpty()
             }
 
             it("contains the words of a non-empty dictionary file") {
-                val dictionary = BundledDictionary.cache.get("dictionaries/simple.dic", false)
+                val dictionary = BundledDictionary("dictionaries/simple.dic")
 
                 assertThat(dictionary.words).containsExactlyInAnyOrder("a", "the", "dog", "woof", "cat", "meow")
             }
 
             it("does not contain duplicate words") {
-                val dictionary = BundledDictionary.cache.get("dictionaries/duplicates.dic", false)
+                val dictionary = BundledDictionary("dictionaries/duplicates.dic")
 
                 assertThat(dictionary.words).containsExactlyInAnyOrder("dog", "woof", "cat", "meow")
             }
 
             it("ignores empty lines") {
-                val dictionary = BundledDictionary.cache.get("dictionaries/empty-lines.dic", false)
+                val dictionary = BundledDictionary("dictionaries/empty-lines.dic")
 
                 assertThat(dictionary.words).containsExactlyInAnyOrder("woof", "meow")
             }
 
             it("ignores commented lines") {
-                val dictionary = BundledDictionary.cache.get("dictionaries/comments.dic", false)
+                val dictionary = BundledDictionary("dictionaries/comments.dic")
 
                 assertThat(dictionary.words).containsExactlyInAnyOrder("cat", "mouse", "tree")
             }
@@ -83,13 +70,13 @@ object DictionaryTest : Spek({
 
         describe("toString") {
             it("returns a human-readable string of the dictionary's filename") {
-                val dictionary = BundledDictionary.cache.get("dictionaries/simple.dic", false)
+                val dictionary = BundledDictionary("dictionaries/simple.dic")
 
                 assertThat(dictionary.toString()).isEqualTo("dictionaries/simple.dic")
             }
 
             it("works even if the file does not exist") {
-                val dictionary = BundledDictionary.cache.get("does_not_exist.dic", false)
+                val dictionary = BundledDictionary("does_not_exist.dic")
 
                 assertThat(dictionary.toString()).isEqualTo("does_not_exist.dic")
             }
@@ -97,29 +84,36 @@ object DictionaryTest : Spek({
 
         describe("equals + hash code") {
             it("equals itself") {
-                val dictionary = BundledDictionary.cache.get("dictionary.dic")
+                val dictionary = BundledDictionary("dictionary.dic")
 
                 assertThat(dictionary).isEqualTo(dictionary)
                 assertThat(dictionary.hashCode()).isEqualTo(dictionary.hashCode())
             }
 
             it("equals a dictionary with the same filename") {
-                val dictionary1 = BundledDictionary.cache.get("dictionary.dic")
-                val dictionary2 = BundledDictionary.cache.get("dictionary.dic")
+                val dictionary1 = BundledDictionary("dictionary.dic")
+                val dictionary2 = BundledDictionary("dictionary.dic")
 
                 assertThat(dictionary1).isEqualTo(dictionary2)
                 assertThat(dictionary1.hashCode()).isEqualTo(dictionary2.hashCode())
             }
 
+            it("does not equal a bundled dictionary with a different filename") {
+                val dictionary1 = BundledDictionary("dictionary1.dic")
+                val dictionary2 = BundledDictionary("dictionary2.dic")
+
+                assertThat(dictionary1).isNotEqualTo(dictionary2)
+            }
+
             it("does not equal a user dictionary with the same filename") {
-                val dictionary1 = BundledDictionary.cache.get("dictionary.dic")
-                val dictionary2 = UserDictionary.cache.get("dictionary.dic")
+                val dictionary1 = BundledDictionary("dictionary.dic")
+                val dictionary2 = UserDictionary("dictionary.dic")
 
                 assertThat(dictionary1).isNotEqualTo(dictionary2)
             }
 
             it("does not equal a different object") {
-                val dictionary = BundledDictionary.cache.get("dictionary.dic")
+                val dictionary = BundledDictionary("dictionary.dic")
                 val other = Any()
 
                 assertThat(dictionary).isNotEqualTo(other)
@@ -136,106 +130,134 @@ object DictionaryTest : Spek({
         }
 
 
-        describe("validation") {
-            it("passes if the file exists") {
-                val dictionaryFile = tempFileHelper.createFile("ladder\nkempt\npork", ".dic")
-                val dictionary = UserDictionary.cache.get(dictionaryFile.absolutePath, false)
-
-                assertThat(dictionary.isValid()).isTrue()
-                assertThatCode { dictionary.validate() }.doesNotThrowAnyException()
-            }
-
-            it("fails if the file does not exist") {
-                val dictionary = UserDictionary.cache.get("does_not_exist.dic", false)
-
-                assertThat(dictionary.isValid()).isFalse()
-                assertThatThrownBy { dictionary.validate() }
-                    .isInstanceOf(InvalidDictionaryException::class.java)
-                    .hasMessage("File not found.")
-            }
-
-            it("fails if the file is deleted after construction of the dictionary") {
-                val dictionaryFile = tempFileHelper.createFile("blizzard\nflames\ninvest", ".dic")
-                val dictionary = UserDictionary.cache.get(dictionaryFile.absolutePath, false)
-
-                if (!dictionaryFile.delete())
-                    fail("Failed to delete file as part of test.")
-
-                assertThat(dictionary.isValid()).isFalse()
-                assertThatThrownBy { dictionary.validate() }
-                    .isInstanceOf(InvalidDictionaryException::class.java)
-                    .hasMessage("File not found.")
-            }
-
-            it("fails if the file exists but cannot be accessed") {
-                if (isWindows()) return@it // setReadable does not work in Windows
-
-                val dictionaryFile = tempFileHelper.createFile("ladder\nkempt\npork", ".dic")
-                    .also { it.setReadable(false) }
-                val dictionary = UserDictionary.cache.get(dictionaryFile.absolutePath, false)
-
-                assertThat(dictionary.isValid()).isFalse()
-                assertThatThrownBy { dictionary.validate() }
-                    .isInstanceOf(InvalidDictionaryException::class.java)
-                    .hasMessage("File unreadable.")
-            }
-        }
-
         describe("words") {
-            it("fails if the file does not exist") {
-                val dictionary = UserDictionary.cache.get("does_not_exist.dic", false)
+            describe("validation") {
+                it("fails if the file does not exist") {
+                    val dictionary = UserDictionary("does_not_exist.dic")
 
-                assertThatThrownBy { dictionary.words }
-                    .isInstanceOf(InvalidDictionaryException::class.java)
-                    .hasMessage("File not found.")
+                    assertThatThrownBy { dictionary.words }
+                        .isInstanceOf(InvalidDictionaryException::class.java)
+                        .hasMessage("File not found.")
+                }
+
+                it("fails if the file is deleted after construction of the dictionary") {
+                    val file = tempFileHelper.createFile("blizzard\nflames\ninvest", ".dic")
+                    val dictionary = UserDictionary(file.absolutePath)
+
+                    if (!file.delete())
+                        fail("Failed to delete file as part of test.")
+
+                    assertThatThrownBy { dictionary.words }
+                        .isInstanceOf(InvalidDictionaryException::class.java)
+                        .hasMessage("File not found.")
+                }
+
+                it("fails if the file exists but cannot be accessed") {
+                    if (isWindows()) return@it // setReadable does not work in Windows
+
+                    val file = tempFileHelper.createFile("ladder\nkempt\npork", ".dic")
+                        .also { it.setReadable(false) }
+                    val dictionary = UserDictionary(file.absolutePath)
+
+                    assertThatThrownBy { dictionary.words }
+                        .isInstanceOf(InvalidDictionaryException::class.java)
+                        .hasMessage("File unreadable.")
+                }
             }
 
-            it("is an empty list if the dictionary is empty") {
-                val dictionaryFile = tempFileHelper.createFile("", ".dic")
-                val dictionary = UserDictionary.cache.get(dictionaryFile.absolutePath, false)
+            describe("parsing") {
+                it("is an empty list if the dictionary is empty") {
+                    val file = tempFileHelper.createFile("", ".dic")
+                    val dictionary = UserDictionary(file.absolutePath)
 
-                assertThat(dictionary.words).isEmpty()
+                    assertThat(dictionary.words).isEmpty()
+                }
+
+                it("contains the words of a non-empty dictionary file") {
+                    val file = tempFileHelper.createFile("batmen\njollity\nbolts", ".dic")
+                    val dictionary = UserDictionary(file.absolutePath)
+
+                    assertThat(dictionary.words).containsExactlyInAnyOrder("batmen", "jollity", "bolts")
+                }
+
+                it("does not contain duplicate words") {
+                    val file = tempFileHelper.createFile("dolphins\nmappings\ndolphins\nflat", ".dic")
+                    val dictionary = UserDictionary(file.absolutePath)
+
+                    assertThat(dictionary.words).containsExactlyInAnyOrder("dolphins", "mappings", "flat")
+                }
+
+                it("ignores empty lines") {
+                    val file = tempFileHelper.createFile("\n\nwoof\nmeow\n\n\n", ".dic")
+                    val dictionary = UserDictionary(file.absolutePath)
+
+                    assertThat(dictionary.words).containsExactlyInAnyOrder("woof", "meow")
+                }
+
+                it("ignores commented lines") {
+                    val file = tempFileHelper.createFile("# Comment\nflaming\nlove\n# Destiny\n", ".dic")
+                    val dictionary = UserDictionary(file.absolutePath)
+
+                    assertThat(dictionary.words).containsExactlyInAnyOrder("flaming", "love")
+                }
             }
 
-            it("contains the words of a non-empty dictionary file") {
-                val dictionaryFile = tempFileHelper.createFile("batmen\njollity\nbolts", ".dic")
-                val dictionary = UserDictionary.cache.get(dictionaryFile.absolutePath, false)
+            describe("caching") {
+                it("returns different words after the filename has been changed") {
+                    val file1 = tempFileHelper.createFile("grass\nthank", ".dic")
+                    val file2 = tempFileHelper.createFile("serve\nleaf", ".dic")
+                    val dictionary = UserDictionary(file1.absolutePath)
 
-                assertThat(dictionary.words).containsExactlyInAnyOrder("batmen", "jollity", "bolts")
-            }
+                    dictionary.words
+                    dictionary.filename = file2.absolutePath
 
-            it("does not contain duplicate words") {
-                val dictionaryFile = tempFileHelper.createFile("dolphins\nmappings\ndolphins\nflat", ".dic")
-                val dictionary = UserDictionary.cache.get(dictionaryFile.absolutePath, false)
+                    assertThat(dictionary.words).containsExactly("serve", "leaf")
+                }
 
-                assertThat(dictionary.words).containsExactlyInAnyOrder("dolphins", "mappings", "flat")
-            }
+                it("returns the same words even if the file is changed") {
+                    val file = tempFileHelper.createFile("nest\nthose", ".dic")
+                    val dictionary = UserDictionary(file.absolutePath)
 
-            it("ignores empty lines") {
-                val dictionaryFile = tempFileHelper.createFile("\n\nwoof\nmeow\n\n\n", ".dic")
-                val dictionary = UserDictionary.cache.get(dictionaryFile.absolutePath, false)
+                    dictionary.words
+                    file.writeText("worth\nearn")
 
-                assertThat(dictionary.words).containsExactlyInAnyOrder("woof", "meow")
-            }
+                    assertThat(dictionary.words).containsExactly("nest", "those")
+                }
 
-            it("ignores commented lines") {
-                val dictionaryFile = tempFileHelper.createFile("# Comment\nflaming\nlove\n# Destiny\n", ".dic")
-                val dictionary = UserDictionary.cache.get(dictionaryFile.absolutePath, false)
+                it("returns the same words as another instance even if the file is changed") {
+                    val file = tempFileHelper.createFile("annoy\nregular", ".dic")
+                    val dictionary1 = UserDictionary(file.absolutePath)
+                    val dictionary2 = UserDictionary(file.absolutePath)
 
-                assertThat(dictionary.words).containsExactlyInAnyOrder("flaming", "love")
+                    dictionary1.words
+                    file.writeText("furnish\nthan")
+
+                    assertThat(dictionary2.words).containsExactly("annoy", "regular")
+                }
+
+                it("returns the updated words from the file after the cache is cleared") {
+                    val file = tempFileHelper.createFile("seem\ngod", ".dic")
+                    val dictionary = UserDictionary(file.absolutePath)
+
+                    dictionary.words
+                    file.writeText("safe\nonly")
+                    UserDictionary.clearCache()
+
+                    assertThat(dictionary.words).containsExactly("safe", "only")
+                }
             }
         }
 
         describe("toString") {
             it("returns a human-readable string of the dictionary's filename") {
-                val dictionaryFile = tempFileHelper.createFile("mode\ndepeche", ".dic")
-                val dictionary = UserDictionary.cache.get(dictionaryFile.absolutePath, false)
+                val file = tempFileHelper.createFile("mode\ndepeche", ".dic")
+                val dictionary = UserDictionary(file.absolutePath)
 
                 assertThat(dictionary.toString()).endsWith(".dic")
             }
 
             it("works even if the file does not exist") {
-                val dictionary = UserDictionary.cache.get("does_not_exist.dic", false)
+                val dictionary = UserDictionary("does_not_exist.dic")
 
                 assertThat(dictionary.toString()).isEqualTo("does_not_exist.dic")
             }
@@ -243,113 +265,40 @@ object DictionaryTest : Spek({
 
         describe("equals + hash code") {
             it("equals itself") {
-                val dictionary = UserDictionary.cache.get("dictionary.dic")
+                val dictionary = UserDictionary("dictionary.dic")
 
                 assertThat(dictionary).isEqualTo(dictionary)
                 assertThat(dictionary.hashCode()).isEqualTo(dictionary.hashCode())
             }
 
             it("equals a dictionary with the same filename") {
-                val dictionary1 = UserDictionary.cache.get("dictionary.dic")
-                val dictionary2 = UserDictionary.cache.get("dictionary.dic")
+                val dictionary1 = UserDictionary("dictionary.dic")
+                val dictionary2 = UserDictionary("dictionary.dic")
 
                 assertThat(dictionary1).isEqualTo(dictionary2)
                 assertThat(dictionary1.hashCode()).isEqualTo(dictionary2.hashCode())
             }
 
-            it("does not equal a user dictionary with the same filename") {
-                val dictionary1 = UserDictionary.cache.get("dictionary.dic")
-                val dictionary2 = BundledDictionary.cache.get("dictionary.dic")
+            it("does not equal a user dictionary with a different filename") {
+                val dictionary1 = UserDictionary("dictionary1.dic")
+                val dictionary2 = UserDictionary("dictionary2.dic")
+
+                assertThat(dictionary1).isNotEqualTo(dictionary2)
+            }
+
+            it("does not equal a bundled dictionary with the same filename") {
+                val dictionary1 = UserDictionary("dictionary.dic")
+                val dictionary2 = BundledDictionary("dictionary.dic")
 
                 assertThat(dictionary1).isNotEqualTo(dictionary2)
             }
 
             it("does not equal a different object") {
-                val dictionary = UserDictionary.cache.get("dictionary.dic")
+                val dictionary = UserDictionary("dictionary.dic")
                 val other = Any()
 
                 assertThat(dictionary).isNotEqualTo(other)
             }
-        }
-    }
-})
-
-/**
- * Unit tests for [DictionaryReference]s.
- */
-object DictionaryReferenceTest : Spek({
-    val tempFileHelper = TempFileHelper()
-
-
-    beforeEachTest {
-        BundledDictionary.cache.clear()
-        UserDictionary.cache.clear()
-    }
-
-    afterGroup {
-        tempFileHelper.cleanUp()
-    }
-
-
-    describe("instantiation") {
-        it("creates a bundled dictionary reference") {
-            val dictionary = BundledDictionary.cache.get("bundled.dic")
-
-            val reference = DictionaryReference.to(dictionary)
-
-            assertThat(reference.isBundled).isTrue()
-            assertThat(reference.filename).isEqualTo("bundled.dic")
-            assertThat(reference.referent).isEqualTo(dictionary)
-        }
-
-        it("creates a user dictionary reference") {
-            val dictionary = UserDictionary.cache.get("user.dic")
-
-            val reference = DictionaryReference.to(dictionary)
-
-            assertThat(reference.isBundled).isFalse()
-            assertThat(reference.filename).isEqualTo("user.dic")
-            assertThat(reference.referent).isEqualTo(dictionary)
-        }
-
-        it("fails for other dictionary types") {
-            val dictionary = object : Dictionary {
-                override val words = setOf("word")
-
-                override fun validate() = Unit
-            }
-
-            assertThatThrownBy { DictionaryReference.to(dictionary) }
-                .isInstanceOf(IllegalStateException::class.java)
-                .hasMessage(DictionaryReference.DICTIONARY_CAST_EXCEPTION)
-        }
-    }
-
-    describe("validation") {
-        it("fails for an invalid dictionary") {
-            if (isWindows()) return@it // setReadable does not work in Windows
-
-            val dictionaryFile = tempFileHelper.createFile("contents\n", ".dic")
-                .also { it.setReadable(false) }
-            val dictionary = UserDictionary.cache.get(dictionaryFile.absolutePath, false)
-            val reference = DictionaryReference.to(dictionary)
-
-            assertThat(reference.isValid()).isFalse()
-        }
-
-        it("no longer fails for a now-valid dictionary") {
-            if (isWindows()) return@it // setReadable does not work in Windows
-
-            val dictionaryFile = tempFileHelper.createFile("contents\n", ".dic")
-                .also { it.setReadable(false) }
-            val dictionary = UserDictionary.cache.get(dictionaryFile.absolutePath, false)
-            val reference = DictionaryReference.to(dictionary)
-
-            assertThat(reference.isValid()).isFalse()
-
-            dictionaryFile.setReadable(true)
-
-            assertThat(reference.isValid()).isTrue()
         }
     }
 })

--- a/src/test/kotlin/com/fwdekker/randomness/word/WordSchemeEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/word/WordSchemeEditorTest.kt
@@ -41,7 +41,7 @@ object WordSchemeEditorTest : Spek({
         ideaFixture.setUp()
 
         dictionarySettings = DictionarySettings()
-        scheme = WordScheme(dictionarySettings)
+        scheme = WordScheme().also { it.dictionarySettings += dictionarySettings }
         editor = GuiActionRunner.execute<WordSchemeEditor> { WordSchemeEditor(scheme) }
         frame = showInFrame(editor.rootComponent)
 
@@ -111,10 +111,8 @@ object WordSchemeEditorTest : Spek({
 
             GuiActionRunner.execute {
                 editor.loadState(
-                    WordScheme(
-                        dictionarySettings = DictionarySettings(allDictionaries.toMutableSet()),
-                        activeDictionaries = activeDictionaries.toMutableSet()
-                    )
+                    WordScheme(activeDictionaries = activeDictionaries.toMutableSet())
+                        .also { it.dictionarySettings += DictionarySettings(allDictionaries.toMutableSet()) }
                 )
             }
 
@@ -175,8 +173,8 @@ object WordSchemeEditorTest : Spek({
             assertThat(readState)
                 .isEqualTo(editor.originalState)
                 .isNotSameAs(editor.originalState)
-            assertThat(readState.dictionarySettings)
-                .isSameAs(editor.originalState.dictionarySettings)
+            assertThat(+readState.dictionarySettings)
+                .isSameAs(+editor.originalState.dictionarySettings)
             assertThat(readState.decorator)
                 .isEqualTo(editor.originalState.decorator)
                 .isNotSameAs(editor.originalState.decorator)

--- a/src/test/kotlin/com/fwdekker/randomness/word/WordSchemeEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/word/WordSchemeEditorTest.kt
@@ -72,7 +72,7 @@ object WordSchemeEditorTest : Spek({
     }
 
 
-    describe("loadScheme") {
+    describe("loadState") {
         it("loads the scheme's minimum length") {
             GuiActionRunner.execute { editor.loadState(WordScheme(minLength = 4, maxLength = 12)) }
 
@@ -123,7 +123,7 @@ object WordSchemeEditorTest : Spek({
         }
     }
 
-    describe("readScheme") {
+    describe("readState") {
         describe("defaults") {
             it("returns default enclosure if no enclosure is selected") {
                 GuiActionRunner.execute { editor.loadState(WordScheme(enclosure = "unsupported")) }

--- a/src/test/kotlin/com/fwdekker/randomness/word/WordSchemeEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/word/WordSchemeEditorTest.kt
@@ -174,14 +174,46 @@ object WordSchemeEditorTest : Spek({
                 .isEqualTo(editor.originalState)
                 .isNotSameAs(editor.originalState)
             assertThat(+readState.dictionarySettings)
-                .isSameAs(+editor.originalState.dictionarySettings)
+                .isEqualTo(+editor.originalState.dictionarySettings)
+                .isNotSameAs(+editor.originalState.dictionarySettings)
             assertThat(readState.decorator)
                 .isEqualTo(editor.originalState.decorator)
                 .isNotSameAs(editor.originalState.decorator)
         }
 
+        it("returns a scheme with a deep copy of the dictionary settings") {
+            GuiActionRunner.execute {
+                repeat(dictionaryTable.items.size) { dictionaryTable.listTableModel.removeRow(0) }
+                dictionaryTable.listTableModel.addRow(EditableDatum(active = true, UserDictionary("fasten.dic")))
+            }
+
+            assertThat((+editor.readState().dictionarySettings).dictionaries)
+                .containsExactly(UserDictionary("fasten.dic"))
+            assertThat(dictionarySettings.dictionaries)
+                .doesNotContain(UserDictionary("fasten.dic"))
+        }
+
         it("retains the scheme's UUID") {
             assertThat(editor.readState().uuid).isEqualTo(editor.originalState.uuid)
+        }
+    }
+
+    describe("applyState") {
+        it("does not change the target's reference to the dictionary settings") {
+            GuiActionRunner.execute { editor.applyState() }
+
+            assertThat(+scheme.dictionarySettings).isSameAs(dictionarySettings)
+        }
+
+        it("copies the changes from the table into the original state's dictionary settings") {
+            GuiActionRunner.execute {
+                repeat(dictionaryTable.items.size) { dictionaryTable.listTableModel.removeRow(0) }
+                dictionaryTable.listTableModel.addRow(EditableDatum(active = true, UserDictionary("fat.dic")))
+            }
+
+            GuiActionRunner.execute { editor.applyState() }
+
+            assertThat(dictionarySettings.dictionaries).containsExactly(UserDictionary("fat.dic"))
         }
     }
 

--- a/src/test/kotlin/com/fwdekker/randomness/word/WordSchemeEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/word/WordSchemeEditorTest.kt
@@ -106,14 +106,14 @@ object WordSchemeEditorTest : Spek({
         }
 
         it("loads the scheme's bundled dictionaries") {
-            val allDictionaries = mutableListOf(UserDictionary("dictionary1.dic"), UserDictionary("dictionary2.dic"))
-            val activeDictionaries = mutableListOf(UserDictionary("dictionary1.dic"))
+            val allDictionaries = mutableSetOf(UserDictionary("dictionary1.dic"), UserDictionary("dictionary2.dic"))
+            val activeDictionaries = mutableSetOf(UserDictionary("dictionary1.dic"))
 
             GuiActionRunner.execute {
                 editor.loadState(
                     WordScheme(
-                        dictionarySettings = DictionarySettings(allDictionaries.toMutableList()),
-                        activeDictionaries = activeDictionaries.toMutableList()
+                        dictionarySettings = DictionarySettings(allDictionaries.toMutableSet()),
+                        activeDictionaries = activeDictionaries.toMutableSet()
                     )
                 )
             }
@@ -184,6 +184,19 @@ object WordSchemeEditorTest : Spek({
 
         it("retains the scheme's UUID") {
             assertThat(editor.readState().uuid).isEqualTo(editor.originalState.uuid)
+        }
+    }
+
+
+    describe("doValidate") {
+        it("is invalid if a duplicate dictionary has been defined") {
+            val file = tempFileHelper.createFile("lay\ngray", ".dic")
+            GuiActionRunner.execute {
+                dictionaryTable.listTableModel.addRow(EditableDatum(active = true, UserDictionary(file.absolutePath)))
+                dictionaryTable.listTableModel.addRow(EditableDatum(active = true, UserDictionary(file.absolutePath)))
+            }
+
+            assertThat(editor.doValidate()).matches("Duplicate dictionary '.*\\.dic'\\.")
         }
     }
 

--- a/src/test/kotlin/com/fwdekker/randomness/word/WordSchemeEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/word/WordSchemeEditorTest.kt
@@ -106,22 +106,22 @@ object WordSchemeEditorTest : Spek({
         }
 
         it("loads the scheme's bundled dictionaries") {
-            val allUserDictionaries = mutableSetOf("dictionary1.dic", "dictionary2.dic")
-            val activeUserDictionaries = mutableSetOf("dictionary1.dic")
+            val allDictionaries = mutableListOf(UserDictionary("dictionary1.dic"), UserDictionary("dictionary2.dic"))
+            val activeDictionaries = mutableListOf(UserDictionary("dictionary1.dic"))
 
             GuiActionRunner.execute {
                 editor.loadState(
                     WordScheme(
-                        dictionarySettings = DictionarySettings(mutableSetOf(), allUserDictionaries),
-                        activeUserDictionaryFiles = activeUserDictionaries
+                        dictionarySettings = DictionarySettings(allDictionaries.toMutableList()),
+                        activeDictionaries = activeDictionaries.toMutableList()
                     )
                 )
             }
 
             assertThat(dictionaryTable.items.map { it.datum })
-                .containsExactlyElementsOf(allUserDictionaries.map { DictionaryReference(isBundled = false, it) })
+                .containsExactlyElementsOf(allDictionaries)
             assertThat(dictionaryTable.items.filter { it.active }.map { it.datum })
-                .containsExactlyElementsOf(activeUserDictionaries.map { DictionaryReference(isBundled = false, it) })
+                .containsExactlyElementsOf(activeDictionaries)
         }
     }
 

--- a/src/test/kotlin/com/fwdekker/randomness/word/WordSchemeEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/word/WordSchemeEditorTest.kt
@@ -106,13 +106,13 @@ object WordSchemeEditorTest : Spek({
         }
 
         it("loads the scheme's bundled dictionaries") {
-            val allDictionaries = mutableSetOf(UserDictionary("dictionary1.dic"), UserDictionary("dictionary2.dic"))
-            val activeDictionaries = mutableSetOf(UserDictionary("dictionary1.dic"))
+            val allDictionaries = setOf(UserDictionary("dictionary1.dic"), UserDictionary("dictionary2.dic"))
+            val activeDictionaries = setOf(UserDictionary("dictionary1.dic"))
 
             GuiActionRunner.execute {
                 editor.loadState(
-                    WordScheme(activeDictionaries = activeDictionaries.toMutableSet())
-                        .also { it.dictionarySettings += DictionarySettings(allDictionaries.toMutableSet()) }
+                    WordScheme(activeDictionaries = activeDictionaries.toSet())
+                        .also { it.dictionarySettings += DictionarySettings(allDictionaries.toSet()) }
                 )
             }
 

--- a/src/test/kotlin/com/fwdekker/randomness/word/WordSchemeTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/word/WordSchemeTest.kt
@@ -86,11 +86,10 @@ object WordSchemeTest : Spek({
             }
 
             it("fails if the length range ends too low to match any words") {
-                val dictionaryFile = tempFileHelper.createFile("save", ".dic")
-                val dictionary = DictionaryReference(isBundled = false, dictionaryFile.absolutePath)
+                val file = tempFileHelper.createFile("save", ".dic")
+                val dictionary = UserDictionary(file.absolutePath)
 
-                wordScheme.activeBundledDictionaries = emptySet()
-                wordScheme.activeUserDictionaries = setOf(dictionary)
+                wordScheme.activeDictionaries = mutableListOf(dictionary)
                 wordScheme.minLength = 1
                 wordScheme.maxLength = 1
 
@@ -113,16 +112,15 @@ object WordSchemeTest : Spek({
 
         describe("dictionaries") {
             it("fails if the dictionary settings are invalid") {
-                val dictionaryFile = tempFileHelper.createFile("heavenly\npet\n", ".dic").also { it.delete() }
+                val file = tempFileHelper.createFile("heavenly\npet\n", ".dic").also { it.delete() }
 
-                wordScheme.dictionarySettings.userDictionaryFiles = mutableSetOf(dictionaryFile.absolutePath)
+                wordScheme.dictionarySettings.dictionaries = mutableListOf(UserDictionary(file.absolutePath))
 
                 assertThat(wordScheme.doValidate()).isNotNull()
             }
 
             it("fails if no dictionaries are selected") {
-                wordScheme.activeBundledDictionaries = emptySet()
-                wordScheme.activeUserDictionaries = emptySet()
+                wordScheme.activeDictionaries = mutableListOf()
 
                 assertThat(wordScheme.doValidate()).isEqualTo("Activate at least one dictionary.")
             }

--- a/src/test/kotlin/com/fwdekker/randomness/word/WordSchemeTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/word/WordSchemeTest.kt
@@ -89,7 +89,7 @@ object WordSchemeTest : Spek({
                 val file = tempFileHelper.createFile("save", ".dic")
                 val dictionary = UserDictionary(file.absolutePath)
 
-                wordScheme.activeDictionaries = mutableListOf(dictionary)
+                wordScheme.activeDictionaries = mutableSetOf(dictionary)
                 wordScheme.minLength = 1
                 wordScheme.maxLength = 1
 
@@ -114,13 +114,13 @@ object WordSchemeTest : Spek({
             it("fails if the dictionary settings are invalid") {
                 val file = tempFileHelper.createFile("heavenly\npet\n", ".dic").also { it.delete() }
 
-                wordScheme.dictionarySettings.dictionaries = mutableListOf(UserDictionary(file.absolutePath))
+                wordScheme.dictionarySettings.dictionaries = mutableSetOf(UserDictionary(file.absolutePath))
 
                 assertThat(wordScheme.doValidate()).isNotNull()
             }
 
             it("fails if no dictionaries are selected") {
-                wordScheme.activeDictionaries = mutableListOf()
+                wordScheme.activeDictionaries = mutableSetOf()
 
                 assertThat(wordScheme.doValidate()).isEqualTo("Activate at least one dictionary.")
             }

--- a/src/test/kotlin/com/fwdekker/randomness/word/WordSchemeTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/word/WordSchemeTest.kt
@@ -92,7 +92,7 @@ object WordSchemeTest : Spek({
 
             it("fails if the length range ends too low to match any words") {
                 val file = tempFileHelper.createFile("save", ".dic")
-                wordScheme.activeDictionaries = mutableSetOf(UserDictionary(file.absolutePath))
+                wordScheme.activeDictionaries = setOf(UserDictionary(file.absolutePath))
 
                 wordScheme.minLength = 1
                 wordScheme.maxLength = 1
@@ -118,13 +118,13 @@ object WordSchemeTest : Spek({
             it("fails if the dictionary settings are invalid") {
                 val file = tempFileHelper.createFile("heavenly\npet\n", ".dic").also { it.delete() }
 
-                dictionarySettings.dictionaries = mutableSetOf(UserDictionary(file.absolutePath))
+                dictionarySettings.dictionaries = setOf(UserDictionary(file.absolutePath))
 
                 assertThat(wordScheme.doValidate()).isNotNull()
             }
 
             it("fails if no dictionaries are selected") {
-                wordScheme.activeDictionaries = mutableSetOf()
+                wordScheme.activeDictionaries = emptySet()
 
                 assertThat(wordScheme.doValidate()).isEqualTo("Activate at least one dictionary.")
             }
@@ -160,10 +160,10 @@ object WordSchemeTest : Spek({
         }
 
         it("creates an independent copy of the dictionary settings") {
-            (+wordScheme.dictionarySettings).dictionaries = mutableSetOf(UserDictionary("classify.dic"))
+            (+wordScheme.dictionarySettings).dictionaries = setOf(UserDictionary("classify.dic"))
 
             val copy = wordScheme.deepCopy()
-            (+copy.dictionarySettings).dictionaries = mutableSetOf(UserDictionary("decay.dic"))
+            (+copy.dictionarySettings).dictionaries = setOf(UserDictionary("decay.dic"))
 
             assertThat((+wordScheme.dictionarySettings).dictionaries).containsExactly(UserDictionary("classify.dic"))
         }
@@ -202,12 +202,12 @@ object WordSchemeTest : Spek({
         }
 
         it("writes a deep copy of the given scheme's dictionary settings into the target") {
-            val otherSettings = DictionarySettings(mutableSetOf(UserDictionary("complain.dic")))
+            val otherSettings = DictionarySettings(setOf(UserDictionary("complain.dic")))
             val otherScheme = WordScheme()
             otherScheme.dictionarySettings += otherSettings
 
             wordScheme.copyFrom(otherScheme)
-            (+otherScheme.dictionarySettings).dictionaries = mutableSetOf(UserDictionary("spit.dic"))
+            (+otherScheme.dictionarySettings).dictionaries = setOf(UserDictionary("spit.dic"))
 
             assertThat((+wordScheme.dictionarySettings).dictionaries).containsExactly(UserDictionary("complain.dic"))
         }

--- a/src/test/kotlin/com/fwdekker/randomness/word/WordSchemeTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/word/WordSchemeTest.kt
@@ -15,7 +15,8 @@ object WordSchemeTest : Spek({
 
 
     beforeEachTest {
-        wordScheme = WordScheme(DictionarySettings())
+        wordScheme = WordScheme()
+        wordScheme.dictionarySettings += DictionarySettings()
     }
 
 
@@ -47,12 +48,12 @@ object WordSchemeTest : Spek({
     }
 
     describe("setSettingsState") {
-        it("overwrites the constructor's symbol set settings") {
+        it("overwrites the default symbol set settings") {
             val newSettings = SettingsState(dictionarySettings = DictionarySettings())
 
             wordScheme.setSettingsState(newSettings)
 
-            assertThat(wordScheme.dictionarySettings).isSameAs(newSettings.dictionarySettings)
+            assertThat(+wordScheme.dictionarySettings).isSameAs(newSettings.dictionarySettings)
         }
     }
 
@@ -67,7 +68,7 @@ object WordSchemeTest : Spek({
 
 
         it("passes for the default settings") {
-            assertThat(WordScheme(DictionarySettings()).doValidate()).isNull()
+            assertThat(wordScheme.doValidate()).isNull()
         }
 
         describe("length range") {
@@ -114,7 +115,7 @@ object WordSchemeTest : Spek({
             it("fails if the dictionary settings are invalid") {
                 val file = tempFileHelper.createFile("heavenly\npet\n", ".dic").also { it.delete() }
 
-                wordScheme.dictionarySettings.dictionaries = mutableSetOf(UserDictionary(file.absolutePath))
+                (+wordScheme.dictionarySettings).dictionaries = mutableSetOf(UserDictionary(file.absolutePath))
 
                 assertThat(wordScheme.doValidate()).isNotNull()
             }
@@ -149,7 +150,7 @@ object WordSchemeTest : Spek({
         }
 
         it("retains the reference to the dictionary settings") {
-            assertThat(wordScheme.deepCopy().dictionarySettings).isSameAs(wordScheme.dictionarySettings)
+            assertThat(+wordScheme.deepCopy().dictionarySettings).isSameAs(+wordScheme.dictionarySettings)
         }
     }
 
@@ -160,23 +161,18 @@ object WordSchemeTest : Spek({
             wordScheme.enclosure = "QJ8S4UrFaa"
             wordScheme.decorator.count = 513
 
-            val newScheme = WordScheme(DictionarySettings())
+            val newScheme = WordScheme()
+            newScheme.dictionarySettings += DictionarySettings()
             newScheme.copyFrom(wordScheme)
 
             assertThat(newScheme)
                 .isEqualTo(wordScheme)
                 .isNotSameAs(wordScheme)
+            assertThat(+newScheme.dictionarySettings)
+                .isSameAs(+wordScheme.dictionarySettings)
             assertThat(newScheme.decorator)
                 .isEqualTo(wordScheme.decorator)
                 .isNotSameAs(wordScheme.decorator)
-        }
-
-        it("retains the reference to the symbol set settings") {
-            val newSettings = DictionarySettings()
-
-            wordScheme.copyFrom(WordScheme(newSettings))
-
-            assertThat(wordScheme.dictionarySettings).isSameAs(newSettings)
         }
     }
 })


### PR DESCRIPTION
* Removes unnecessary mutability introduced in 23ae642a4eab6e5ed377be21a52c08c4a198808d to work around a bug in IntelliJ. The bug has been reported as [IDEA-277015](https://youtrack.jetbrains.com/issue/IDEA-277015), and I have proposed a fix in JetBrains/intellij-community#1691. The bug caused a crash when settings were loaded and the settings contained a custom modification which cannot be created by the editor but is technically still valid. The quick fix in 23ae642a4eab6e5ed377be21a52c08c4a198808d turned all lists/sets/maps into mutable types, but really all that was necessary was to make the _instances_ mutable.
*  Removes the unnecessary `DictionaryReference` class. Previously, `Dictionary` instances were cached to prevent having to look up the words every time a word was inserted. However, this meant that it was not possible to force dictionaries to re-read the words when needed. A `DictionaryReference` was a special `Dictionary` that wrapped around another `Dictionary` and always re-read the words.
  The new solution is to make the cache cache the words associated with a particular dictionary by name. Then, dictionaries simply look up their words in the cache. Clearing the cache then necessarily causes dictionaries to re-read the file when the words are requested.
* Rectifies the semantics of `readState` for `StringScheme`, `WordScheme`, and their editors. Now, `readScheme` returns a deep copy of the contained settings, and only `applyState` writes them into the original instance. This is not necessary for `TemplateReference` because it does not modify the settings.
* Enables the validator to detect duplicate symbol sets and dictionaries. Before, duplicates were automatically merged into one. (This was a regression since v2.)