### PR TITLE
Run CI on all pushes to all branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
     paths-ignore:
       - 'README.md'
       - '.github/**.md'


### PR DESCRIPTION
Makes it behave the same as before migrating to GitHub Actions. This is quite essential to make the integration, well, continuous.