### PR TITLE
Split template tree

### DIFF
--- a/src/main/kotlin/com/fwdekker/randomness/SettingsState.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/SettingsState.kt
@@ -24,9 +24,11 @@ data class SettingsState(
     override fun copyFrom(other: State) {
         require(other is SettingsState) { "Cannot copy from different type." }
 
+        uuid = other.uuid
         templateList.copyFrom(other.templateList)
         symbolSetSettings.copyFrom(other.symbolSetSettings)
         dictionarySettings.copyFrom(other.dictionarySettings)
+        templateList.applySettingsState(this)
     }
 
     override fun deepCopy(retainUuid: Boolean) =
@@ -34,7 +36,11 @@ data class SettingsState(
             templateList = templateList.deepCopy(retainUuid = retainUuid),
             symbolSetSettings = symbolSetSettings.deepCopy(retainUuid = retainUuid),
             dictionarySettings = dictionarySettings.deepCopy(retainUuid = retainUuid)
-        ).also { if (retainUuid) it.uuid = uuid }
+        ).also {
+            if (retainUuid) it.uuid = uuid
+
+            it.templateList.applySettingsState(it)
+        }
 
 
     /**
@@ -44,7 +50,7 @@ data class SettingsState(
         /**
          * The persistent `SettingsState` instance.
          */
