### PR TITLE
UX improvements

### DIFF
--- a/src/main/kotlin/com/fwdekker/randomness/template/TemplateJTree.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/template/TemplateJTree.kt
@@ -4,6 +4,7 @@ import com.fwdekker.randomness.Scheme
 import com.fwdekker.randomness.State
 import com.intellij.ui.ColoredTreeCellRenderer
 import com.intellij.ui.SimpleTextAttributes
+import com.intellij.ui.TreeSpeedSearch
 import com.intellij.ui.treeStructure.Tree
 import java.util.Collections
 import java.util.Enumeration
@@ -24,7 +25,7 @@ import kotlin.math.min
  *
  * @property isModified Returns true if and only if the given scheme has been modified.
  */
-class TemplateTree(
+class TemplateJTree(
     private val isModified: (Scheme) -> Boolean
 ) : Tree(DefaultTreeModel(TemplateListTreeNode(TemplateList(emptyList())))) {
     /**
@@ -54,6 +55,10 @@ class TemplateTree(
 
 
     init {
+        TreeSpeedSearch(this) { path ->
+            path.path.map { (it as StateTreeNode<*>).state }.filterIsInstance<Scheme>().joinToString { it.name }
+        }
+
         emptyText.text = TemplateListEditor.EMPTY_TEXT
         isRootVisible = false
         selectionModel.selectionMode = TreeSelectionModel.SINGLE_TREE_SELECTION
@@ -291,13 +296,13 @@ class TemplateTree(
         abstract override fun children(): Enumeration<out StateTreeNode<*>>
 
         /**
-         * Returns all nodes recursively contained in this node, in no particular order.
+         * Returns all nodes recursively contained in this node in depth-first order.
          *
-         * @return all nodes recursively contained in this node, in no particular order
+         * @return all nodes recursively contained in this node in depth-first order
          */
         fun recursiveChildren(): Enumeration<out StateTreeNode<*>> {
             val children = children().toList()
-            return Collections.enumeration(children.flatMap { it.recursiveChildren().toList() } + children)
+            return Collections.enumeration(children.flatMap { listOf(it) + it.recursiveChildren().toList() })
         }
 
         /**

--- a/src/main/kotlin/com/fwdekker/randomness/template/TemplateListEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/template/TemplateListEditor.kt
@@ -63,12 +63,17 @@ class TemplateListEditor(settings: SettingsState = SettingsState.default) : Stat
     private var schemeEditor: StateEditor<*>? = null
 
     /**
-     * The UUID of the template to select after the next invocation of [reset].
+     * The UUID of the scheme to select after the next invocation of [reset].
      *
      * @see TemplateSettingsConfigurable
      * @see TemplateSettingsAction
      */
     var queueSelection: String? = null
+
+    /**
+     * Whether to focus on the scheme editor after the next invocation of [reset].
+     */
+    var queueFocus: Boolean = false
 
 
     init {
@@ -195,13 +200,20 @@ class TemplateListEditor(settings: SettingsState = SettingsState.default) : Stat
     override fun readState() = currentSettingsState.deepCopy(retainUuid = true)
 
     override fun reset() {
+        if (queueSelection == null) {
+            queueFocus = false
+            queueSelection = templateTree.selectedNode?.state?.uuid
+        }
+
         super.reset()
 
-        queueSelection?.also { selection ->
-            templateTree.selectTemplate(selection)
-            SwingUtilities.invokeLater { schemeEditor?.preferredFocusedComponent?.requestFocus() }
-
+        if (queueSelection != null) {
+            templateTree.selectScheme(queueSelection)
             queueSelection = null
+        }
+        if (queueFocus) {
+            SwingUtilities.invokeLater { schemeEditor?.preferredFocusedComponent?.requestFocus() }
+            queueFocus = false
         }
     }
 

--- a/src/main/kotlin/com/fwdekker/randomness/template/TemplateListEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/template/TemplateListEditor.kt
@@ -20,12 +20,14 @@ import com.fwdekker.randomness.word.WordScheme
 import com.fwdekker.randomness.word.WordSchemeEditor
 import com.intellij.icons.AllIcons
 import com.intellij.openapi.actionSystem.ActionToolbarPosition
+import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.ui.popup.JBPopupFactory
+import com.intellij.openapi.ui.popup.ListSeparator
 import com.intellij.openapi.ui.popup.PopupStep
 import com.intellij.openapi.ui.popup.util.BaseListPopupStep
 import com.intellij.ui.AnActionButton
-import com.intellij.ui.AnActionButtonRunnable
+import com.intellij.ui.CommonActionsPanel
 import com.intellij.ui.JBSplitter
 import com.intellij.ui.LayeredIcon
 import com.intellij.ui.ToolbarDecorator
@@ -53,7 +55,7 @@ import javax.swing.SwingUtilities
 class TemplateListEditor(settings: SettingsState = SettingsState.default) : StateEditor<SettingsState>(settings) {
     override val rootComponent = JPanel(BorderLayout())
     private var currentSettingsState: SettingsState = SettingsState()
-    private val templateTree = TemplateTree { scheme ->
+    private val templateTree = TemplateJTree { scheme ->
         val templates = originalState.templateList.templates
         val schemesAndTemplates = templates.flatMap { it.schemes } + templates
 
@@ -77,7 +79,7 @@ class TemplateListEditor(settings: SettingsState = SettingsState.default) : Stat
 
 
     init {
-        val splitter = JBSplitter(false, DEFAULT_SPLITTER_PROPORTION)
+        val splitter = JBSplitter(false, SPLITTER_PROPORTION_KEY, DEFAULT_SPLITTER_PROPORTION)
         rootComponent.add(splitter, BorderLayout.CENTER)
 
         // Left half
@@ -115,21 +117,23 @@ class TemplateListEditor(settings: SettingsState = SettingsState.default) : Stat
             .setToolbarPosition(ActionToolbarPosition.TOP)
             .setPanelBorder(JBUI.Borders.empty())
             .setScrollPaneBorder(JBUI.Borders.empty())
-            .setAddAction {
-                it.preferredPopupPoint?.let { point ->
-                    JBPopupFactory.getInstance().createListPopup(AddPopupStep()).show(point)
-                }
-            }
-            .setAddActionName("Add")
-            .setAddIcon(LayeredIcon.ADD_WITH_DROPDOWN)
-            .setRemoveAction(RemoveAction())
-            .setRemoveActionName("Remove")
-            .setRemoveActionUpdater { templateTree.selectedNode != null }
+            .disableAddAction()
+            .disableRemoveAction()
+            .addExtraAction(AddSchemeActionButton())
+            .addExtraAction(RemoveActionButton())
             .addExtraAction(CopyActionButton())
             .addExtraAction(UpActionButton())
             .addExtraAction(DownActionButton())
-            .setButtonComparator("Add", "Remove", "Copy", "Up", "Down")
+            .setButtonComparator("Add", "Edit", "Remove", "Copy", "Up", "Down")
             .createPanel()
+            .also {
+                // Focus on editor when `Enter` is pressed
+                object : AnAction() {
+                    override fun actionPerformed(event: AnActionEvent) {
+                        schemeEditor?.preferredFocusedComponent?.requestFocus()
+                    }
+                }.registerCustomShortcutSet(CommonActionsPanel.getCommonShortcut(CommonActionsPanel.Buttons.EDIT), it)
+            }
 
     /**
      * Invoked when an entry is (de)selected in the tree.
@@ -184,7 +188,7 @@ class TemplateListEditor(settings: SettingsState = SettingsState.default) : Stat
      * Adds the given scheme to the tree.
      *
      * @param newScheme the scheme to add
-     * @see TemplateTree.addScheme
+     * @see TemplateJTree.addScheme
      */
     @ActuallyPrivate("Exposed for testing because popup cannot easily be tested.")
     internal fun addScheme(newScheme: Scheme) = templateTree.addScheme(newScheme)
@@ -225,39 +229,33 @@ class TemplateListEditor(settings: SettingsState = SettingsState.default) : Stat
 
 
     /**
-     * The entries to display in a popup when the add button is pressed.
+     * Displays a popup to add a scheme, or immediately adds a template if nothing is currently selected.
      */
-    private inner class AddPopupStep : BaseListPopupStep<String>(null, listOf("Template", "Scheme")) {
-        override fun hasSubstep(selectedValue: String?) = true
-
-        override fun onChosen(selectedValue: String?, finalChoice: Boolean) =
-            when (selectedValue) {
-                "Template" -> AddTemplatePopupStep()
-                "Scheme" -> AddSchemePopupStep()
-                else -> null
+    private inner class AddSchemeActionButton : AnActionButton("Add", AllIcons.General.Add) {
+        override fun actionPerformed(event: AnActionEvent) {
+            if (templateTree.selectedNode == null) {
+                addScheme(AVAILABLE_ADD_SCHEMES[0])
+                return
             }
 
-
-        /**
-         * The [Template]-related entries in [AddPopupStep].
-         */
-        private inner class AddTemplatePopupStep : BaseListPopupStep<Template>(null, AVAILABLE_ADD_TEMPLATES) {
-            override fun getIconFor(value: Template?) = value?.icon
-
-            override fun getTextFor(value: Template?) = value?.name ?: Template.DEFAULT_NAME
-
-            override fun onChosen(value: Template?, finalChoice: Boolean): PopupStep<*>? {
-                if (value != null)
-                    templateTree.addScheme(value.deepCopy().also { it.setSettingsState(currentSettingsState) })
-
-                return null
-            }
-
-            override fun isSpeedSearchEnabled() = true
+            JBPopupFactory.getInstance()
+                .createListPopup(AddSchemePopupStep())
+                .show(preferredPopupPoint ?: return)
         }
 
+        override fun getShortcut() = CommonActionsPanel.getCommonShortcut(CommonActionsPanel.Buttons.ADD)
+
+        override fun updateButton(event: AnActionEvent) {
+            super.updateButton(event)
+
+            event.presentation.icon =
+                if (templateTree.selectedNode == null) AllIcons.General.Add
+                else LayeredIcon.ADD_WITH_DROPDOWN
+        }
+
+
         /**
-         * The [Scheme]-related entries in [AddPopupStep].
+         * The [Scheme]-related entries in [AddSchemeActionButton].
          */
         private inner class AddSchemePopupStep : BaseListPopupStep<Scheme>(null, AVAILABLE_ADD_SCHEMES) {
             override fun getIconFor(value: Scheme?) = value?.icon
@@ -272,16 +270,26 @@ class TemplateListEditor(settings: SettingsState = SettingsState.default) : Stat
             }
 
             override fun isSpeedSearchEnabled() = true
+
+            override fun getSeparatorAbove(value: Scheme?) =
+                if (value == AVAILABLE_ADD_SCHEMES[1]) ListSeparator()
+                else null
+
+            override fun getDefaultOptionIndex() = 0
         }
     }
 
     /**
      * The action to invoke when the remove button is pressed.
      */
-    private inner class RemoveAction : AnActionButtonRunnable {
-        override fun run(t: AnActionButton?) {
-            templateTree.removeNode(templateTree.selectedNode ?: return)
+    private inner class RemoveActionButton : AnActionButton("Remove", AllIcons.General.Remove) {
+        override fun actionPerformed(event: AnActionEvent) {
+            templateTree.selectedNode?.also { templateTree.removeNode(it) }
         }
+
+        override fun isEnabled() = templateTree.selectedNode != null
+
+        override fun getShortcut() = CommonActionsPanel.getCommonShortcut(CommonActionsPanel.Buttons.REMOVE)
     }
 
     /**
@@ -311,6 +319,8 @@ class TemplateListEditor(settings: SettingsState = SettingsState.default) : Stat
             val node = templateTree.selectedNode ?: return false
             return node.parent!!.getIndex(node) > 0
         }
+
+        override fun getShortcut() = CommonActionsPanel.getCommonShortcut(CommonActionsPanel.Buttons.UP)
     }
 
     /**
@@ -325,6 +335,8 @@ class TemplateListEditor(settings: SettingsState = SettingsState.default) : Stat
             val node = templateTree.selectedNode ?: return false
             return node.parent!!.getIndex(node) < node.parent!!.childCount - 1
         }
+
+        override fun getShortcut() = CommonActionsPanel.getCommonShortcut(CommonActionsPanel.Buttons.DOWN)
     }
 
 
@@ -332,6 +344,11 @@ class TemplateListEditor(settings: SettingsState = SettingsState.default) : Stat
      * Holds constants.
      */
     companion object {
+        /**
+         * The key to store the user's last-used splitter proportion under.
+         */
+        const val SPLITTER_PROPORTION_KEY = "com.fwdekker.randomness.template.TemplateListEditor"
+
         /**
          * The default proportion of the splitter component.
          */
@@ -343,22 +360,17 @@ class TemplateListEditor(settings: SettingsState = SettingsState.default) : Stat
         const val EMPTY_TEXT = "No templates configured."
 
         /**
-         * Returns the list of templates that the user can add from the add action.
-         */
-        val AVAILABLE_ADD_TEMPLATES: List<Template>
-            get() = TemplateList.DEFAULT_TEMPLATES
-
-        /**
          * Returns the list of schemes that the user can add from the add action.
          */
         val AVAILABLE_ADD_SCHEMES: List<Scheme>
             get() = listOf(
-                LiteralScheme(),
+                Template("Template", emptyList()),
                 IntegerScheme(),
                 DecimalScheme(),
                 StringScheme(),
                 WordScheme(),
                 UuidScheme(),
+                LiteralScheme(),
                 TemplateReference()
             )
     }

--- a/src/main/kotlin/com/fwdekker/randomness/template/TemplateListEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/template/TemplateListEditor.kt
@@ -88,7 +88,7 @@ class TemplateListEditor(settings: SettingsState = SettingsState.default) : Stat
                     else selectedNode.parent!!.state as Scheme
                 }
 
-            readState().templateList.templates.first { it.uuid == selectedTemplate.uuid }
+            currentSettingsState.templateList.templates.first { it.uuid == selectedTemplate.uuid }
         }
         addChangeListener { previewPanel.updatePreview() }
         schemeEditorPanel.add(previewPanel.rootComponent, BorderLayout.SOUTH)

--- a/src/main/kotlin/com/fwdekker/randomness/template/TemplateSettings.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/template/TemplateSettings.kt
@@ -74,5 +74,8 @@ class TemplateSettingsConfigurable : SettingsConfigurable() {
      */
     override fun getDisplayName() = "Randomness"
 
-    override fun createEditor() = TemplateListEditor().also { it.queueSelection = templateToSelect }
+    override fun createEditor() = TemplateListEditor().also {
+        it.queueFocus = true
+        it.queueSelection = templateToSelect
+    }
 }

--- a/src/main/kotlin/com/fwdekker/randomness/template/TemplateTree.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/template/TemplateTree.kt
@@ -84,8 +84,8 @@ class TemplateTree(
      * @param newScheme the scheme to add. Must be an instance of [Template] if [selectedNode] is null.
      */
     fun addScheme(newScheme: Scheme) {
-        val root = myModel.root as TemplateListTreeNode
         val selectedNode = selectedNode
+        if (newScheme is Template) newScheme.name = findUniqueNameFor(newScheme)
 
         val (childNode, parent, index) =
             if (selectedNode == null) {
@@ -170,6 +170,32 @@ class TemplateTree(
      * @return the path from the given node to the root path, including both ends
      */
     private fun getPathToRoot(treeNode: TreeNode) = TreePath(myModel.getPathToRoot(treeNode))
+
+    /**
+     * Finds a good, unique name for the given template so that it can be inserted into this list without conflict.
+     *
+     * If the name is already unique, that name is returned. Otherwise, the name is appended with the first number `i`
+     * such that `$name ($i)` is unique. If the template's current name already ends with a number in parentheses, that
+     * number is taken as the starting number.
+     *
+     * @param template the template to find a good name for
+     * @return a unique name for the given template
+     */
+    private fun findUniqueNameFor(template: Template): String {
+        val templateNames = root.children().toList().map { it.state.name }
+        if (template.name !in templateNames) return template.name
+
+        var i = 1
+        var name = template.name
+
+        if (name.matches(Regex(".* \\([1-9][0-9]*\\)"))) {
+            i = name.substring(name.lastIndexOf('(') + 1, name.lastIndexOf(')')).toInt()
+            name = name.substring(0, name.lastIndexOf('(') - 1)
+        }
+
+        while ("$name ($i)" in templateNames) i++
+        return "$name ($i)"
+    }
 
 
     /**

--- a/src/main/kotlin/com/fwdekker/randomness/template/TemplateTree.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/template/TemplateTree.kt
@@ -153,13 +153,13 @@ class TemplateTree(
     }
 
     /**
-     * Selects the template with the given UUID, if it exists; otherwise, nothing happens.
+     * Selects the scheme with the given UUID, if it exists; otherwise, nothing happens.
      *
-     * @param targetUuid the UUID of the template to select
-     * @return true if and only if the template was found and selected
+     * @param targetUuid the UUID of the scheme to select, or `null` if nothing should be done
+     * @return true if and only if the scheme was found and selected
      */
-    fun selectTemplate(targetUuid: String) =
-        root.children().toList().firstOrNull { it.state.uuid == targetUuid }
+    fun selectScheme(targetUuid: String?) =
+        root.recursiveChildren().toList().firstOrNull { it.state.uuid == targetUuid }
             ?.also { selectionPath = getPathToRoot(it) } != null
 
 
@@ -289,6 +289,16 @@ class TemplateTree(
          * @return the children of this node
          */
         abstract override fun children(): Enumeration<out StateTreeNode<*>>
+
+        /**
+         * Returns all nodes recursively contained in this node, in no particular order.
+         *
+         * @return all nodes recursively contained in this node, in no particular order
+         */
+        fun recursiveChildren(): Enumeration<out StateTreeNode<*>> {
+            val children = children().toList()
+            return Collections.enumeration(children.flatMap { it.recursiveChildren().toList() } + children)
+        }
 
         /**
          * Returns the child at the given index.

--- a/src/main/kotlin/com/fwdekker/randomness/ui/ActivityTableModelEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/ui/ActivityTableModelEditor.kt
@@ -1,6 +1,5 @@
 package com.fwdekker.randomness.ui
 
-import com.intellij.ide.IdeBundle
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonShortcuts
 import com.intellij.openapi.keymap.KeymapUtil
@@ -108,12 +107,6 @@ abstract class ActivityTableModelEditor<T>(
             )
         }
 
-        val copyAction =
-            object : ToolbarDecorator.ElementActionButton(IdeBundle.message("button.copy"), PlatformIcons.COPY_ICON) {
-                override fun actionPerformed(e: AnActionEvent) = copySelectedItems(table)
-
-                override fun isEnabled() = table.selection.all { isCopyable(it.datum) }
-            }
         // Implementation based on `TableModelEditor#createComponent`
         return TableModelEditor::class.java.getDeclaredField("toolbarDecorator")
             .apply { isAccessible = true }
@@ -123,7 +116,12 @@ abstract class ActivityTableModelEditor<T>(
                 if (table.selectedObject != null)
                     table.editCellAt(table.selectedRow, table.selectedColumn)
             }
-            .addExtraAction(copyAction)
+            .setEditActionUpdater { table.selectedObject?.let { isEditable(it) } == true }
+            .addExtraAction(object : ToolbarDecorator.ElementActionButton("Copy", PlatformIcons.COPY_ICON) {
+                override fun actionPerformed(e: AnActionEvent) = copySelectedItems(table)
+
+                override fun isEnabled() = table.selection.all { isCopyable(it.datum) }
+            })
             .createPanel()
     }
 

--- a/src/main/kotlin/com/fwdekker/randomness/ui/ListenerHelper.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/ui/ListenerHelper.kt
@@ -1,8 +1,6 @@
 package com.fwdekker.randomness.ui
 
 import com.fwdekker.randomness.StateEditor
-import java.awt.event.MouseEvent
-import java.awt.event.MouseListener
 import java.beans.PropertyChangeEvent
 import javax.swing.ButtonGroup
 import javax.swing.JCheckBox
@@ -72,49 +70,6 @@ fun JTextField.addChangeListener(changeListener: (JTextField) -> Unit) {
     this.document.addDocumentListener(dl)
 }
 
-
-/**
- * A [MouseListener] that listens only to mouse clicks.
- *
- * @property listener The listener to invoke whenever the mouse is clicked on the element that this listener is attached
- * to.
- */
-class MouseClickListener(private val listener: (MouseEvent?) -> Unit) : MouseListener {
-    /**
-     * Invokes the [listener].
-     *
-     * @param event the event that triggered the listener
-     */
-    override fun mouseClicked(event: MouseEvent?) = listener(event)
-
-    /**
-     * Does nothing.
-     *
-     * @param event ignored
-     */
-    override fun mousePressed(event: MouseEvent?) = Unit
-
-    /**
-     * Does nothing.
-     *
-     * @param event ignored
-     */
-    override fun mouseReleased(event: MouseEvent?) = Unit
-
-    /**
-     * Does nothing.
-     *
-     * @param event ignored
-     */
-    override fun mouseEntered(event: MouseEvent?) = Unit
-
-    /**
-     * Does nothing.
-     *
-     * @param event ignored
-     */
-    override fun mouseExited(event: MouseEvent?) = Unit
-}
 
 /**
  * A [TreeModelListener] that invokes the same listener on each event.

--- a/src/main/kotlin/com/fwdekker/randomness/ui/PreviewPanel.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/ui/PreviewPanel.kt
@@ -38,12 +38,10 @@ class PreviewPanel(private val getGenerator: () -> Scheme) {
         previewLabel.border = null
         previewLabel.isFocusable = false
 
-        refreshButton.addMouseListener(
-            MouseClickListener {
-                seed = Random.nextInt()
-                updatePreview()
-            }
-        )
+        refreshButton.addActionListener {
+            seed = Random.nextInt()
+            updatePreview()
+        }
     }
 
 

--- a/src/main/kotlin/com/fwdekker/randomness/word/DictionaryTable.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/word/DictionaryTable.kt
@@ -30,6 +30,14 @@ class DictionaryTable : ActivityTableModelEditor<Dictionary>(
      */
     override fun createElement() = Companion.createElement()
 
+    /**
+     * Returns true if and only if the given item can be edited.
+     *
+     * @param item the item to check for editability
+     * @return true if and only if the given item can be edited
+     */
+    override fun isEditable(item: EditableDatum<Dictionary>) = item.datum !is BundledDictionary
+
 
     /**
      * Holds constants.

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateListEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateListEditorTest.kt
@@ -202,35 +202,6 @@ object TemplateListEditorTest : Spek({
         }
     }
 
-    describe("selection after reload") {
-        it("selects the desired queued selection if it exists") {
-            GuiActionRunner.execute {
-                editor.queueSelection = editor.originalState.templateList.templates[2].uuid
-                editor.reset()
-            }
-
-            frame.tree().requireSelection(6)
-        }
-
-        it("selects the first scheme if the queued selection is invalid") {
-            GuiActionRunner.execute {
-                editor.queueSelection = IntegerScheme().uuid
-                editor.reset()
-            }
-
-            frame.tree().requireSelection(1)
-        }
-
-        it("does not override the default selection if the desired queue selection is null") {
-            GuiActionRunner.execute {
-                editor.queueSelection = null
-                editor.reset()
-            }
-
-            frame.tree().requireSelection(1)
-        }
-    }
-
 
     describe("loadState") {
         it("loads the list's templates") {
@@ -465,6 +436,77 @@ object TemplateListEditorTest : Spek({
             GuiActionRunner.execute { editor.reset() }
 
             assertThat(editor.originalState.dictionarySettings.dictionaries).doesNotContain(dictionary)
+        }
+    }
+
+    describe("reset") {
+        describe("manual override of selected scheme") {
+            it("selects the desired template") {
+                GuiActionRunner.execute {
+                    editor.queueSelection = editor.originalState.templateList.templates[2].uuid
+                    editor.reset()
+                }
+
+                frame.tree().requireSelection(6)
+            }
+
+            it("selects the desired scheme") {
+                GuiActionRunner.execute {
+                    editor.queueSelection = editor.originalState.templateList.templates[2].uuid
+                    editor.reset()
+                }
+
+                frame.tree().requireSelection(6)
+            }
+
+            it("selects the first leaf if the queued selection is null") {
+                GuiActionRunner.execute { editor.reset() }
+
+                frame.tree().requireSelection(1)
+            }
+
+            it("selects the first leaf if the queued selection could not be found") {
+                GuiActionRunner.execute {
+                    editor.queueSelection = "4c0d9b93-e842-48b8-84a1-7b50140c614b"
+                    editor.reset()
+                }
+
+                frame.tree().requireSelection(1)
+            }
+        }
+
+        describe("keep selected scheme") {
+            it("keeps focus on the current scheme after a reset") {
+                GuiActionRunner.execute {
+                    frame.tree().target().setSelectionRow(2)
+                    editor.reset()
+                }
+
+                frame.tree().requireSelection(2)
+            }
+
+            it("selects the first leaf if the current scheme is removed during a reset") {
+                GuiActionRunner.execute {
+                    frame.tree().target().clearSelection()
+                    editor.addScheme(Template("Explore"))
+
+                    frame.tree().target().setSelectionRow(10)
+                    editor.reset()
+                }
+
+                frame.tree().requireSelection(1)
+            }
+        }
+
+        describe("editor focus") {
+            it("resets the request after a reset") {
+                GuiActionRunner.execute {
+                    editor.queueFocus = true
+                    editor.reset()
+                }
+
+                assertThat(editor.queueFocus).isFalse()
+            }
         }
     }
 

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateTreeTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateTreeTest.kt
@@ -16,7 +16,7 @@ import javax.swing.tree.TreePath
 
 
 /**
- * Unit tests for [TemplateTree].
+ * Unit tests for [TemplateJTree].
  *
  * @see TemplateListEditorTest
  */
@@ -25,7 +25,7 @@ object TemplateTreeTest : Spek({
     lateinit var frame: FrameFixture
 
     lateinit var basicTemplates: TemplateList // Not loaded by default, but easy to reuse
-    lateinit var tree: TemplateTree
+    lateinit var tree: TemplateJTree
 
 
     beforeEachTest {
@@ -39,7 +39,7 @@ object TemplateTreeTest : Spek({
                 Template("Bite", listOf(DummyScheme.from("f"), DummyScheme.from("g")))
             )
         )
-        tree = GuiActionRunner.execute<TemplateTree> { TemplateTree { false } }
+        tree = GuiActionRunner.execute<TemplateJTree> { TemplateJTree { false } }
         frame = Containers.showInFrame(tree)
     }
 

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateTreeTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateTreeTest.kt
@@ -492,29 +492,28 @@ object TemplateTreeTest : Spek({
         }
     }
 
-    describe("selectTemplate") {
+    describe("selectScheme") {
         it("does nothing if no template with the specified UUID can be found") {
             GuiActionRunner.execute { tree.loadList(basicTemplates) }
             val initialSelection = tree.selectedNode?.state
 
-            GuiActionRunner.execute { tree.selectTemplate("dae4e446-56de-40ca-8415-5bff1f47f2f4") }
+            GuiActionRunner.execute { tree.selectScheme("dae4e446-56de-40ca-8415-5bff1f47f2f4") }
 
             assertThat(tree.selectedNode?.state).isEqualTo(initialSelection)
         }
 
-        it("does nothing if the UUID belongs to a scheme in the tree") {
+        it("selects the scheme with the given UUID") {
             GuiActionRunner.execute { tree.loadList(basicTemplates) }
-            val initialSelection = tree.selectedNode?.state
 
-            GuiActionRunner.execute { tree.selectTemplate(basicTemplates.templates[1].schemes[0].uuid) }
+            GuiActionRunner.execute { tree.selectScheme(basicTemplates.templates[1].schemes[0].uuid) }
 
-            assertThat(tree.selectedNode?.state).isEqualTo(initialSelection)
+            assertThat(tree.selectedNode?.state).isEqualTo(basicTemplates.templates[1].schemes[0])
         }
 
         it("selects the template with the given UUID") {
             GuiActionRunner.execute { tree.loadList(basicTemplates) }
 
-            GuiActionRunner.execute { tree.selectTemplate(basicTemplates.templates[1].uuid) }
+            GuiActionRunner.execute { tree.selectScheme(basicTemplates.templates[1].uuid) }
 
             assertThat(tree.selectedNode?.state).isEqualTo(basicTemplates.templates[1])
         }

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateTreeTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateTreeTest.kt
@@ -163,6 +163,49 @@ object TemplateTreeTest : Spek({
                 assertThat(basicTemplates.templates.map { it.name })
                     .containsExactly("Small", "Agency", "Clock", "Bite")
             }
+
+            it("adds a `(1)` suffix if the template name is already taken") {
+                GuiActionRunner.execute {
+                    tree.clearSelection()
+                    tree.addScheme(Template(name = "Small"))
+                }
+
+                assertThat(basicTemplates.templates.map { it.name })
+                    .containsExactly("Small", "Clock", "Bite", "Small (1)")
+            }
+
+            it("adds a `(2)` suffix if the `(1)` suffix is already taken") {
+                GuiActionRunner.execute {
+                    tree.clearSelection()
+                    tree.addScheme(Template(name = "Small"))
+                    tree.addScheme(Template(name = "Small"))
+                }
+
+                assertThat(basicTemplates.templates.map { it.name })
+                    .containsExactly("Small", "Clock", "Bite", "Small (1)", "Small (2)")
+            }
+
+            it("replaces and increments the suffix if the name is already taken") {
+                GuiActionRunner.execute {
+                    tree.clearSelection()
+                    tree.addScheme(Template(name = "Small"))
+                    tree.addScheme(Template(name = "Small (1)"))
+                }
+
+                assertThat(basicTemplates.templates.map { it.name })
+                    .containsExactly("Small", "Clock", "Bite", "Small (1)", "Small (2)")
+            }
+
+            it("replaces and increments the suffix if the name is already taken, even if a lower value is available") {
+                GuiActionRunner.execute {
+                    tree.clearSelection()
+                    tree.addScheme(Template(name = "Small (9)"))
+                    tree.addScheme(Template(name = "Small (9)"))
+                }
+
+                assertThat(basicTemplates.templates.map { it.name })
+                    .containsExactly("Small", "Clock", "Bite", "Small (9)", "Small (10)")
+            }
         }
 
         describe("add scheme") {

--- a/src/test/kotlin/com/fwdekker/randomness/ui/ListenerHelperTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/ui/ListenerHelperTest.kt
@@ -9,10 +9,8 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.swing.edt.GuiActionRunner
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
-import java.awt.event.MouseEvent
 import javax.swing.ButtonGroup
 import javax.swing.JCheckBox
-import javax.swing.JLabel
 import javax.swing.JRadioButton
 import javax.swing.JSpinner
 import javax.swing.JTextField
@@ -125,46 +123,6 @@ object ListenerHelperTest : Spek({
             assertThatThrownBy { addChangeListenerTo("rock") {} }
                 .isInstanceOf(IllegalArgumentException::class.java)
                 .hasMessage("Unknown component type 'java.lang.String'.")
-        }
-    }
-})
-
-
-/**
- * Unit tests for [MouseClickListener].
- */
-object MouseClickListenerTest : Spek({
-    lateinit var label: JLabel
-    var listenerInvoked = false
-
-
-    beforeEachTest {
-        listenerInvoked = false
-
-        label = GuiActionRunner.execute<JLabel> {
-            JLabel().apply { addMouseListener(MouseClickListener { listenerInvoked = true }) }
-        }
-    }
-
-
-    describe("MouseListener") {
-        it("is not invoked if the mouse is pressed, released, entered, or exited") {
-            GuiActionRunner.execute {
-                label.dispatchEvent(MouseEvent(label, MouseEvent.MOUSE_PRESSED, 0, 0, 0, 0, 1, false))
-                label.dispatchEvent(MouseEvent(label, MouseEvent.MOUSE_RELEASED, 0, 0, 0, 0, 1, false))
-                label.dispatchEvent(MouseEvent(label, MouseEvent.MOUSE_ENTERED, 0, 0, 0, 0, 1, false))
-                label.dispatchEvent(MouseEvent(label, MouseEvent.MOUSE_EXITED, 0, 0, 0, 0, 1, false))
-            }
-
-            assertThat(listenerInvoked).isFalse()
-        }
-
-        it("is invoked if the mouse is clicked") {
-            GuiActionRunner.execute {
-                label.dispatchEvent(MouseEvent(label, MouseEvent.MOUSE_CLICKED, 0, 0, 0, 0, 1, false))
-            }
-
-            assertThat(listenerInvoked).isTrue()
         }
     }
 })

--- a/src/test/kotlin/com/fwdekker/randomness/ui/PreviewPanelTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/ui/PreviewPanelTest.kt
@@ -61,9 +61,7 @@ object PreviewPanelTest : Spek({
             GuiActionRunner.execute { panel.updatePreview() }
             val oldRandom = scheme?.random
 
-            GuiActionRunner.execute {
-                frame.button("refreshButton").target().mouseListeners.forEach { it.mouseClicked(null) }
-            }
+            GuiActionRunner.execute { frame.button("refreshButton").target().doClick() }
 
             GuiActionRunner.execute { panel.updatePreview() }
             val newRandom = scheme?.random


### PR DESCRIPTION
Contains several important QoL/UX improvements, such as:
* Copying/adding a template will give it a unique name to prevent conflicts, so that you can immediately save.
* After pressing reset, the previously-selected scheme remains selected.
* Speed search in template list
* Added shortcuts to template list buttons
* Template editor splitter ratio is now persistent
* Fixed old bug where bundled dictionaries could always be edited
* Button to add scheme to template list now changes behaviour depending on current selection, and is not flat to make it quicker to select a scheme to add, and supports fast searching
* Preview can now be refreshed from keyboard