-        val default by lazy {
+        val default: SettingsState by lazy {
             SettingsState(
                 TemplateSettings.default.state,
                 SymbolSetSettings.default,

--- a/src/main/kotlin/com/fwdekker/randomness/template/TemplateListEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/template/TemplateListEditor.kt
@@ -3,7 +3,6 @@ package com.fwdekker.randomness.template
 import com.fwdekker.randomness.ActuallyPrivate
 import com.fwdekker.randomness.Scheme
 import com.fwdekker.randomness.SettingsState
-import com.fwdekker.randomness.State
 import com.fwdekker.randomness.StateEditor
 import com.fwdekker.randomness.decimal.DecimalScheme
 import com.fwdekker.randomness.decimal.DecimalSchemeEditor
@@ -13,11 +12,10 @@ import com.fwdekker.randomness.literal.LiteralScheme
 import com.fwdekker.randomness.literal.LiteralSchemeEditor
 import com.fwdekker.randomness.string.StringScheme
 import com.fwdekker.randomness.string.StringSchemeEditor
-import com.fwdekker.randomness.string.SymbolSetSettings
 import com.fwdekker.randomness.ui.PreviewPanel
+import com.fwdekker.randomness.ui.SimpleTreeModelListener
 import com.fwdekker.randomness.uuid.UuidScheme
 import com.fwdekker.randomness.uuid.UuidSchemeEditor
-import com.fwdekker.randomness.word.DictionarySettings
 import com.fwdekker.randomness.word.WordScheme
 import com.fwdekker.randomness.word.WordSchemeEditor
 import com.intellij.icons.AllIcons
@@ -28,28 +26,15 @@ import com.intellij.openapi.ui.popup.PopupStep
 import com.intellij.openapi.ui.popup.util.BaseListPopupStep
 import com.intellij.ui.AnActionButton
 import com.intellij.ui.AnActionButtonRunnable
-import com.intellij.ui.ColoredTreeCellRenderer
 import com.intellij.ui.JBSplitter
 import com.intellij.ui.LayeredIcon
-import com.intellij.ui.SimpleTextAttributes
 import com.intellij.ui.ToolbarDecorator
 import com.intellij.ui.components.JBScrollPane
 import com.intellij.ui.treeStructure.Tree
 import com.intellij.util.ui.JBUI
 import java.awt.BorderLayout
-import java.util.Collections
-import java.util.Enumeration
 import javax.swing.JPanel
-import javax.swing.JTree
 import javax.swing.SwingUtilities
-import javax.swing.event.TreeModelEvent
-import javax.swing.event.TreeModelListener
-import javax.swing.tree.DefaultTreeModel
-import javax.swing.tree.MutableTreeNode
-import javax.swing.tree.TreeNode
-import javax.swing.tree.TreePath
-import javax.swing.tree.TreeSelectionModel
-import kotlin.math.min
 
 
 /**
@@ -67,10 +52,13 @@ import kotlin.math.min
  */
 class TemplateListEditor(settings: SettingsState = SettingsState.default) : StateEditor<SettingsState>(settings) {
     override val rootComponent = JPanel(BorderLayout())
-    private var dictionarySettings: DictionarySettings = DictionarySettings()
-    private var symbolSetSettings: SymbolSetSettings = SymbolSetSettings()
-    private val templateTreeModel = DefaultTreeModel(TemplateListTreeNode(TemplateList(emptyList())))
-    private val templateTree = Tree(templateTreeModel)
+    private var currentSettingsState: SettingsState = SettingsState()
+    private val templateTree = TemplateTree { scheme ->
+        val templates = originalState.templateList.templates
+        val schemesAndTemplates = templates.flatMap { it.schemes } + templates
+
+        schemesAndTemplates.firstOrNull { it.uuid == scheme.uuid } != scheme
+    }
     private var schemeEditorPanel = JPanel(BorderLayout())
     private var schemeEditor: StateEditor<*>? = null
 
@@ -88,76 +76,12 @@ class TemplateListEditor(settings: SettingsState = SettingsState.default) : Stat
         rootComponent.add(splitter, BorderLayout.CENTER)
 
         // Left half
-        templateTree.isRootVisible = false
-        templateTree.selectionModel.selectionMode = TreeSelectionModel.SINGLE_TREE_SELECTION
-        templateTree.cellRenderer = object : ColoredTreeCellRenderer() {
-            override fun customizeCellRenderer(
-                tree: JTree,
-                value: Any?,
-                selected: Boolean,
-                expanded: Boolean,
-                leaf: Boolean,
-                row: Int,
-                hasFocus: Boolean
-            ) {
-                val scheme = (value as StateTreeNode<*>).state as? Scheme
-                if (scheme == null) {
-                    append("<unknown>")
-                    return
-                }
-
-                icon = scheme.icon
-
-                val templates = originalState.templateList.templates
-                val schemes = templates.flatMap { it.schemes }
-                append(
-                    scheme.name.ifBlank { "<empty>" },
-                    when {
-                        scheme.doValidate() != null ->
-                            SimpleTextAttributes.ERROR_ATTRIBUTES
-                        scheme is Template && templates.firstOrNull { it.uuid == scheme.uuid } != scheme ->
-                            SimpleTextAttributes.LINK_PLAIN_ATTRIBUTES
-                        scheme !is Template && schemes.firstOrNull { it.uuid == scheme.uuid } != scheme ->
-                            SimpleTextAttributes.LINK_PLAIN_ATTRIBUTES
-                        else ->
-                            SimpleTextAttributes.REGULAR_ATTRIBUTES
-                    }
-                )
-            }
-        }
-        templateTree.emptyText.text = EMPTY_TEXT
-        templateTree.addTreeSelectionListener {
-            schemeEditor?.also {
-                schemeEditorPanel.remove(it.rootComponent)
-                schemeEditor = null
-            }
-
-            val selectedNode = templateTree.getSelectedNode()
-            val selectedObject = selectedNode?.state
-            if (selectedObject !is Scheme) {
-                templateTreeModel.nodeChanged(selectedNode)
-                return@addTreeSelectionListener
-            }
-
-            schemeEditor = createEditor(selectedObject)
-                .also { editor ->
-                    editor.addChangeListener(
-                        {
-                            editor.applyState()
-                            templateTreeModel.nodeChanged(selectedNode)
-                            templateTreeModel.nodeStructureChanged(selectedNode)
-                        }.also { it() } // Invoke listener to apply automatic fixes from editor's constructor
-                    )
-
-                    schemeEditorPanel.add(editor.rootComponent)
-                    schemeEditorPanel.revalidate() // Show editor immediately
-                }
-        }
+        templateTree.addTreeSelectionListener { onTreeSelection() }
         splitter.firstComponent = JBScrollPane(decorateTemplateList(templateTree))
 
         // Right half
         val previewPanel = PreviewPanel {
-            val selectedNode = templateTree.getSelectedNode() ?: return@PreviewPanel LiteralScheme("")
+            val selectedNode = templateTree.selectedNode ?: return@PreviewPanel LiteralScheme("")
             val selectedTemplate =
                 selectedNode.state.let {
                     if (it is Template) it
@@ -173,6 +97,7 @@ class TemplateListEditor(settings: SettingsState = SettingsState.default) : Stat
 
         loadState()
     }
+
 
     /**
      * Decorates the given list with buttons for adding, removing, copying, etc.
@@ -194,13 +119,43 @@ class TemplateListEditor(settings: SettingsState = SettingsState.default) : Stat
             .setAddIcon(LayeredIcon.ADD_WITH_DROPDOWN)
             .setRemoveAction(RemoveAction())
             .setRemoveActionName("Remove")
-            .setRemoveActionUpdater { templateTree.getSelectedNode() != null }
+            .setRemoveActionUpdater { templateTree.selectedNode != null }
             .addExtraAction(CopyActionButton())
             .addExtraAction(UpActionButton())
             .addExtraAction(DownActionButton())
             .setButtonComparator("Add", "Remove", "Copy", "Up", "Down")
             .createPanel()
 
+    /**
+     * Invoked when an entry is (de)selected in the tree.
+     */
+    private fun onTreeSelection() {
+        schemeEditor?.also {
+            schemeEditorPanel.remove(it.rootComponent)
+            schemeEditor = null
+        }
+
+        val selectedNode = templateTree.selectedNode
+        val selectedObject = selectedNode?.state
+        if (selectedObject !is Scheme) {
+            templateTree.myModel.nodeChanged(selectedNode)
+            return
+        }
+
+        schemeEditor = createEditor(selectedObject)
+            .also { editor ->
+                editor.addChangeListener(
+                    {
+                        editor.applyState()
+                        templateTree.myModel.nodeChanged(selectedNode)
+                        templateTree.myModel.nodeStructureChanged(selectedNode)
+                    }.also { it() } // Invoke listener to apply automatic fixes from editor's constructor
+                )
+
+                schemeEditorPanel.add(editor.rootComponent)
+                schemeEditorPanel.revalidate() // Show editor immediately
+            }
+    }
 
     /**
      * Creates an editor to edit the given scheme.
@@ -221,121 +176,38 @@ class TemplateListEditor(settings: SettingsState = SettingsState.default) : Stat
         }
 
     /**
-     * Adds the given scheme at an appropriate location in the tree based on the currently selected node.
+     * Adds the given scheme to the tree.
      *
      * @param newScheme the scheme to add
+     * @see TemplateTree.addScheme
      */
-    @ActuallyPrivate("Exposed for testing.")
-    internal fun addScheme(newScheme: Scheme) {
-        val root = templateTreeModel.root as TemplateListTreeNode
-        val selectedNode = templateTree.getSelectedNode()
-        newScheme.setSettingsState(SettingsState(root.state, symbolSetSettings, dictionarySettings))
-
-        val (childNode, parent, index) =
-            if (selectedNode == null) {
-                if (newScheme is Template)
-                    Triple(TemplateTreeNode(newScheme), root, root.childCount)
-                else
-                    error("Cannot add non-template to root.")
-            } else if (selectedNode is TemplateTreeNode) {
-                if (newScheme is Template)
-                    Triple(TemplateTreeNode(newScheme), root, root.getIndex(selectedNode) + 1)
-                else
-                    Triple(SchemeTreeNode(newScheme), selectedNode, selectedNode.childCount)
-            } else if (selectedNode is SchemeTreeNode) {
-                if (newScheme is Template)
-                    Triple(TemplateTreeNode(newScheme), root, root.getIndex(selectedNode.parent) + 1)
-                else
-                    selectedNode.parent!!.let { Triple(SchemeTreeNode(newScheme), it, it.getIndex(selectedNode) + 1) }
-            } else {
-                error("Unknown node type '${selectedNode.javaClass.canonicalName}'.")
-            }
-
-        templateTreeModel.insertNodeInto(childNode, parent, index)
-        templateTree.selectionPath = templateTree.getPathToRoot(childNode)
-        templateTree.expandPath(templateTree.selectionPath)
-    }
-
-    /**
-     * Moves the given node down the given number of positions.
-     *
-     * The node will be moved down relative to its siblings. The parent does not change.
-     *
-     * @param node the node to move down
-     * @param positions the number of positions to move the node down by within its parent; can be negative
-     */
-    private fun moveNodeDownBy(node: StateTreeNode<*>, positions: Int) {
-        val parent = node.parent as StateTreeNode<*>
-        val oldIndex = parent.getIndex(node)
-
-        templateTreeModel.removeNodeFromParent(node)
-        templateTreeModel.insertNodeInto(node, parent, oldIndex + positions)
-        templateTree.selectionPath = templateTree.getPathToRoot(node)
-        templateTree.expandPath(templateTree.selectionPath)
-    }
+    @ActuallyPrivate("Exposed for testing because popup cannot easily be tested.")
+    internal fun addScheme(newScheme: Scheme) = templateTree.addScheme(newScheme)
 
 
     override fun loadState(state: SettingsState) {
         super.loadState(state)
 
-        val stateCopy = state.deepCopy(retainUuid = true)
-        dictionarySettings = stateCopy.dictionarySettings
-        symbolSetSettings = stateCopy.symbolSetSettings
-        templateTreeModel.setRoot(TemplateListTreeNode(stateCopy.templateList.applySettingsState(stateCopy)))
-        templateTreeModel.reload()
-
-        val root = templateTreeModel.root as TemplateListTreeNode
-        root.children().toList().forEach { templateTree.expandPath(templateTree.getPathToRoot(it)) }
-        root.firstLeaf()?.also { templateTree.selectionPath = templateTree.getPathToRoot(it) }
+        currentSettingsState.copyFrom(state)
+        templateTree.loadList(currentSettingsState.templateList)
     }
 
-    override fun readState() =
-        SettingsState(
-            (templateTreeModel.root as TemplateListTreeNode).state.deepCopy(retainUuid = true),
-            symbolSetSettings.deepCopy(retainUuid = true),
-            dictionarySettings.deepCopy(retainUuid = true)
-        ).also { it.uuid = originalState.uuid }
-
-    override fun applyState() = originalState.copyFrom(readState().also { it.templateList.applySettingsState(it) })
+    override fun readState() = currentSettingsState.deepCopy(retainUuid = true)
 
     override fun reset() {
         super.reset()
 
         queueSelection?.also { selection ->
-            (templateTreeModel.root as TemplateListTreeNode)
-                .children().toList()
-                .firstOrNull { it.state.uuid == selection }
-                ?.also {
-                    templateTree.selectionPath = templateTree.getPathToRoot(it)
-                    SwingUtilities.invokeLater { schemeEditor?.preferredFocusedComponent?.requestFocus() }
-                }
+            templateTree.selectTemplate(selection)
+            SwingUtilities.invokeLater { schemeEditor?.preferredFocusedComponent?.requestFocus() }
 
             queueSelection = null
         }
     }
 
 
-    override fun doValidate() = readState().doValidate()
-
-
     override fun addChangeListener(listener: () -> Unit) {
-        templateTreeModel.addTreeModelListener(object : TreeModelListener {
-            override fun treeNodesChanged(event: TreeModelEvent) {
-                listener()
-            }
-
-            override fun treeNodesInserted(event: TreeModelEvent) {
-                listener()
-            }
-
-            override fun treeNodesRemoved(event: TreeModelEvent) {
-                listener()
-            }
-
-            override fun treeStructureChanged(event: TreeModelEvent) {
-                listener()
-            }
-        })
+        templateTree.model.addTreeModelListener(SimpleTreeModelListener(listener))
         templateTree.addTreeSelectionListener { listener() }
     }
 
@@ -362,8 +234,12 @@ class TemplateListEditor(settings: SettingsState = SettingsState.default) : Stat
 
             override fun getTextFor(value: Template?) = value?.name ?: Template.DEFAULT_NAME
 
-            override fun onChosen(value: Template?, finalChoice: Boolean): PopupStep<*>? =
-                value?.also { addScheme(it.deepCopy()) }?.let { null }
+            override fun onChosen(value: Template?, finalChoice: Boolean): PopupStep<*>? {
+                if (value != null)
+                    templateTree.addScheme(value.deepCopy().also { it.setSettingsState(currentSettingsState) })
+
+                return null
+            }
 
             override fun isSpeedSearchEnabled() = true
         }
@@ -376,8 +252,12 @@ class TemplateListEditor(settings: SettingsState = SettingsState.default) : Stat
 
             override fun getTextFor(value: Scheme?) = value?.name ?: Scheme.DEFAULT_NAME
 
-            override fun onChosen(value: Scheme?, finalChoice: Boolean): PopupStep<*>? =
-                value?.also { addScheme(it.deepCopy()) }?.let { null }
+            override fun onChosen(value: Scheme?, finalChoice: Boolean): PopupStep<*>? {
+                if (value != null)
+                    templateTree.addScheme(value.deepCopy().also { it.setSettingsState(currentSettingsState) })
+
+                return null
+            }
 
             override fun isSpeedSearchEnabled() = true
         }
@@ -388,19 +268,7 @@ class TemplateListEditor(settings: SettingsState = SettingsState.default) : Stat
      */
     private inner class RemoveAction : AnActionButtonRunnable {
         override fun run(t: AnActionButton?) {
-            val selectedNode = templateTree.getSelectedNode() ?: return
-            val parent = selectedNode.parent as StateTreeNode<*>
-            val oldIndex = parent.getIndex(selectedNode)
-
-            templateTreeModel.removeNodeFromParent(selectedNode)
-            if (parent.isLeaf && parent == templateTreeModel.root)
-                templateTree.clearSelection()
-            else
-                templateTree.selectionPath =
-                    templateTree.getPathToRoot(
-                        if (parent.isLeaf) parent
-                        else parent.getChildAt(min(oldIndex, parent.childCount - 1))
-                    )
+            templateTree.removeNode(templateTree.selectedNode ?: return)
         }
     }
 
@@ -409,12 +277,14 @@ class TemplateListEditor(settings: SettingsState = SettingsState.default) : Stat
      */
     private inner class CopyActionButton : AnActionButton("Copy", AllIcons.Actions.Copy) {
         override fun actionPerformed(event: AnActionEvent) {
-            val node = templateTree.getSelectedNode() ?: return
+            val node = templateTree.selectedNode ?: return
+            val copy = (node.state as Scheme).deepCopy()
+                .also { it.setSettingsState(currentSettingsState) }
 
-            addScheme((node.state as Scheme).deepCopy())
+            templateTree.addScheme(copy)
         }
 
-        override fun isEnabled() = templateTree.getSelectedNode() != null
+        override fun isEnabled() = templateTree.selectedNode != null
     }
 
     /**
@@ -422,12 +292,11 @@ class TemplateListEditor(settings: SettingsState = SettingsState.default) : Stat
      */
     private inner class UpActionButton : AnActionButton("Up", AllIcons.Actions.MoveUp) {
         override fun actionPerformed(event: AnActionEvent) {
-            templateTree.getSelectedNode()?.also { moveNodeDownBy(it, -1) }
+            templateTree.selectedNode?.also { templateTree.moveNodeDownBy(it, -1) }
         }
 
         override fun isEnabled(): Boolean {
-            val node = templateTree.getSelectedNode() ?: return false
-
+            val node = templateTree.selectedNode ?: return false
             return node.parent!!.getIndex(node) > 0
         }
     }
@@ -437,12 +306,11 @@ class TemplateListEditor(settings: SettingsState = SettingsState.default) : Stat
      */
     private inner class DownActionButton : AnActionButton("Down", AllIcons.Actions.MoveDown) {
         override fun actionPerformed(event: AnActionEvent) {
-            templateTree.getSelectedNode()?.also { moveNodeDownBy(it, 1) }
+            templateTree.selectedNode?.also { templateTree.moveNodeDownBy(it, 1) }
         }
 
         override fun isEnabled(): Boolean {
-            val node = templateTree.getSelectedNode() ?: return false
-
+            val node = templateTree.selectedNode ?: return false
             return node.parent!!.getIndex(node) < node.parent!!.childCount - 1
         }
     }
@@ -481,358 +349,5 @@ class TemplateListEditor(settings: SettingsState = SettingsState.default) : Stat
                 UuidScheme(),
                 TemplateReference()
             )
-    }
-}
-
-
-/**
- * Returns the currently selected node, or `null` if no node is selected, or `null` if the root is selected.
- *
- * @return the currently selected node
- */
-private fun JTree.getSelectedNode() =
-    (lastSelectedPathComponent as? StateTreeNode<*>)
-        ?.let {
-            if (it == model.root) null
-            else it
-        }
-
-/**
- * Returns the path from the given node to the root path, including both ends.
- *
- * @param treeNode the node to return the path to root from
- * @return the path from the given node to the root path, including both ends
- */
-private fun JTree.getPathToRoot(treeNode: TreeNode) = TreePath((model as DefaultTreeModel).getPathToRoot(treeNode))
-
-
-/**
- * A mutable tree node that contains a state of type [S].
- *
- * The node is mutable in the sense that its [state] is mutable, but the reference to the state is not.
- *
- * `StateTreeNode`s are peculiar in that its parent and all its children must also be `StateTreeNode`s.
- *
- * @param S the type of state contained in the mutable tree node
- */
-private sealed class StateTreeNode<S : State> : MutableTreeNode {
-    /**
-     * The parent of this node.
-     */
-    private var _parent: StateTreeNode<*>? = null
-
-    /**
-     * The mutable [State] contained in this node.
-     */
-    abstract val state: S
-
-
-    /**
-     * Returns the parent of this node, as assigned through [setParent], or `null` if there is no parent (anymore).
-     *
-     * @return the parent of this node
-     */
-    override fun getParent(): StateTreeNode<*>? = _parent
-
-    /**
-     * Sets the parent of this node.
-     *
-     * @param newParent the new parent of this node, or `null` if the parent should be removed; must be an instance of
-     * [StateTreeNode]
-     */
-    override fun setParent(newParent: MutableTreeNode?) {
-        require(newParent is StateTreeNode<*>?) { "Parent of StateTreeNode must be a StateTreeNode." }
-
-        _parent = newParent
-    }
-
-    /**
-     * Removes this node as a child from its parent.
-     *
-     * Note that this does not remove this node's reference to its parent; use [setParent] for that.
-     */
-    override fun removeFromParent() {
-        _parent?.remove(this)
-    }
-
-
-    /**
-     * Returns the children of this node, all of which are `StateTreeNode`s.
-     *
-     * If this node does not or cannot contain children, an empty enumeration is returned.
-     *
-     * @return the children of this node
-     */
-    abstract override fun children(): Enumeration<out StateTreeNode<*>>
-
-    /**
-     * Returns the child at the given index.
-     *
-     * If the node cannot have children or the index is out of bounds, an exception is thrown.
-     *
-     * @param childIndex the index of the child to retrieve, corresponding to the ordering in [children]
-     * @return the child at the given index
-     */
-    abstract override fun getChildAt(childIndex: Int): StateTreeNode<*>
-
-
-    /**
-     * Not implemented; [state] cannot be replaced by another instance.
-     *
-     * @param userObject ignored
-     * @throws UnsupportedOperationException this method has not been implemented
-     */
-    final override fun setUserObject(userObject: Any?) =
-        throw UnsupportedOperationException("Cannot replace state of StateTreeNode.")
-}
-
-/**
- * A [StateTreeNode] of which the children correspond directly to a field in [state].
- *
- * Modifications to the children of this node directly affect the entries in [state] through the [entries] field.
- *
- * @param S the type of state represented by this node
- * @param T the type of state contained as children in an [S]
- */
-private sealed class StateTreeListNode<S : State, T : State> : StateTreeNode<S>() {
-    /**
-     * The entries of [T] contained in [state].
-     *
-     * This field connects this node's children to the backing field in [state], so that this field can be modified to
-     * modify [state] whenever the children of this node are changed.
-     */
-    protected abstract var entries: List<T>
-
-
-    /**
-     * Creates a node containing [child] that can be added to this node.
-     *
-     * @param child the child to wrap in a node
-     * @return the child wrapped in a node
-     */
-    abstract fun createChildNodeFor(child: T): StateTreeNode<T>
-
-
-    /**
-     * Returns true.
-     *
-     * @return true
-     */
-    override fun getAllowsChildren() = true
-
-    /**
-     * Returns the schemes in [state] mapped to nodes.
-     *
-     * This method creates new nodes each time it is called, but the nodes wrap the same [Scheme] instances.
-     *
-     * @return the schemes in [state] mapped to nodes
-     */
-    override fun children(): Enumeration<StateTreeNode<T>> =
-        Collections.enumeration(entries.map { createChildNodeFor(it) }.onEach { it.setParent(this) })
-
-    /**
-     * Returns the child at the given index.
-     *
-     * If the index is out of bounds, an exception is thrown.
-     *
-     * @param childIndex the index of the child to retrieve, corresponding to the ordering in [children]
-     * @return the child at the given index
-     */
-    override fun getChildAt(childIndex: Int): StateTreeNode<T> =
-        createChildNodeFor(entries[childIndex]).also { it.setParent(this) }
-
-    /**
-     * Returns the number of schemes in [state].
-     *
-     * @return the number of schemes in [state]
-     */
-    override fun getChildCount() = entries.size
-
-    /**
-     * Returns true if and only if [state] has no schemes.
-     *
-     * @return true if and only if [state] has no schemes
-     */
-    override fun isLeaf() = entries.isEmpty()
-
-
-    /**
-     * Returns the index of the child's scheme in [state]'s schemes, or -1 if [child] is not a child of this node.
-     *
-     * @param child the child to return the index of
-     * @return the index of the child's scheme in [state]'s schemes, or -1 if [child] is not a child of this node
-     */
-    override fun getIndex(child: TreeNode?): Int {
-        if (child !is StateTreeNode<*>) return -1
-
-        return entries.indexOfFirst { it.uuid == child.state.uuid }
-    }
-
-    /**
-     * Adds the child's scheme to [state]'s schemes.
-     *
-     * @param node the child of which the scheme should be added to [state]
-     * @param index the index to insert the scheme at; should be in the range 0..[getChildCount]
-     */
-    @Suppress("UNCHECKED_CAST") // No way around it because we're breaking covariance
-    override fun insert(node: MutableTreeNode, index: Int) {
-        require(node is StateTreeNode<*>) { "Cannot add child that does not contain a Scheme." }
-
-        node.setParent(this)
-        entries = entries.toMutableList().also { it.add(index, node.state as T) }
-    }
-
-    /**
-     * Removes the child at the given index from this node.
-     *
-     * If the index is out of bounds, an exception is thrown.
-     *
-     * @param index the index of the child to remove
-     */
-    override fun remove(index: Int) {
-        getChildAt(index).setParent(null)
-        entries = entries.toMutableList().also { it.removeAt(index) }
-    }
-
-    /**
-     * Removes the given node as a child from this node.
-     *
-     * If the given node is not a child of this node, an exception is thrown.
-     *
-     * @param child the node to remove as a child from this node; must be a [SchemeTreeNode]
-     */
-    override fun remove(child: MutableTreeNode?) = remove(getIndex(child))
-}
-
-/**
- * A [StateTreeListNode] for a [TemplateList], which is composed of [Template]s.
- *
- * @property state the template list represented by this node; its templates are this node's children
- */
-private class TemplateListTreeNode(override val state: TemplateList) : StateTreeListNode<TemplateList, Template>() {
-    override var entries: List<Template>
-        get() = state.templates
-        set(value) {
-            state.templates = value.toList()
-        }
-
-
-    override fun createChildNodeFor(child: Template) = TemplateTreeNode(child)
-
-
-    /**
-     * Returns the depth-first node without children in the tree rooted at this node that is not this node, or `null` if
-     * no such node exists.
-     *
-     * @return the depth-first node without children in the tree rooted at this node that is not this node, or `null` if
-     * no such node exists
-     */
-    fun firstLeaf() =
-        if (isLeaf) null
-        else if (getChildAt(0).isLeaf) getChildAt(0)
-        else getChildAt(0).getChildAt(0)
-}
-
-/**
- * A [StateTreeListNode] for [Template]s, which is composed of [Scheme]s.
- *
- * @property state the template represented by this node; its schemes are this node's children
- */
-private class TemplateTreeNode(override val state: Template) : StateTreeListNode<Template, Scheme>() {
-    override var entries: List<Scheme>
-        get() = state.schemes
-        set(value) {
-            state.schemes = value.toList()
-        }
-
-
-    override fun createChildNodeFor(child: Scheme) = SchemeTreeNode(child)
-}
-
-/**
- * A [StateTreeNode] for [Scheme]s.
- *
- * @property state the scheme represented by this node
- */
-private class SchemeTreeNode(override val state: Scheme) : StateTreeNode<Scheme>() {
-    /**
-     * Returns false.
-     *
-     * @return false
-     */
-    override fun getAllowsChildren() = false
-
-    /**
-     * Returns an empty enumeration.
-     *
-     * @return an empty enumeration
-     */
-    override fun children(): Enumeration<StateTreeNode<*>> = Collections.emptyEnumeration()
-
-    /**
-     * Not implemented; schemes cannot contain children.
-     *
-     * @param childIndex ignored
-     * @throws UnsupportedOperationException this method has not been implemented
-     */
-    override fun getChildAt(childIndex: Int) = throw UnsupportedOperationException(NO_CHILDREN_MESSAGE)
-
-    /**
-     * Returns 0.
-     *
-     * @return 0
-     */
-    override fun getChildCount() = 0
-
-    /**
-     * Returns true.
-     *
-     * @return true
-     */
-    override fun isLeaf() = true
-
-
-    /**
-     * Returns -1 as this node cannot contain children.
-     *
-     * @param child ignored
-     * @return -1
-     */
-    override fun getIndex(child: TreeNode?) = -1
-
-    /**
-     * Not implemented; schemes cannot contain children.
-     *
-     * @param child ignored
-     * @param index ignored
-     * @throws UnsupportedOperationException this method has not been implemented
-     */
-    override fun insert(child: MutableTreeNode?, index: Int) = throw UnsupportedOperationException(NO_CHILDREN_MESSAGE)
-
-    /**
-     * Not implemented; schemes cannot contain children.
-     *
-     * @param childIndex ignored
-     * @throws UnsupportedOperationException this method has not been implemented
-     */
-    override fun remove(childIndex: Int) = throw UnsupportedOperationException(NO_CHILDREN_MESSAGE)
-
-    /**
-     * Not implemented; schemes cannot contain children.
-     *
-     * @param child ignored
-     * @throws UnsupportedOperationException this method has not been implemented
-     */
-    override fun remove(child: MutableTreeNode?) = throw UnsupportedOperationException(NO_CHILDREN_MESSAGE)
-
-
-    /**
-     * Holds constants.
-     */
-    companion object {
-        /**
-         * The exception message when an unsupported function is invoked.
-         */
-        const val NO_CHILDREN_MESSAGE = "Schemes cannot have children."
     }
 }

--- a/src/main/kotlin/com/fwdekker/randomness/template/TemplateTree.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/template/TemplateTree.kt
@@ -1,0 +1,539 @@
+package com.fwdekker.randomness.template
+
+import com.fwdekker.randomness.Scheme
+import com.fwdekker.randomness.State
+import com.intellij.ui.ColoredTreeCellRenderer
+import com.intellij.ui.SimpleTextAttributes
+import com.intellij.ui.treeStructure.Tree
+import java.util.Collections
+import java.util.Enumeration
+import javax.swing.JTree
+import javax.swing.tree.DefaultTreeModel
+import javax.swing.tree.MutableTreeNode
+import javax.swing.tree.TreeNode
+import javax.swing.tree.TreePath
+import javax.swing.tree.TreeSelectionModel
+import kotlin.math.min
+
+
+/**
+ * A tree containing templates and schemes.
+ *
+ * The tree is initially empty. Templates can be loaded into the tree using [loadList]. See its documentation for more
+ * information.
+ *
+ * @property isModified Returns true if and only if the given scheme has been modified.
+ */
+class TemplateTree(
+    private val isModified: (Scheme) -> Boolean
+) : Tree(DefaultTreeModel(TemplateListTreeNode(TemplateList(emptyList())))) {
+    /**
+     * The tree's model.
+     *
+     * This field cannot be named `model` because this causes an NPE during initialization. This field cannot be named
+     * `treeModel` because this name is already taken and cannot be overridden.
+     */
+    val myModel: DefaultTreeModel
+        get() = super.getModel() as DefaultTreeModel
+
+    /**
+     * The undisplayed root element of the tree.
+     */
+    internal val root: TemplateListTreeNode
+        get() = model.root as TemplateListTreeNode
+
+    /**
+     * The currently selected node, or `null` if no node is selected, or `null` if the root is selected.
+     */
+    val selectedNode: StateTreeNode<*>?
+        get() = (lastSelectedPathComponent as? StateTreeNode<*>)
+            ?.let {
+                if (it == model.root) null
+                else it
+            }
+
+
+    init {
+        emptyText.text = TemplateListEditor.EMPTY_TEXT
+        isRootVisible = false
+        selectionModel.selectionMode = TreeSelectionModel.SINGLE_TREE_SELECTION
+        setCellRenderer(CellRenderer())
+    }
+
+
+    /**
+     * Loads the given list of templates.
+     *
+     * The list loaded there will be contained directly in this tree. Addition, removal, and reordering of templates or
+     * schemes from this tree will be synchronised with [list], and vice versa.
+     *
+     * @param list the state to load into the tree
+     */
+    fun loadList(list: TemplateList) {
+        myModel.setRoot(TemplateListTreeNode(list))
+        myModel.reload()
+
+        root.children().toList().forEach { expandPath(getPathToRoot(it)) }
+        root.firstLeaf()?.also { selectionPath = getPathToRoot(it) }
+    }
+
+
+    /**
+     * Adds the given scheme at an appropriate location in the tree based on the currently selected node.
+     *
+     * @param newScheme the scheme to add. Must be an instance of [Template] if [selectedNode] is null.
+     */
+    fun addScheme(newScheme: Scheme) {
+        val root = myModel.root as TemplateListTreeNode
+        val selectedNode = selectedNode
+
+        val (childNode, parent, index) =
+            if (selectedNode == null) {
+                if (newScheme is Template)
+                    Triple(TemplateTreeNode(newScheme), root, root.childCount)
+                else
+                    error("Cannot add non-template to root.")
+            } else if (selectedNode is TemplateTreeNode) {
+                if (newScheme is Template)
+                    Triple(TemplateTreeNode(newScheme), root, root.getIndex(selectedNode) + 1)
+                else
+                    Triple(SchemeTreeNode(newScheme), selectedNode, selectedNode.childCount)
+            } else if (selectedNode is SchemeTreeNode) {
+                if (newScheme is Template)
+                    Triple(TemplateTreeNode(newScheme), root, root.getIndex(selectedNode.parent) + 1)
+                else
+                    selectedNode.parent!!.let { Triple(SchemeTreeNode(newScheme), it, it.getIndex(selectedNode) + 1) }
+            } else {
+                error("Unknown node type '${selectedNode.javaClass.canonicalName}'.")
+            }
+
+        myModel.insertNodeInto(childNode, parent, index)
+        selectionPath = getPathToRoot(childNode)
+        expandPath(selectionPath)
+    }
+
+    /**
+     * Removes the given node from the tree, and selects an appropriate other node.
+     *
+     * @param node the node to remove
+     */
+    fun removeNode(node: StateTreeNode<*>) {
+        val parent = node.parent as StateTreeNode<*>
+        val oldIndex = parent.getIndex(node)
+
+        myModel.removeNodeFromParent(node)
+        if (parent.isLeaf && parent == myModel.root)
+            clearSelection()
+        else
+            selectionPath =
+                getPathToRoot(
+                    if (parent.isLeaf) parent
+                    else parent.getChildAt(min(oldIndex, parent.childCount - 1))
+                )
+    }
+
+    /**
+     * Moves the given node down the given number of positions.
+     *
+     * The node will be moved down relative to its siblings. The parent does not change.
+     *
+     * @param node the node to move down
+     * @param positions the number of positions to move the node down by within its parent; can be negative
+     */
+    fun moveNodeDownBy(node: StateTreeNode<*>, positions: Int) {
+        if (positions == 0) return
+
+        val parent = node.parent as StateTreeNode<*>
+        val oldIndex = parent.getIndex(node)
+
+        myModel.removeNodeFromParent(node)
+        myModel.insertNodeInto(node, parent, oldIndex + positions)
+        selectionPath = getPathToRoot(node)
+        expandPath(selectionPath)
+    }
+
+    /**
+     * Selects the template with the given UUID, if it exists; otherwise, nothing happens.
+     *
+     * @param targetUuid the UUID of the template to select
+     * @return true if and only if the template was found and selected
+     */
+    fun selectTemplate(targetUuid: String) =
+        root.children().toList().firstOrNull { it.state.uuid == targetUuid }
+            ?.also { selectionPath = getPathToRoot(it) } != null
+
+
+    /**
+     * Returns the path from the given node to the root path, including both ends.
+     *
+     * @param treeNode the node to return the path to root from
+     * @return the path from the given node to the root path, including both ends
+     */
+    private fun getPathToRoot(treeNode: TreeNode) = TreePath(myModel.getPathToRoot(treeNode))
+
+
+    /**
+     * Renders a cell in the tree.
+     */
+    private inner class CellRenderer : ColoredTreeCellRenderer() {
+        override fun customizeCellRenderer(
+            tree: JTree,
+            value: Any?,
+            selected: Boolean,
+            expanded: Boolean,
+            leaf: Boolean,
+            row: Int,
+            hasFocus: Boolean
+        ) {
+            val scheme = (value as StateTreeNode<*>).state as? Scheme
+            if (scheme == null) {
+                append("<unknown>")
+                return
+            }
+
+            icon = scheme.icon
+
+            append(
+                scheme.name.ifBlank { "<empty>" },
+                when {
+                    scheme.doValidate() != null -> SimpleTextAttributes.ERROR_ATTRIBUTES
+                    isModified(scheme) -> SimpleTextAttributes.LINK_PLAIN_ATTRIBUTES
+                    else -> SimpleTextAttributes.REGULAR_ATTRIBUTES
+                }
+            )
+        }
+    }
+
+
+    /**
+     * A mutable tree node that contains a state of type [S].
+     *
+     * The node is mutable in the sense that its [state] is mutable, but the reference to the state is not.
+     *
+     * `StateTreeNode`s are peculiar in that its parent and all its children must also be `StateTreeNode`s.
+     *
+     * @param S the type of state contained in the mutable tree node
+     */
+    sealed class StateTreeNode<S : State> : MutableTreeNode {
+        /**
+         * The parent of this node.
+         */
+        private var _parent: StateTreeNode<*>? = null
+
+        /**
+         * The mutable [State] contained in this node.
+         */
+        abstract val state: S
+
+
+        /**
+         * Returns the parent of this node, as assigned through [setParent], or `null` if there is no parent (anymore).
+         *
+         * @return the parent of this node
+         */
+        override fun getParent(): StateTreeNode<*>? = _parent
+
+        /**
+         * Sets the parent of this node.
+         *
+         * @param newParent the new parent of this node, or `null` if the parent should be removed; must be an instance
+         * of [StateTreeNode]
+         */
+        override fun setParent(newParent: MutableTreeNode?) {
+            require(newParent is StateTreeNode<*>?) { "Parent of StateTreeNode must be a StateTreeNode." }
+
+            _parent = newParent
+        }
+
+        /**
+         * Removes this node as a child from its parent.
+         *
+         * Note that this does not remove this node's reference to its parent; use [setParent] for that.
+         */
+        override fun removeFromParent() {
+            _parent?.remove(this)
+        }
+
+
+        /**
+         * Returns the children of this node, all of which are `StateTreeNode`s.
+         *
+         * If this node does not or cannot contain children, an empty enumeration is returned.
+         *
+         * @return the children of this node
+         */
+        abstract override fun children(): Enumeration<out StateTreeNode<*>>
+
+        /**
+         * Returns the child at the given index.
+         *
+         * If the node cannot have children or the index is out of bounds, an exception is thrown.
+         *
+         * @param childIndex the index of the child to retrieve, corresponding to the ordering in [children]
+         * @return the child at the given index
+         */
+        abstract override fun getChildAt(childIndex: Int): StateTreeNode<*>
+
+
+        /**
+         * Not implemented; [state] cannot be replaced by another instance.
+         *
+         * @param userObject ignored
+         * @throws UnsupportedOperationException this method has not been implemented
+         */
+        final override fun setUserObject(userObject: Any?) =
+            throw UnsupportedOperationException("Cannot replace state of StateTreeNode.")
+    }
+
+    /**
+     * A [StateTreeNode] of which the children correspond directly to a field in [state].
+     *
+     * Modifications to the children of this node directly affect the entries in [state] through the [entries] field.
+     *
+     * @param S the type of state represented by this node
+     * @param T the type of state contained as children in an [S]
+     */
+    sealed class StateTreeListNode<S : State, T : State> : StateTreeNode<S>() {
+        /**
+         * The entries of [T] contained in [state].
+         *
+         * This field connects this node's children to the backing field in [state], so that this field can be modified
+         * to modify [state] whenever the children of this node are changed.
+         */
+        protected abstract var entries: List<T>
+
+
+        /**
+         * Creates a node containing [child] that can be added to this node.
+         *
+         * @param child the child to wrap in a node
+         * @return the child wrapped in a node
+         */
+        abstract fun createChildNodeFor(child: T): StateTreeNode<T>
+
+
+        /**
+         * Returns true.
+         *
+         * @return true
+         */
+        override fun getAllowsChildren() = true
+
+        /**
+         * Returns the schemes in [state] mapped to nodes.
+         *
+         * This method creates new nodes each time it is called, but the nodes wrap the same [Scheme] instances.
+         *
+         * @return the schemes in [state] mapped to nodes
+         */
+        override fun children(): Enumeration<StateTreeNode<T>> =
+            Collections.enumeration(entries.map { createChildNodeFor(it) }.onEach { it.setParent(this) })
+
+        /**
+         * Returns the child at the given index.
+         *
+         * If the index is out of bounds, an exception is thrown.
+         *
+         * @param childIndex the index of the child to retrieve, corresponding to the ordering in [children]
+         * @return the child at the given index
+         */
+        override fun getChildAt(childIndex: Int): StateTreeNode<T> =
+            createChildNodeFor(entries[childIndex]).also { it.setParent(this) }
+
+        /**
+         * Returns the number of schemes in [state].
+         *
+         * @return the number of schemes in [state]
+         */
+        override fun getChildCount() = entries.size
+
+        /**
+         * Returns true if and only if [state] has no schemes.
+         *
+         * @return true if and only if [state] has no schemes
+         */
+        override fun isLeaf() = entries.isEmpty()
+
+
+        /**
+         * Returns the index of the child's scheme in [state]'s schemes, or -1 if [child] is not a child of this node.
+         *
+         * @param child the child to return the index of
+         * @return the index of the child's scheme in [state]'s schemes, or -1 if [child] is not a child of this node
+         */
+        override fun getIndex(child: TreeNode?): Int {
+            if (child !is StateTreeNode<*>) return -1
+
+            return entries.indexOfFirst { it.uuid == child.state.uuid }
+        }
+
+        /**
+         * Adds the child's scheme to [state]'s schemes.
+         *
+         * @param node the child of which the scheme should be added to [state]
+         * @param index the index to insert the scheme at; should be in the range 0..[getChildCount]
+         */
+        @Suppress("UNCHECKED_CAST") // No way around it because we're breaking covariance
+        override fun insert(node: MutableTreeNode, index: Int) {
+            require(node is StateTreeNode<*>) { "Cannot add child that does not contain a Scheme." }
+
+            node.setParent(this)
+            entries = entries.toMutableList().also { it.add(index, node.state as T) }
+        }
+
+        /**
+         * Removes the child at the given index from this node.
+         *
+         * If the index is out of bounds, an exception is thrown.
+         *
+         * @param index the index of the child to remove
+         */
+        override fun remove(index: Int) {
+            getChildAt(index).setParent(null)
+            entries = entries.toMutableList().also { it.removeAt(index) }
+        }
+
+        /**
+         * Removes the given node as a child from this node.
+         *
+         * If the given node is not a child of this node, an exception is thrown.
+         *
+         * @param child the node to remove as a child from this node; must be a [SchemeTreeNode]
+         */
+        override fun remove(child: MutableTreeNode?) = remove(getIndex(child))
+    }
+
+    /**
+     * A [StateTreeListNode] for a [TemplateList], which is composed of [Template]s.
+     *
+     * @property state the template list represented by this node; its templates are this node's children
+     */
+    class TemplateListTreeNode(override val state: TemplateList) : StateTreeListNode<TemplateList, Template>() {
+        override var entries: List<Template>
+            get() = state.templates
+            set(value) {
+                state.templates = value.toList()
+            }
+
+
+        override fun createChildNodeFor(child: Template) = TemplateTreeNode(child)
+
+
+        /**
+         * Returns the depth-first node without children in the tree rooted at this node that is not this node, or
+         * `null` if no such node exists.
+         *
+         * @return the depth-first node without children in the tree rooted at this node that is not this node, or
+         * `null` if no such node exists
+         */
+        fun firstLeaf() =
+            if (isLeaf) null
+            else if (getChildAt(0).isLeaf) getChildAt(0)
+            else getChildAt(0).getChildAt(0)
+    }
+
+    /**
+     * A [StateTreeListNode] for [Template]s, which is composed of [Scheme]s.
+     *
+     * @property state the template represented by this node; its schemes are this node's children
+     */
+    class TemplateTreeNode(override val state: Template) : StateTreeListNode<Template, Scheme>() {
+        override var entries: List<Scheme>
+            get() = state.schemes
+            set(value) {
+                state.schemes = value.toList()
+            }
+
+
+        override fun createChildNodeFor(child: Scheme) = SchemeTreeNode(child)
+    }
+
+    /**
+     * A [StateTreeNode] for [Scheme]s.
+     *
+     * @property state the scheme represented by this node
+     */
+    class SchemeTreeNode(override val state: Scheme) : StateTreeNode<Scheme>() {
+        /**
+         * Returns false.
+         *
+         * @return false
+         */
+        override fun getAllowsChildren() = false
+
+        /**
+         * Returns an empty enumeration.
+         *
+         * @return an empty enumeration
+         */
+        override fun children(): Enumeration<StateTreeNode<*>> = Collections.emptyEnumeration()
+
+        /**
+         * Not implemented; schemes cannot contain children.
+         *
+         * @param childIndex ignored
+         * @throws UnsupportedOperationException this method has not been implemented
+         */
+        override fun getChildAt(childIndex: Int) = throw UnsupportedOperationException(NO_CHILDREN_MESSAGE)
+
+        /**
+         * Returns 0.
+         *
+         * @return 0
+         */
+        override fun getChildCount() = 0
+
+        /**
+         * Returns true.
+         *
+         * @return true
+         */
+        override fun isLeaf() = true
+
+
+        /**
+         * Returns -1 as this node cannot contain children.
+         *
+         * @param child ignored
+         * @return -1
+         */
+        override fun getIndex(child: TreeNode?) = -1
+
+        /**
+         * Not implemented; schemes cannot contain children.
+         *
+         * @param child ignored
+         * @param index ignored
+         * @throws UnsupportedOperationException this method has not been implemented
+         */
+        override fun insert(child: MutableTreeNode?, index: Int) =
+            throw UnsupportedOperationException(NO_CHILDREN_MESSAGE)
+
+        /**
+         * Not implemented; schemes cannot contain children.
+         *
+         * @param childIndex ignored
+         * @throws UnsupportedOperationException this method has not been implemented
+         */
+        override fun remove(childIndex: Int) = throw UnsupportedOperationException(NO_CHILDREN_MESSAGE)
+
+        /**
+         * Not implemented; schemes cannot contain children.
+         *
+         * @param child ignored
+         * @throws UnsupportedOperationException this method has not been implemented
+         */
+        override fun remove(child: MutableTreeNode?) = throw UnsupportedOperationException(NO_CHILDREN_MESSAGE)
+
+
+        /**
+         * Holds constants.
+         */
+        companion object {
+            /**
+             * The exception message when an unsupported function is invoked.
+             */
+            const val NO_CHILDREN_MESSAGE = "Schemes cannot have children."
+        }
+    }
+}

--- a/src/main/kotlin/com/fwdekker/randomness/ui/ListenerHelper.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/ui/ListenerHelper.kt
@@ -11,6 +11,8 @@ import javax.swing.JSpinner
 import javax.swing.JTextField
 import javax.swing.event.DocumentEvent
 import javax.swing.event.DocumentListener
+import javax.swing.event.TreeModelEvent
+import javax.swing.event.TreeModelListener
 import javax.swing.text.Document
 
 
@@ -112,4 +114,39 @@ class MouseClickListener(private val listener: (MouseEvent?) -> Unit) : MouseLis
      * @param event ignored
      */
     override fun mouseExited(event: MouseEvent?) = Unit
+}
+
+/**
+ * A [TreeModelListener] that invokes the same listener on each event.
+ *
+ * @property listener The listener to invoke on any event.
+ */
+class SimpleTreeModelListener(private val listener: () -> Unit) : TreeModelListener {
+    /**
+     * Invoked after a node has changed.
+     *
+     * @param event ignored
+     */
+    override fun treeNodesChanged(event: TreeModelEvent) = listener()
+
+    /**
+     * Invoked after a node has been inserted.
+     *
+     * @param event ignored
+     */
+    override fun treeNodesInserted(event: TreeModelEvent) = listener()
+
+    /**
+     * Invoked after a node has been removed.
+     *
+     * @param event ignored
+     */
+    override fun treeNodesRemoved(event: TreeModelEvent) = listener()
+
+    /**
+     * Invoked after the structure of the tree has changed.
+     *
+     * @param event ignored
+     */
+    override fun treeStructureChanged(event: TreeModelEvent) = listener()
 }

--- a/src/test/kotlin/com/fwdekker/randomness/Dummies.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/Dummies.kt
@@ -22,7 +22,7 @@ data class DummyScheme(
     override var decorator: ArraySchemeDecorator = ArraySchemeDecorator()
 ) : Scheme() {
     override var icons: RandomnessIcons? = RandomnessIcons.Data
-    override var name = "Dummy"
+    override var name = literals.joinToString()
 
 
     override fun generateUndecoratedStrings(count: Int) = List(count) { literals[it % literals.size] }

--- a/src/test/kotlin/com/fwdekker/randomness/SettingsStateTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/SettingsStateTest.kt
@@ -1,0 +1,115 @@
+package com.fwdekker.randomness
+
+import com.fwdekker.randomness.string.SymbolSetSettings
+import com.fwdekker.randomness.template.Template
+import com.fwdekker.randomness.template.TemplateList
+import com.fwdekker.randomness.template.TemplateReference
+import com.fwdekker.randomness.word.UserDictionary
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+
+/**
+ * Unit tests for [SettingsState].
+ */
+object SettingsStateTest : Spek({
+    lateinit var state: SettingsState
+
+
+    beforeEachTest {
+        state = SettingsState(symbolSetSettings = SymbolSetSettings(mapOf("film" to "C0ouF")))
+    }
+
+
+    describe("doValidate") {
+        it("passes for the default values") {
+            assertThat(state.doValidate()).isNull()
+        }
+
+        it("fails if the template list is invalid") {
+            state.templateList.templates = listOf(Template(name = "Among"), Template(name = "Among"))
+
+            assertThat(state.doValidate()).isNotNull()
+        }
+
+        it("fails if the symbol set settings are invalid") {
+            state.symbolSetSettings.symbolSets = mapOf("" to "9KNKtWw")
+
+            assertThat(state.doValidate()).isNotNull()
+        }
+
+        it("fails if the dictionary settings are invalid") {
+            state.dictionarySettings.dictionaries = setOf(UserDictionary("does_not_exist.dic"))
+
+            assertThat(state.doValidate()).isNotNull()
+        }
+    }
+
+    describe("copyFrom") {
+        it("cannot copy from another type") {
+            assertThatThrownBy { state.copyFrom(DummyScheme()) }.isNotNull()
+        }
+
+        it("copies the other's UUIDs") {
+            val other = SettingsState()
+
+            state.copyFrom(other)
+
+            assertThat(state.uuid).isEqualTo(other.uuid)
+            assertThat(state.templateList.uuid).isEqualTo(other.templateList.uuid)
+            assertThat(state.symbolSetSettings.uuid).isEqualTo(other.symbolSetSettings.uuid)
+            assertThat(state.dictionarySettings.uuid).isEqualTo(other.dictionarySettings.uuid)
+        }
+
+        it("writes deep copies into the target's settings fields") {
+            val otherState = SettingsState()
+
+            state.copyFrom(otherState)
+
+            assertThat(state.templateList)
+                .isEqualTo(otherState.templateList)
+                .isNotSameAs(otherState.templateList)
+            assertThat(state.symbolSetSettings)
+                .isEqualTo(otherState.symbolSetSettings)
+                .isNotSameAs(otherState.symbolSetSettings)
+            assertThat(state.dictionarySettings)
+                .isEqualTo(otherState.dictionarySettings)
+                .isNotSameAs(otherState.dictionarySettings)
+        }
+
+        it("writes itself into the template list's templates") {
+            val otherState = SettingsState(TemplateList.from(TemplateReference()))
+
+            state.copyFrom(otherState)
+
+            assertThat(+(state.templateList.templates[0].schemes[0] as TemplateReference).templateList)
+                .isSameAs(state.templateList)
+        }
+    }
+
+    describe("deepCopy") {
+        it("retains its own UUID if retainUuid is true") {
+            val oldUuid = state.uuid
+
+            assertThat(state.deepCopy(retainUuid = true).uuid).isEqualTo(oldUuid)
+        }
+
+        it("does not retain its own UUID if retainUuid is false") {
+            val oldUuid = state.uuid
+
+            assertThat(state.deepCopy(retainUuid = false).uuid).isNotEqualTo(oldUuid)
+        }
+
+        it("writes itself into the template list's templates") {
+            val reference = TemplateReference()
+            state.templateList = TemplateList.from(reference)
+
+            val copy = state.deepCopy()
+
+            assertThat(+(copy.templateList.templates[0].schemes[0] as TemplateReference).templateList)
+                .isSameAs(copy.templateList)
+        }
+    }
+})

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateListEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateListEditorTest.kt
@@ -94,6 +94,9 @@ object TemplateListEditorTest : Spek({
                     frame.tree().target().clearSelection()
                     frame.clickActionButton("Remove")
                 }
+
+                assertThat(editor.readState().templateList.templates.map { it.name })
+                    .containsExactly("Further", "Enclose", "Student")
             }
 
             it("removes the selected template") {
@@ -117,6 +120,16 @@ object TemplateListEditorTest : Spek({
         }
 
         describe("copy") {
+            it("does nothing if no node is selected") {
+                GuiActionRunner.execute {
+                    frame.tree().target().clearSelection()
+                    frame.clickActionButton("Copy")
+                }
+
+                assertThat(editor.readState().templateList.templates.map { it.name })
+                    .containsExactly("Further", "Enclose", "Student")
+            }
+
             it("places a copy of the template underneath the selected template") {
                 GuiActionRunner.execute {
                     frame.tree().target().setSelectionRow(3)
@@ -158,6 +171,17 @@ object TemplateListEditorTest : Spek({
         }
 
         describe("move up/down") {
+            it("does nothing if no node is selected") {
+                GuiActionRunner.execute {
+                    frame.tree().target().clearSelection()
+                    frame.clickActionButton("Up")
+                    frame.clickActionButton("Down")
+                }
+
+                assertThat(editor.readState().templateList.templates.map { it.name })
+                    .containsExactly("Further", "Enclose", "Student")
+            }
+
             it("marks the editor as modified if two templates are reordered") {
                 GuiActionRunner.execute {
                     frame.tree().target().setSelectionRow(0)
@@ -169,8 +193,8 @@ object TemplateListEditorTest : Spek({
 
             it("marks the editor as modified if two schemes are reordered") {
                 GuiActionRunner.execute {
-                    frame.tree().target().setSelectionRow(1)
-                    frame.clickActionButton("Down")
+                    frame.tree().target().setSelectionRow(2)
+                    frame.clickActionButton("Up")
                 }
 
                 assertThat(editor.isModified()).isTrue()

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateListTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateListTest.kt
@@ -117,7 +117,7 @@ object TemplateListTest : Spek({
         it("fails if the single template is invalid") {
             templateList.templates = listOf(Template("Gold", listOf(DummyScheme.from(DummyScheme.INVALID_OUTPUT))))
 
-            assertThat(templateList.doValidate()).startsWith("Gold > Dummy > ")
+            assertThat(templateList.doValidate()).startsWith("Gold > ${DummyScheme.INVALID_OUTPUT} > ")
         }
 
         it("fails if multiple templates have the same name") {
@@ -135,7 +135,7 @@ object TemplateListTest : Spek({
                 Template(name = "Honesty")
             )
 
-            assertThat(templateList.doValidate()).startsWith("View > Dummy > ")
+            assertThat(templateList.doValidate()).startsWith("View > ${DummyScheme.INVALID_OUTPUT} > ")
         }
     }
 

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateTest.kt
@@ -136,7 +136,7 @@ object TemplateTest : Spek({
         it("fails if the single scheme is invalid") {
             template.schemes = listOf(DummyScheme.from(DummyScheme.INVALID_OUTPUT))
 
-            assertThat(template.doValidate()).isEqualTo("Dummy > Invalid input!")
+            assertThat(template.doValidate()).isEqualTo("${DummyScheme.INVALID_OUTPUT} > Invalid input!")
         }
 
         it("fails if one of multiple schemes is invalid") {
@@ -147,7 +147,7 @@ object TemplateTest : Spek({
                 DummyScheme()
             )
 
-            assertThat(template.doValidate()).isEqualTo("Dummy > Invalid input!")
+            assertThat(template.doValidate()).isEqualTo("${DummyScheme.INVALID_OUTPUT} > Invalid input!")
         }
     }
 

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateTreeTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateTreeTest.kt
@@ -1,0 +1,515 @@
+package com.fwdekker.randomness.template
+
+import com.fwdekker.randomness.DummyScheme
+import com.fwdekker.randomness.Scheme
+import com.fwdekker.randomness.ui.SimpleTreeModelListener
+import com.intellij.testFramework.fixtures.IdeaTestFixture
+import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.assertj.swing.edt.GuiActionRunner
+import org.assertj.swing.fixture.Containers
+import org.assertj.swing.fixture.FrameFixture
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import javax.swing.tree.TreePath
+
+
+/**
+ * Unit tests for [TemplateTree].
+ *
+ * @see TemplateListEditorTest
+ */
+object TemplateTreeTest : Spek({
+    lateinit var ideaFixture: IdeaTestFixture
+    lateinit var frame: FrameFixture
+
+    lateinit var basicTemplates: TemplateList // Not loaded by default, but easy to reuse
+    lateinit var tree: TemplateTree
+
+
+    beforeEachTest {
+        ideaFixture = IdeaTestFixtureFactory.getFixtureFactory().createBareFixture()
+        ideaFixture.setUp()
+
+        basicTemplates = TemplateList(
+            listOf(
+                Template("Small", listOf(DummyScheme.from("a"), DummyScheme.from("b"), DummyScheme.from("c"))),
+                Template("Clock", listOf(DummyScheme.from("d"), DummyScheme.from("e"))),
+                Template("Bite", listOf(DummyScheme.from("f"), DummyScheme.from("g")))
+            )
+        )
+        tree = GuiActionRunner.execute<TemplateTree> { TemplateTree { false } }
+        frame = Containers.showInFrame(tree)
+    }
+
+    afterEachTest {
+        frame.cleanUp()
+        ideaFixture.tearDown()
+    }
+
+
+    describe("loadState") {
+        it("loads the given templates and schemes into the tree") {
+            GuiActionRunner.execute { tree.loadList(basicTemplates) }
+
+            val templates = tree.root.children().toList()
+            assertThat(templates.map { it.state.name }).containsExactly("Small", "Clock", "Bite")
+
+            val schemes = templates.flatMap { it.children().toList() }
+            assertThat(schemes.map { (it.state as Scheme).name }).containsExactly("a", "b", "c", "d", "e", "f", "g")
+        }
+
+        it("loads other templates and schemes into the tree") {
+            GuiActionRunner.execute { tree.loadList(basicTemplates) }
+
+            val otherTemplates = TemplateList(listOf(Template("Deserve"), Template("Charge")))
+            GuiActionRunner.execute { tree.loadList(otherTemplates) }
+
+            assertThat(tree.root.children().toList().map { it.state.name }).containsExactly("Deserve", "Charge")
+        }
+
+        describe("synchronization") {
+            it("synchronizes with external template additions after a reset") {
+                GuiActionRunner.execute { tree.loadList(basicTemplates) }
+
+                basicTemplates.templates = listOf(Template("Rail"))
+                GuiActionRunner.execute { tree.myModel.reload() }
+
+                assertThat(tree.root.children().toList().map { it.state.name }).containsExactly("Rail")
+            }
+
+            it("synchronizes with external scheme additions after a reset") {
+                GuiActionRunner.execute { tree.loadList(basicTemplates) }
+
+                basicTemplates.templates[0].schemes = listOf(DummyScheme.from("fear"))
+                GuiActionRunner.execute { tree.myModel.reload() }
+
+                assertThat(tree.root.children().toList()[0].children().toList().map { (it.state as Scheme).name })
+                    .containsExactly("fear")
+            }
+        }
+
+        describe("selection") {
+            it("selects the first scheme after reload") {
+                GuiActionRunner.execute {
+                    tree.loadList(TemplateList(listOf(Template("Furnish", listOf(DummyScheme())))))
+                }
+
+                assertThat(tree.isRowSelected(1)).isTrue()
+            }
+
+            it("selects the first template if it does not have any schemes") {
+                GuiActionRunner.execute {
+                    tree.loadList(
+                        TemplateList(listOf(Template("Flame", emptyList()), Template("Pen", listOf(DummyScheme()))))
+                    )
+                }
+
+                assertThat(tree.isRowSelected(0)).isTrue()
+            }
+
+            it("does nothing if no templates or schemes are loaded") {
+                GuiActionRunner.execute { tree.loadList(TemplateList(emptyList())) }
+
+                assertThat(tree.selectedNode).isNull()
+            }
+        }
+    }
+
+
+    describe("addScheme") {
+        beforeEachTest {
+            GuiActionRunner.execute { tree.loadList(basicTemplates) }
+        }
+
+
+        describe("add template") {
+            it("adds the template to the bottom if no node is selected") {
+                GuiActionRunner.execute {
+                    tree.clearSelection()
+                    tree.addScheme(Template(name = "Game"))
+                }
+
+                assertThat(tree.isRowSelected(10))
+                assertThat(tree.root.children().toList().map { it.state.name })
+                    .containsExactly("Small", "Clock", "Bite", "Game")
+                assertThat(basicTemplates.templates.map { it.name })
+                    .containsExactly("Small", "Clock", "Bite", "Game")
+            }
+
+            it("adds the template underneath the currently selected template") {
+                GuiActionRunner.execute {
+                    frame.tree().target().setSelectionRow(4)
+                    tree.addScheme(Template(name = "Flower"))
+                }
+
+                assertThat(tree.isRowSelected(7))
+                assertThat(tree.root.children().toList().map { it.state.name })
+                    .containsExactly("Small", "Clock", "Flower", "Bite")
+                assertThat(basicTemplates.templates.map { it.name })
+                    .containsExactly("Small", "Clock", "Flower", "Bite")
+            }
+
+            it("adds the template underneath the parent of the currently selected scheme") {
+                GuiActionRunner.execute {
+                    frame.tree().target().setSelectionRow(2)
+                    tree.addScheme(Template(name = "Agency"))
+                }
+
+                assertThat(tree.isRowSelected(4))
+                assertThat(tree.root.children().toList().map { it.state.name })
+                    .containsExactly("Small", "Agency", "Clock", "Bite")
+                assertThat(basicTemplates.templates.map { it.name })
+                    .containsExactly("Small", "Agency", "Clock", "Bite")
+            }
+        }
+
+        describe("add scheme") {
+            it("fails if no node is selected") {
+                GuiActionRunner.execute {
+                    frame.tree().target().clearSelection()
+
+                    assertThatThrownBy { tree.addScheme(DummyScheme()) }
+                        .isInstanceOf(IllegalStateException::class.java)
+                        .hasMessage("Cannot add non-template to root.")
+                }
+            }
+
+            it("adds the scheme at the bottom of the selected template") {
+                GuiActionRunner.execute {
+                    frame.tree().target().setSelectionRow(7)
+                    tree.addScheme(DummyScheme.from("z"))
+                }
+
+                assertThat(tree.isRowSelected(4))
+                assertThat(tree.root.children().toList()[2].children().toList().map { (it.state as DummyScheme).name })
+                    .containsExactly("f", "g", "z")
+                assertThat(basicTemplates.templates[2].schemes.map { it.name })
+                    .containsExactly("f", "g", "z")
+            }
+
+            it("adds the scheme underneath the currently selected scheme") {
+                GuiActionRunner.execute {
+                    frame.tree().target().setSelectionRow(1)
+                    tree.addScheme(DummyScheme.from("z"))
+                }
+
+                assertThat(tree.isRowSelected(2))
+                assertThat(tree.root.children().toList()[0].children().toList().map { (it.state as DummyScheme).name })
+                    .containsExactly("a", "z", "b", "c")
+                assertThat(basicTemplates.templates[0].schemes.map { it.name })
+                    .containsExactly("a", "z", "b", "c")
+            }
+        }
+    }
+
+    describe("removeNode") {
+        beforeEachTest {
+            GuiActionRunner.execute { tree.loadList(basicTemplates) }
+        }
+
+
+        describe("remove template") {
+            it("removes the template from the tree") {
+                GuiActionRunner.execute {
+                    tree.setSelectionRow(0)
+                    tree.removeNode(tree.selectedNode!!)
+                }
+
+                assertThat(tree.root.children().toList().map { it.state.name }).containsExactly("Clock", "Bite")
+            }
+
+            it("removes the template from the model") {
+                GuiActionRunner.execute {
+                    tree.setSelectionRow(4)
+                    tree.removeNode(tree.selectedNode!!)
+                }
+
+                assertThat(basicTemplates.templates.map { it.name }).containsExactly("Small", "Bite")
+            }
+
+            it("selects nothing if the last template is removed") {
+                GuiActionRunner.execute {
+                    repeat(3) {
+                        tree.setSelectionRow(0)
+                        tree.removeNode(tree.selectedNode!!)
+                    }
+                }
+
+                assertThat(tree.selectedNode).isNull()
+            }
+
+            it("selects the next template if a non-bottom template is removed") {
+                GuiActionRunner.execute {
+                    tree.setSelectionRow(4)
+                    tree.removeNode(tree.selectedNode!!)
+                }
+
+                assertThat((tree.selectedNode?.state as Template).name).isEqualTo("Bite")
+                assertThat(tree.isRowSelected(4))
+            }
+
+            it("selects the new bottom template if the bottom template is removed") {
+                GuiActionRunner.execute {
+                    tree.setSelectionRow(7)
+                    tree.removeNode(tree.selectedNode!!)
+                }
+
+                assertThat((tree.selectedNode?.state as Template).name).isEqualTo("Clock")
+                assertThat(tree.isRowSelected(4))
+            }
+        }
+
+        describe("remove scheme") {
+            it("removes the scheme from the tree") {
+                GuiActionRunner.execute {
+                    tree.setSelectionRow(2)
+                    tree.removeNode(tree.selectedNode!!)
+                }
+
+                val schemes = tree.root.children().toList()[0].children().toList()
+                assertThat(schemes.map { (it.state as DummyScheme).name }).containsExactly("a", "c")
+            }
+
+            it("removes the scheme from the model") {
+                GuiActionRunner.execute {
+                    tree.setSelectionRow(6)
+                    tree.removeNode(tree.selectedNode!!)
+                }
+
+                val schemes = tree.root.children().toList()[1].children().toList()
+                assertThat(schemes.map { (it.state as DummyScheme).name }).containsExactly("d")
+            }
+
+            it("selects the template if its last scheme is removed") {
+                GuiActionRunner.execute {
+                    repeat(2) {
+                        tree.setSelectionRow(5)
+                        tree.removeNode(tree.selectedNode!!)
+                    }
+                }
+
+                assertThat((tree.selectedNode?.state as Template).name).isEqualTo("Clock")
+                assertThat(tree.isRowSelected(4))
+            }
+
+            it("selects the next scheme if a non-bottom scheme is removed") {
+                GuiActionRunner.execute {
+                    tree.setSelectionRow(1)
+                    tree.removeNode(tree.selectedNode!!)
+                }
+
+                assertThat((tree.selectedNode?.state as Scheme).name).isEqualTo("b")
+                assertThat(tree.isRowSelected(1))
+            }
+
+            it("selects the new bottom scheme if the bottom scheme is removed") {
+                GuiActionRunner.execute {
+                    frame.tree().target().setSelectionRow(9)
+                    tree.removeNode(tree.selectedNode!!)
+                }
+
+                assertThat((tree.selectedNode?.state as Scheme).name).isEqualTo("f")
+                assertThat(tree.isRowSelected(8))
+            }
+        }
+    }
+
+    describe("moveNodeDownBy") {
+        beforeEachTest {
+            GuiActionRunner.execute { tree.loadList(basicTemplates) }
+        }
+
+
+        describe("templates") {
+            it("fails if the template would go too far up") {
+                GuiActionRunner.execute { tree.setSelectionRow(4) }
+
+                assertThatThrownBy { tree.moveNodeDownBy(tree.selectedNode!!, -2) }.isNotNull()
+            }
+
+            it("fails if the template would go too far down") {
+                GuiActionRunner.execute { tree.setSelectionRow(4) }
+
+                assertThatThrownBy { tree.moveNodeDownBy(tree.selectedNode!!, 4) }.isNotNull()
+            }
+
+            it("moves the template up by the given number of positions") {
+                GuiActionRunner.execute {
+                    tree.setSelectionRow(4)
+                    tree.moveNodeDownBy(tree.selectedNode!!, 1)
+                }
+
+                assertThat(tree.root.children().toList().map { it.state.name })
+                    .containsExactly("Small", "Bite", "Clock")
+            }
+
+            it("moves the template down by the given number of positions") {
+                GuiActionRunner.execute {
+                    tree.setSelectionRow(7)
+                    tree.moveNodeDownBy(tree.selectedNode!!, -2)
+                }
+
+                assertThat(tree.root.children().toList().map { it.state.name })
+                    .containsExactly("Bite", "Small", "Clock")
+            }
+
+            it("selects the moved template") {
+                GuiActionRunner.execute {
+                    tree.setSelectionRow(0)
+                    tree.moveNodeDownBy(tree.selectedNode!!, 2)
+                }
+
+                assertThat((tree.selectedNode?.state as Template).name).isEqualTo("Small")
+                assertThat(tree.isRowSelected(6)).isTrue()
+            }
+
+            it("modifies the original list of templates") {
+                GuiActionRunner.execute {
+                    tree.setSelectionRow(4)
+                    tree.moveNodeDownBy(tree.selectedNode!!, 1)
+                }
+
+                assertThat(basicTemplates.templates.map { it.name }).containsExactly("Small", "Bite", "Clock")
+            }
+        }
+
+        describe("schemes") {
+            it("fails if the scheme would go too far up") {
+                GuiActionRunner.execute { tree.setSelectionRow(2) }
+
+                assertThatThrownBy { tree.moveNodeDownBy(tree.selectedNode!!, -2) }.isNotNull()
+            }
+
+            it("fails if the scheme would go too far down") {
+                GuiActionRunner.execute { tree.setSelectionRow(5) }
+
+                assertThatThrownBy { tree.moveNodeDownBy(tree.selectedNode!!, 2) }.isNotNull()
+            }
+
+            it("moves the scheme up by the given number of positions") {
+                GuiActionRunner.execute {
+                    tree.setSelectionRow(3)
+                    tree.moveNodeDownBy(tree.selectedNode!!, -2)
+                }
+
+                val schemes = tree.root.children().toList()[0].children().toList()
+                assertThat(schemes.map { (it.state as DummyScheme).name })
+                    .containsExactly("c", "a", "b")
+            }
+
+            it("moves the scheme down by the given number of positions") {
+                GuiActionRunner.execute {
+                    tree.setSelectionRow(5)
+                    tree.moveNodeDownBy(tree.selectedNode!!, 1)
+                }
+
+                val schemes = tree.root.children().toList()[1].children().toList()
+                assertThat(schemes.map { (it.state as DummyScheme).name }).containsExactly("e", "d")
+            }
+
+            it("selects the moved scheme") {
+                GuiActionRunner.execute {
+                    tree.setSelectionRow(8)
+                    tree.moveNodeDownBy(tree.selectedNode!!, 1)
+                }
+
+                assertThat((tree.selectedNode?.state as DummyScheme).name).isEqualTo("f")
+                assertThat(tree.isRowSelected(9)).isTrue()
+            }
+
+            it("modifies the original list of schemes in the template") {
+                GuiActionRunner.execute {
+                    tree.setSelectionRow(1)
+                    tree.moveNodeDownBy(tree.selectedNode!!, 2)
+                }
+
+                assertThat(basicTemplates.templates[0].schemes.map { (it as DummyScheme).name })
+                    .containsExactly("b", "c", "a")
+            }
+        }
+
+        it("notifies observers of an insertion and of a removal") {
+            var isInvoked = 0
+            tree.myModel.addTreeModelListener(SimpleTreeModelListener { isInvoked++ })
+
+            GuiActionRunner.execute { tree.moveNodeDownBy(tree.selectedNode!!, 1) }
+
+            assertThat(isInvoked).isEqualTo(2)
+        }
+
+        it("does nothing if the number of positions is 0") {
+            var isInvoked = 0
+            tree.myModel.addTreeModelListener(SimpleTreeModelListener { isInvoked++ })
+
+            GuiActionRunner.execute { tree.moveNodeDownBy(tree.selectedNode!!, 0) }
+
+            assertThat(isInvoked).isZero()
+        }
+    }
+
+    describe("selectTemplate") {
+        it("does nothing if no template with the specified UUID can be found") {
+            GuiActionRunner.execute { tree.loadList(basicTemplates) }
+            val initialSelection = tree.selectedNode?.state
+
+            GuiActionRunner.execute { tree.selectTemplate("dae4e446-56de-40ca-8415-5bff1f47f2f4") }
+
+            assertThat(tree.selectedNode?.state).isEqualTo(initialSelection)
+        }
+
+        it("does nothing if the UUID belongs to a scheme in the tree") {
+            GuiActionRunner.execute { tree.loadList(basicTemplates) }
+            val initialSelection = tree.selectedNode?.state
+
+            GuiActionRunner.execute { tree.selectTemplate(basicTemplates.templates[1].schemes[0].uuid) }
+
+            assertThat(tree.selectedNode?.state).isEqualTo(initialSelection)
+        }
+
+        it("selects the template with the given UUID") {
+            GuiActionRunner.execute { tree.loadList(basicTemplates) }
+
+            GuiActionRunner.execute { tree.selectTemplate(basicTemplates.templates[1].uuid) }
+
+            assertThat(tree.selectedNode?.state).isEqualTo(basicTemplates.templates[1])
+        }
+    }
+
+
+    describe("getSelectedNode") {
+        beforeEachTest {
+            GuiActionRunner.execute { tree.loadList(basicTemplates) }
+        }
+
+
+        it("returns null if nothing is selected") {
+            GuiActionRunner.execute { tree.clearSelection() }
+
+            assertThat(tree.selectedNode).isNull()
+        }
+
+        it("returns null if the root is selected") {
+            GuiActionRunner.execute { tree.selectionPath = TreePath(tree.myModel.root) }
+
+            assertThat(tree.selectedNode).isNull()
+        }
+
+        it("returns the selected node if the node is a template") {
+            GuiActionRunner.execute { tree.loadList(basicTemplates) }
+
+            GuiActionRunner.execute { tree.setSelectionRow(4) }
+
+            assertThat((tree.selectedNode?.state as Scheme).name).isEqualTo("Clock")
+        }
+
+        it("returns the selected node if the node is a scheme") {
+            GuiActionRunner.execute { tree.loadList(basicTemplates) }
+
+            GuiActionRunner.execute { tree.setSelectionRow(8) }
+
+            assertThat((tree.selectedNode?.state as Scheme).name).isEqualTo("f")
+        }
+    }
+})


### PR DESCRIPTION
Splits off the part of `TemplateListEditor` that is about showing a tree of templates and moves it into its own class `TemplateTree`, and tests it.