### PR TITLE
Reordering detection, settings reset, and literal capitalisation modes

### DIFF
--- a/src/main/kotlin/com/fwdekker/randomness/Scheme.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/Scheme.kt
@@ -23,7 +23,7 @@ abstract class Scheme : State() {
     /**
      * The icons that represent schemes of this type.
      */
-    @Transient
+    @get:Transient
     open val icons: RandomnessIcons? = null
 
     /**
@@ -42,6 +42,7 @@ abstract class Scheme : State() {
      * decorators, use [generateUndecoratedStrings]. Decorators are applied in ascending order. That is, the output of
      * the scheme is fed into the decorator at index 0, and that output is fed into the decorator at index 1, and so on.
      */
+    @get:Transient
     @get:XCollection(elementTypes = [ArrayDecorator::class, FixedLengthDecorator::class])
     abstract val decorators: List<SchemeDecorator>
 

--- a/src/main/kotlin/com/fwdekker/randomness/SettingsState.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/SettingsState.kt
@@ -15,8 +15,8 @@ import com.fwdekker.randomness.word.DictionarySettings
  */
 data class SettingsState(
     var templateList: TemplateList = TemplateList(emptyList()),
-    var symbolSetSettings: SymbolSetSettings = SymbolSetSettings(emptyMap()),
-    var dictionarySettings: DictionarySettings = DictionarySettings(emptySet())
+    var symbolSetSettings: SymbolSetSettings = SymbolSetSettings(emptyList()),
+    var dictionarySettings: DictionarySettings = DictionarySettings(emptyList())
 ) : State() {
     override fun doValidate() = templateList.doValidate()
 

--- a/src/main/kotlin/com/fwdekker/randomness/StateEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/StateEditor.kt
@@ -68,7 +68,7 @@ abstract class StateEditor<S : State>(val originalState: S) {
      *
      * @return `null` if the state is valid, or a string explaining why the state is invalid
      */
-    open fun doValidate(): String? = readState().doValidate()
+    fun doValidate(): String? = readState().doValidate()
 
 
     /**

--- a/src/main/kotlin/com/fwdekker/randomness/literal/LiteralScheme.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/literal/LiteralScheme.kt
@@ -1,5 +1,6 @@
 package com.fwdekker.randomness.literal
 
+import com.fwdekker.randomness.CapitalizationMode
 import com.fwdekker.randomness.Scheme
 import com.fwdekker.randomness.SchemeDecorator
 import com.fwdekker.randomness.array.ArrayDecorator
@@ -11,10 +12,12 @@ import icons.RandomnessIcons
  * Contains settings for generating non-random literals.
  *
  * @property literal The literal string.
+ * @property capitalization The capitalization mode of the literal.
  * @property arrayDecorator Settings that determine whether the output should be an array of values.
  */
 data class LiteralScheme(
     var literal: String = DEFAULT_LITERAL,
+    var capitalization: CapitalizationMode = DEFAULT_CAPITALIZATION,
     var arrayDecorator: ArrayDecorator = ArrayDecorator()
 ) : Scheme() {
     @Transient
@@ -31,7 +34,7 @@ data class LiteralScheme(
      * @param count the number of copies of the literal to generate
      * @return a list containing the given number of copies of the literal
      */
-    override fun generateUndecoratedStrings(count: Int) = List(count) { literal }
+    override fun generateUndecoratedStrings(count: Int) = List(count) { capitalization.transform(literal, random) }
 
 
     override fun doValidate() = arrayDecorator.doValidate()
@@ -46,8 +49,13 @@ data class LiteralScheme(
      */
     companion object {
         /**
-         * The default value of the [literal][literal] field.
+         * The default value of the [literal] field.
          */
         const val DEFAULT_LITERAL = ""
+
+        /**
+         * The default value of the [capitalization] field.
+         */
+        val DEFAULT_CAPITALIZATION = CapitalizationMode.RETAIN
     }
 }

--- a/src/main/kotlin/com/fwdekker/randomness/literal/LiteralSchemeEditor.form
+++ b/src/main/kotlin/com/fwdekker/randomness/literal/LiteralSchemeEditor.form
@@ -3,12 +3,12 @@
   <grid id="27dc6" binding="rootComponent" layout-manager="GridLayoutManager" row-count="4" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="500" height="123"/>
+      <xy x="20" y="20" width="500" height="188"/>
     </constraints>
     <properties/>
     <border type="none"/>
     <children>
-      <grid id="81b9e" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="81b9e" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -36,6 +36,49 @@
               <name value="literal"/>
             </properties>
           </component>
+          <component id="74238" class="javax.swing.JLabel">
+            <constraints>
+              <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text resource-bundle="randomness" key="settings.capitalization"/>
+            </properties>
+          </component>
+          <grid id="b8a2c" layout-manager="GridLayoutManager" row-count="1" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+            <margin top="0" left="0" bottom="0" right="0"/>
+            <constraints>
+              <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties/>
+            <border type="none"/>
+            <children>
+              <component id="f4c35" class="javax.swing.JRadioButton" default-binding="true">
+                <constraints>
+                  <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <actionCommand value="retain"/>
+                  <name value="capitalizationRetain"/>
+                  <text resource-bundle="randomness" key="settings.capitalization.retain"/>
+                </properties>
+              </component>
+              <component id="6ba55" class="javax.swing.JRadioButton" default-binding="true">
+                <constraints>
+                  <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <actionCommand value="random" noi18n="true"/>
+                  <name value="capitalizationRandom"/>
+                  <text resource-bundle="randomness" key="settings.capitalization.random"/>
+                </properties>
+              </component>
+              <hspacer id="c8e94">
+                <constraints>
+                  <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                </constraints>
+              </hspacer>
+            </children>
+          </grid>
         </children>
       </grid>
       <vspacer id="1257b">
@@ -60,4 +103,12 @@
       </vspacer>
     </children>
   </grid>
+  <buttonGroups>
+    <group name="capitalizationGroup" bound="true">
+      <member id="7a076"/>
+      <member id="7a076"/>
+      <member id="f8b64"/>
+      <member id="6ba55"/>
+    </group>
+  </buttonGroups>
 </form>

--- a/src/main/kotlin/com/fwdekker/randomness/literal/LiteralSchemeEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/literal/LiteralSchemeEditor.kt
@@ -1,8 +1,13 @@
 package com.fwdekker.randomness.literal
 
+import com.fwdekker.randomness.CapitalizationMode.Companion.getMode
 import com.fwdekker.randomness.StateEditor
 import com.fwdekker.randomness.array.ArrayDecoratorEditor
+import com.fwdekker.randomness.literal.LiteralScheme.Companion.DEFAULT_CAPITALIZATION
 import com.fwdekker.randomness.ui.addChangeListenerTo
+import com.fwdekker.randomness.ui.getValue
+import com.fwdekker.randomness.ui.setValue
+import javax.swing.ButtonGroup
 import javax.swing.JPanel
 import javax.swing.JTextField
 
@@ -18,6 +23,7 @@ class LiteralSchemeEditor(scheme: LiteralScheme = LiteralScheme()) : StateEditor
     override val preferredFocusedComponent = literalInput
 
     private lateinit var literalInput: JTextField
+    private lateinit var capitalizationGroup: ButtonGroup
     private lateinit var arrayDecoratorPanel: JPanel
     private lateinit var arrayDecoratorEditor: ArrayDecoratorEditor
 
@@ -42,12 +48,14 @@ class LiteralSchemeEditor(scheme: LiteralScheme = LiteralScheme()) : StateEditor
         super.loadState(state)
 
         literalInput.text = state.literal
+        capitalizationGroup.setValue(state.capitalization)
         arrayDecoratorEditor.loadState(state.arrayDecorator)
     }
 
     override fun readState() =
         LiteralScheme(
             literal = literalInput.text,
+            capitalization = capitalizationGroup.getValue()?.let(::getMode) ?: DEFAULT_CAPITALIZATION,
             arrayDecorator = arrayDecoratorEditor.readState()
         ).also { it.uuid = originalState.uuid }
 

--- a/src/main/kotlin/com/fwdekker/randomness/string/StringScheme.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/string/StringScheme.kt
@@ -46,7 +46,7 @@ data class StringScheme(
 
     private val activeSymbols: List<String>
         get() =
-            (+symbolSetSettings).symbolSetList
+            (+symbolSetSettings).symbolSets
                 .filter { it.name in activeSymbolSets }
                 .sum(excludeLookAlikeSymbols)
 

--- a/src/main/kotlin/com/fwdekker/randomness/string/StringSchemeEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/string/StringSchemeEditor.kt
@@ -87,9 +87,9 @@ class StringSchemeEditor(scheme: StringScheme = StringScheme()) : StateEditor<St
         excludeLookAlikeSymbolsCheckBox.isSelected = state.excludeLookAlikeSymbols
 
         symbolSetTable.data =
-            (+state.symbolSetSettings).symbolSetList
+            (+state.symbolSetSettings).symbolSets
         symbolSetTable.activeData =
-            (+state.symbolSetSettings).symbolSetList.filter { symbolSet -> symbolSet.name in state.activeSymbolSets }
+            (+state.symbolSetSettings).symbolSets.filter { symbolSet -> symbolSet.name in state.activeSymbolSets }
 
         arrayDecoratorEditor.loadState(state.arrayDecorator)
     }
@@ -107,21 +107,12 @@ class StringSchemeEditor(scheme: StringScheme = StringScheme()) : StateEditor<St
             it.uuid = originalState.uuid
 
             it.symbolSetSettings += (+originalState.symbolSetSettings).deepCopy(retainUuid = true)
-            (+it.symbolSetSettings).symbolSetList = symbolSetTable.data.toSet()
+            (+it.symbolSetSettings).symbolSets = symbolSetTable.data.toSet()
         }
 
     override fun applyState() {
         super.applyState()
         (+originalState.symbolSetSettings).copyFrom(+readState().symbolSetSettings)
-    }
-
-
-    override fun doValidate(): String? {
-        val symbolSets = symbolSetTable.data.map { it.name }
-        val duplicate = symbolSets.firstOrNull { symbolSet -> symbolSets.count { it == symbolSet } > 1 }
-
-        return if (duplicate != null) "Multiple symbol sets with name '$duplicate'."
-        else super.doValidate()
     }
 
 

--- a/src/main/kotlin/com/fwdekker/randomness/string/StringSchemeEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/string/StringSchemeEditor.kt
@@ -107,7 +107,7 @@ class StringSchemeEditor(scheme: StringScheme = StringScheme()) : StateEditor<St
             it.uuid = originalState.uuid
 
             it.symbolSetSettings += (+originalState.symbolSetSettings).deepCopy(retainUuid = true)
-            (+it.symbolSetSettings).symbolSets = symbolSetTable.data.toSet()
+            (+it.symbolSetSettings).symbolSets = symbolSetTable.data
         }
 
     override fun applyState() {

--- a/src/main/kotlin/com/fwdekker/randomness/string/SymbolSet.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/string/SymbolSet.kt
@@ -9,7 +9,7 @@ import com.vdurmont.emoji.EmojiParser
  * @param name the name of the symbol set
  * @param symbols the symbols in the symbol set
  */
-data class SymbolSet(var name: String, var symbols: String) {
+data class SymbolSet(var name: String = "", var symbols: String = "") {
     /**
      * Returns the `name` field.
      *

--- a/src/main/kotlin/com/fwdekker/randomness/string/SymbolSet.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/string/SymbolSet.kt
@@ -78,20 +78,6 @@ data class SymbolSet(var name: String, var symbols: String) {
 
 
 /**
- * Converts a collection of symbol sets to a map from the symbol sets' names to the respective symbols.
- *
- * @return a map from the symbol sets' names to the respective symbols
- */
-fun Collection<SymbolSet>.toMap() = this.map { (name, symbols) -> name to symbols }.toMap()
-
-/**
- * Converts a map to a list of symbol sets, using the key as the name and the value as the symbols.
- *
- * @return a list of symbol sets
- */
-fun Map<String, String>.toSymbolSets() = this.map { (name, symbols) -> SymbolSet(name, symbols) }.toList()
-
-/**
  * Combines the symbols of all the symbol sets, optionally removing duplicate characters.
  *
  * This method respects emoji sequences and will not remove duplicate characters if these characters are essential to

--- a/src/main/kotlin/com/fwdekker/randomness/string/SymbolSetSettings.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/string/SymbolSetSettings.kt
@@ -24,7 +24,7 @@ import com.vdurmont.emoji.EmojiParser
 )
 data class SymbolSetSettings(
     @MapAnnotation(sortBeforeSave = false)
-    var serializedSymbolSets: List<Pair<String, String>> = DEFAULT_SYMBOL_SETS.toMutableList(),
+    var serializedSymbolSets: List<SymbolSet> = DEFAULT_SYMBOL_SETS.toMutableList(),
     @Suppress("unused") // At least two fields are required for serialization to work
     private val placeholder: String = ""
 ) : PersistentStateComponent<SymbolSetSettings>, Settings() {
@@ -33,9 +33,9 @@ data class SymbolSetSettings(
      */
     @get:Transient
     var symbolSets: Collection<SymbolSet>
-        get() = serializedSymbolSets.map { SymbolSet(it.first, EmojiParser.parseToUnicode(it.second)) }
+        get() = serializedSymbolSets.map { SymbolSet(it.name, EmojiParser.parseToUnicode(it.symbols)) }
         set(value) {
-            serializedSymbolSets = value.map { it.name to EmojiParser.parseToAliases(it.symbols) }
+            serializedSymbolSets = value.map { SymbolSet(it.name, EmojiParser.parseToAliases(it.symbols)) }
         }
 
 
@@ -69,7 +69,7 @@ data class SymbolSetSettings(
     }
 
     override fun deepCopy(retainUuid: Boolean) =
-        copy(serializedSymbolSets = serializedSymbolSets.map { it.first to it.second })
+        copy(serializedSymbolSets = serializedSymbolSets.map { it.copy() })
             .also { if (retainUuid) it.uuid = uuid }
 
 
@@ -80,8 +80,8 @@ data class SymbolSetSettings(
         /**
          * The default value of the [symbolSets] field.
          */
-        val DEFAULT_SYMBOL_SETS: List<Pair<String, String>>
-            get() = SymbolSet.defaultSymbolSets.map { it.name to it.symbols }
+        val DEFAULT_SYMBOL_SETS: List<SymbolSet>
+            get() = SymbolSet.defaultSymbolSets
 
         /**
          * The persistent `SymbolSetSettings` instance.

--- a/src/main/kotlin/com/fwdekker/randomness/string/SymbolSetSettings.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/string/SymbolSetSettings.kt
@@ -32,7 +32,7 @@ data class SymbolSetSettings(
      * A list view of the deserialized `SymbolSet` objects described by [serializedSymbolSets].
      */
     @get:Transient
-    var symbolSets: Collection<SymbolSet>
+    var symbolSets: List<SymbolSet>
         get() = serializedSymbolSets.map { SymbolSet(it.name, EmojiParser.parseToUnicode(it.symbols)) }
         set(value) {
             serializedSymbolSets = value.map { SymbolSet(it.name, EmojiParser.parseToAliases(it.symbols)) }

--- a/src/main/kotlin/com/fwdekker/randomness/ui/ActivityTableModelEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/ui/ActivityTableModelEditor.kt
@@ -62,7 +62,7 @@ abstract class ActivityTableModelEditor<T>(
     /**
      * All data currently in the table.
      */
-    var data: Collection<T>
+    var data: List<T>
         get() = model.items.map { it.datum }
         set(value) {
             model.items = value.map { EditableDatum(DEFAULT_STATE, it) }
@@ -71,7 +71,7 @@ abstract class ActivityTableModelEditor<T>(
     /**
      * All data of which the checkbox is currently checked.
      */
-    var activeData: Collection<T>
+    var activeData: List<T>
         get() = model.items.filter { it.active }.map { it.datum }
         set(value) {
             model.items.forEachIndexed { i, item -> model.setValueAt(item.datum in value, i, 0) }

--- a/src/main/kotlin/com/fwdekker/randomness/word/WordSchemeEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/word/WordSchemeEditor.kt
@@ -101,7 +101,7 @@ class WordSchemeEditor(scheme: WordScheme = WordScheme()) : StateEditor<WordSche
             it.uuid = originalState.uuid
 
             it.dictionarySettings += (+originalState.dictionarySettings).deepCopy(retainUuid = true)
-            (+it.dictionarySettings).dictionaries = dictionaryTable.data.toList()
+            (+it.dictionarySettings).dictionaries = dictionaryTable.data
 
             UserDictionary.clearCache()
         }

--- a/src/main/kotlin/com/fwdekker/randomness/word/WordSchemeEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/word/WordSchemeEditor.kt
@@ -101,7 +101,7 @@ class WordSchemeEditor(scheme: WordScheme = WordScheme()) : StateEditor<WordSche
             it.uuid = originalState.uuid
 
             it.dictionarySettings += (+originalState.dictionarySettings).deepCopy(retainUuid = true)
-            (+it.dictionarySettings).dictionaries = dictionaryTable.data.toSet()
+            (+it.dictionarySettings).dictionaries = dictionaryTable.data.toList()
 
             UserDictionary.clearCache()
         }
@@ -109,15 +109,6 @@ class WordSchemeEditor(scheme: WordScheme = WordScheme()) : StateEditor<WordSche
     override fun applyState() {
         super.applyState()
         (+originalState.dictionarySettings).copyFrom(+readState().dictionarySettings)
-    }
-
-
-    override fun doValidate(): String? {
-        val dictionaries = dictionaryTable.data
-        val duplicate = dictionaries.firstOrNull { dictionary -> dictionaries.count { it == dictionary } > 1 }
-
-        return if (duplicate != null) "Duplicate dictionary '$duplicate'."
-        else super.doValidate()
     }
 
 

--- a/src/test/kotlin/com/fwdekker/randomness/SettingsStateTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/SettingsStateTest.kt
@@ -1,6 +1,7 @@
 package com.fwdekker.randomness
 
 import com.fwdekker.randomness.string.StringScheme
+import com.fwdekker.randomness.string.SymbolSet
 import com.fwdekker.randomness.string.SymbolSetSettings
 import com.fwdekker.randomness.template.Template
 import com.fwdekker.randomness.template.TemplateList
@@ -21,7 +22,7 @@ object SettingsStateTest : Spek({
 
 
     beforeEachTest {
-        state = SettingsState(symbolSetSettings = SymbolSetSettings(mapOf("film" to "C0ouF")))
+        state = SettingsState(symbolSetSettings = SymbolSetSettings(listOf("film" to "C0ouF")))
     }
 
 
@@ -37,7 +38,7 @@ object SettingsStateTest : Spek({
         }
 
         it("fails if the symbol set settings are invalid") {
-            state.symbolSetSettings.symbolSets = mapOf("" to "9KNKtWw")
+            state.symbolSetSettings.symbolSets = listOf(SymbolSet("", "9KNKtWw"))
             state.templateList.templates = listOf(Template(schemes = listOf(StringScheme())))
             state.templateList.applySettingsState(state)
 
@@ -45,13 +46,13 @@ object SettingsStateTest : Spek({
         }
 
         it("passes if the symbol set settings are invalid but unused") {
-            state.symbolSetSettings.symbolSets = mapOf("" to "wF7Tl6wX")
+            state.symbolSetSettings.symbolSets = listOf(SymbolSet("", "wF7Tl6wX"))
 
             assertThat(state.doValidate()).isNull()
         }
 
         it("fails if the dictionary settings are invalid") {
-            state.dictionarySettings.dictionaries = setOf(UserDictionary("does_not_exist.dic"))
+            state.dictionarySettings.dictionaries = listOf(UserDictionary("does_not_exist.dic"))
             state.templateList.templates = listOf(Template(schemes = listOf(WordScheme())))
             state.templateList.applySettingsState(state)
 
@@ -59,7 +60,7 @@ object SettingsStateTest : Spek({
         }
 
         it("passes if the dictionary settings are invalid but unused") {
-            state.dictionarySettings.dictionaries = setOf(UserDictionary("does_not_exist.dic"))
+            state.dictionarySettings.dictionaries = listOf(UserDictionary("does_not_exist.dic"))
 
             assertThat(state.doValidate()).isNull()
         }

--- a/src/test/kotlin/com/fwdekker/randomness/SettingsStateTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/SettingsStateTest.kt
@@ -22,7 +22,7 @@ object SettingsStateTest : Spek({
 
 
     beforeEachTest {
-        state = SettingsState(symbolSetSettings = SymbolSetSettings(listOf("film" to "C0ouF")))
+        state = SettingsState(symbolSetSettings = SymbolSetSettings(listOf(SymbolSet("film", "C0ouF"))))
     }
 
 

--- a/src/test/kotlin/com/fwdekker/randomness/literal/LiteralSchemeEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/literal/LiteralSchemeEditorTest.kt
@@ -1,5 +1,6 @@
 package com.fwdekker.randomness.literal
 
+import com.fwdekker.randomness.CapitalizationMode
 import com.fwdekker.randomness.array.ArrayDecorator
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.swing.edt.FailOnThreadViolationRepaintManager
@@ -40,6 +41,13 @@ object LiteralSchemeEditorTest : Spek({
 
             frame.textBox("literal").requireText("scrape")
         }
+
+        it("loads the scheme's capitalization") {
+            GuiActionRunner.execute { editor.loadState(LiteralScheme(capitalization = CapitalizationMode.RANDOM)) }
+
+            frame.radioButton("capitalizationRetain").requireSelected(false)
+            frame.radioButton("capitalizationRandom").requireSelected(true)
+        }
     }
 
     describe("readState") {
@@ -50,10 +58,12 @@ object LiteralSchemeEditorTest : Spek({
         it("returns the editor's state") {
             GuiActionRunner.execute {
                 frame.textBox("literal").target().text = "waste"
+                frame.radioButton("capitalizationRandom").target().isSelected = true
             }
 
             val readScheme = editor.readState()
             assertThat(readScheme.literal).isEqualTo("waste")
+            assertThat(readScheme.capitalization).isEqualTo(CapitalizationMode.RANDOM)
         }
 
         it("returns the loaded state if no editor changes are made") {

--- a/src/test/kotlin/com/fwdekker/randomness/literal/LiteralSchemeTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/literal/LiteralSchemeTest.kt
@@ -1,5 +1,6 @@
 package com.fwdekker.randomness.literal
 
+import com.fwdekker.randomness.CapitalizationMode
 import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -18,22 +19,29 @@ object LiteralSchemeTest : Spek({
 
 
     describe("generateStrings") {
-        it("can generate an empty string") {
+        it("generates an empty string") {
             literalScheme.literal = ""
 
             assertThat(literalScheme.generateStrings()).containsExactly("")
         }
 
-        it("can generate a blank string") {
+        it("generates a blank string") {
             literalScheme.literal = "  "
 
             assertThat(literalScheme.generateStrings()).containsExactly("  ")
         }
 
-        it("can generate the given non-empty string") {
+        it("generates the given non-empty string") {
             literalScheme.literal = "shine"
 
             assertThat(literalScheme.generateStrings()).containsExactly("shine")
+        }
+
+        it("applies the desired capitalization mode") {
+            literalScheme.capitalization = CapitalizationMode.UPPER
+            literalScheme.literal = "elephant"
+
+            assertThat(literalScheme.generateStrings()).containsExactly("ELEPHANT")
         }
     }
 
@@ -69,6 +77,7 @@ object LiteralSchemeTest : Spek({
     describe("copyFrom") {
         it("copies state from another instance") {
             literalScheme.literal = "tame"
+            literalScheme.capitalization = CapitalizationMode.RANDOM
             literalScheme.arrayDecorator.maxCount = 555
 
             val newScheme = LiteralScheme()

--- a/src/test/kotlin/com/fwdekker/randomness/string/StringSchemeEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/string/StringSchemeEditorTest.kt
@@ -104,7 +104,7 @@ object StringSchemeEditorTest : Spek({
 
             GuiActionRunner.execute {
                 val settings = SymbolSetSettings()
-                settings.symbolSetList = allSymbolSets
+                settings.symbolSets = allSymbolSets
                 val newScheme = StringScheme(activeSymbolSets = activeSymbolSets.map { it.name }.toSet())
                 newScheme.symbolSetSettings += settings
 
@@ -195,9 +195,9 @@ object StringSchemeEditorTest : Spek({
                 symbolSetTable.listTableModel.addRow(EditableDatum(active = true, SymbolSet("feel", "5vG6eeU")))
             }
 
-            assertThat((+editor.readState().symbolSetSettings).symbolSetList)
+            assertThat((+editor.readState().symbolSetSettings).symbolSets)
                 .containsExactly(SymbolSet("feel", "5vG6eeU"))
-            assertThat(symbolSetSettings.symbolSetList)
+            assertThat(symbolSetSettings.symbolSets)
                 .doesNotContain(SymbolSet("feel", "5vG6eeU"))
         }
 
@@ -221,7 +221,7 @@ object StringSchemeEditorTest : Spek({
 
             GuiActionRunner.execute { editor.applyState() }
 
-            assertThat(symbolSetSettings.symbolSetList).containsExactly(SymbolSet("excess", "uWX4POU"))
+            assertThat(symbolSetSettings.symbolSets).containsExactly(SymbolSet("excess", "uWX4POU"))
         }
     }
 

--- a/src/test/kotlin/com/fwdekker/randomness/string/StringSchemeTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/string/StringSchemeTest.kt
@@ -19,7 +19,7 @@ object StringSchemeTest : Spek({
 
 
     beforeEachTest {
-        symbolSetSettings = SymbolSetSettings(listOf("steam" to "bH2"))
+        symbolSetSettings = SymbolSetSettings(listOf(SymbolSet("steam", "bH2")))
         stringScheme = StringScheme(activeSymbolSets = setOf("steam"))
         stringScheme.symbolSetSettings += symbolSetSettings
     }
@@ -210,7 +210,7 @@ object StringSchemeTest : Spek({
         }
 
         it("writes a deep copy of the given scheme's symbol set settings into the target") {
-            val otherSettings = SymbolSetSettings(listOf("sew" to "2eNco"))
+            val otherSettings = SymbolSetSettings(listOf(SymbolSet("sew", "2eNco")))
             val otherScheme = StringScheme()
             otherScheme.symbolSetSettings += otherSettings
 

--- a/src/test/kotlin/com/fwdekker/randomness/string/StringSchemeTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/string/StringSchemeTest.kt
@@ -19,7 +19,7 @@ object StringSchemeTest : Spek({
 
 
     beforeEachTest {
-        symbolSetSettings = SymbolSetSettings(mapOf("steam" to "bH2"))
+        symbolSetSettings = SymbolSetSettings(listOf("steam" to "bH2"))
         stringScheme = StringScheme(activeSymbolSets = setOf("steam"))
         stringScheme.symbolSetSettings += symbolSetSettings
     }
@@ -39,16 +39,16 @@ object StringSchemeTest : Spek({
                 val maxLength: Int,
                 val enclosure: String,
                 val capitalization: CapitalizationMode,
-                val symbolSets: Map<String, String>
+                val symbolSets: List<SymbolSet>
             )
 
             mapOf(
-                Param(1, 1, "", CapitalizationMode.RETAIN, mapOf("x" to "x")) to "x",
-                Param(1, 1, "'", CapitalizationMode.UPPER, mapOf("x" to "x")) to "'X'",
-                Param(1, 1, "a", CapitalizationMode.LOWER, mapOf("x" to "x")) to "axa",
-                Param(1, 1, "2Rv", CapitalizationMode.FIRST_LETTER, mapOf("x" to "x")) to "2RvX2Rv",
-                Param(723, 723, "", CapitalizationMode.UPPER, mapOf("x" to "x")) to "X".repeat(723),
-                Param(466, 466, "z", CapitalizationMode.LOWER, mapOf("x" to "x")) to "z${"x".repeat(466)}z"
+                Param(1, 1, "", CapitalizationMode.RETAIN, listOf(SymbolSet("x", "x"))) to "x",
+                Param(1, 1, "'", CapitalizationMode.UPPER, listOf(SymbolSet("x", "x"))) to "'X'",
+                Param(1, 1, "a", CapitalizationMode.LOWER, listOf(SymbolSet("x", "x"))) to "axa",
+                Param(1, 1, "2Rv", CapitalizationMode.FIRST_LETTER, listOf(SymbolSet("x", "x"))) to "2RvX2Rv",
+                Param(723, 723, "", CapitalizationMode.UPPER, listOf(SymbolSet("x", "x"))) to "X".repeat(723),
+                Param(466, 466, "z", CapitalizationMode.LOWER, listOf(SymbolSet("x", "x"))) to "z${"x".repeat(466)}z"
             ).forEach { (minLength, maxLength, enclosure, capitalization, symbolSets), expectedString ->
                 it("generates a formatted string") {
                     stringScheme.symbolSetSettings += SymbolSetSettings().also { it.symbolSets = symbolSets }
@@ -56,7 +56,7 @@ object StringSchemeTest : Spek({
                     stringScheme.maxLength = maxLength
                     stringScheme.enclosure = enclosure
                     stringScheme.capitalization = capitalization
-                    stringScheme.activeSymbolSets = symbolSets.values.toSet()
+                    stringScheme.activeSymbolSets = symbolSets.map { it.name }.toSet()
 
                     assertThat(stringScheme.generateStrings()).containsExactly(expectedString)
                 }
@@ -64,14 +64,14 @@ object StringSchemeTest : Spek({
 
             it("retains emoji modifiers in the right order") {
                 val emoji = "👩‍👩‍👧‍👧"
-                val symbolSets = mapOf("emoji" to emoji)
+                val symbolSets = listOf(SymbolSet("emoji", emoji))
 
                 stringScheme.symbolSetSettings += SymbolSetSettings().also { it.symbolSets = symbolSets }
                 stringScheme.minLength = 1
                 stringScheme.maxLength = 1
                 stringScheme.enclosure = ""
                 stringScheme.capitalization = CapitalizationMode.RETAIN
-                stringScheme.activeSymbolSets = symbolSets.keys.toSet()
+                stringScheme.activeSymbolSets = symbolSets.map { it.name }.toSet()
 
                 assertThat(stringScheme.generateStrings()).containsExactly(emoji)
             }
@@ -112,7 +112,7 @@ object StringSchemeTest : Spek({
 
         describe("symbol sets") {
             it("fails if the symbol set settings are invalid") {
-                symbolSetSettings.symbolSets = emptyMap()
+                symbolSetSettings.symbolSets = emptyList()
                 stringScheme.activeSymbolSets = emptySet()
 
                 assertThat(stringScheme.doValidate()).isEqualTo("Add at least one symbol set.")
@@ -125,7 +125,7 @@ object StringSchemeTest : Spek({
             }
 
             it("fails if only look-alike symbols are selected and look-alike symbols are excluded") {
-                symbolSetSettings.symbolSets = mapOf("Look-alike" to "l01")
+                symbolSetSettings.symbolSets = listOf(SymbolSet("Look-alike", "l01"))
                 stringScheme.activeSymbolSets = setOf("Look-alike")
                 stringScheme.excludeLookAlikeSymbols = true
 
@@ -166,12 +166,12 @@ object StringSchemeTest : Spek({
         }
 
         it("creates an independent copy of the symbol set settings") {
-            (+stringScheme.symbolSetSettings).symbolSets = mapOf("formal" to "feXw8M")
+            (+stringScheme.symbolSetSettings).symbolSets = listOf(SymbolSet("formal", "feXw8M"))
 
             val copy = stringScheme.deepCopy()
-            (+copy.symbolSetSettings).symbolSets = mapOf("absent" to "9hDt")
+            (+copy.symbolSetSettings).symbolSets = listOf(SymbolSet("absent", "9hDt"))
 
-            assertThat((+stringScheme.symbolSetSettings).symbolSets).containsOnlyKeys("formal")
+            assertThat((+stringScheme.symbolSetSettings).symbolSets.map { it.name }).containsExactly("formal")
         }
     }
 
@@ -210,14 +210,14 @@ object StringSchemeTest : Spek({
         }
 
         it("writes a deep copy of the given scheme's symbol set settings into the target") {
-            val otherSettings = SymbolSetSettings(mapOf("sew" to "2eNco"))
+            val otherSettings = SymbolSetSettings(listOf("sew" to "2eNco"))
             val otherScheme = StringScheme()
             otherScheme.symbolSetSettings += otherSettings
 
             stringScheme.copyFrom(otherScheme)
-            (+otherScheme.symbolSetSettings).symbolSets = mapOf("wife" to "4g5X0")
+            (+otherScheme.symbolSetSettings).symbolSets = listOf(SymbolSet("wife", "4g5X0"))
 
-            assertThat((+stringScheme.symbolSetSettings).symbolSets).containsOnlyKeys("sew")
+            assertThat((+stringScheme.symbolSetSettings).symbolSets.map { it.name }).containsExactly("sew")
         }
     }
 })

--- a/src/test/kotlin/com/fwdekker/randomness/string/SymbolSetSettingsTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/string/SymbolSetSettingsTest.kt
@@ -13,11 +13,11 @@ object SymbolSetSettingsTest : Spek({
         it("serializes emoji") {
             val settings = SymbolSetSettings().also { it.symbolSets = listOf(SymbolSet("emoji", "💆")) }
 
-            assertThat(settings.serializedSymbolSets.single { it.first == "emoji" }.second).isEqualTo(":massage:")
+            assertThat(settings.serializedSymbolSets.single { it.name == "emoji" }.symbols).isEqualTo(":massage:")
         }
 
         it("deserializes emoji") {
-            val settings = SymbolSetSettings(listOf("emoji" to ":couple_with_heart_man_man:"))
+            val settings = SymbolSetSettings(listOf(SymbolSet("emoji", ":couple_with_heart_man_man:")))
 
             assertThat(settings.symbolSets.single { it.name == "emoji" }.symbols).isEqualTo("👨‍❤️‍👨")
         }
@@ -34,17 +34,23 @@ object SymbolSetSettingsTest : Spek({
         }
 
         it("fails if a symbol set does not have a name") {
-            assertThat(SymbolSetSettings(listOf("" to "hAA76o")).doValidate())
+            val symbolSets = listOf(SymbolSet("", "hAA76o"))
+
+            assertThat(SymbolSetSettings(symbolSets).doValidate())
                 .isEqualTo("All symbol sets should have a name.")
         }
 
         it("fails if two symbol sets have the same name") {
-            assertThat(SymbolSetSettings(listOf("seldom" to "K0A6pdHk", "seldom" to "sllfXObM")).doValidate())
+            val symbolSets = listOf(SymbolSet("seldom", "K0A6pdHk"), SymbolSet("seldom", "sllfXObM"))
+
+            assertThat(SymbolSetSettings(symbolSets).doValidate())
                 .isEqualTo("Multiple symbol sets with name 'seldom'.")
         }
 
         it("fails if a symbol set has no symbols") {
-            assertThat(SymbolSetSettings(listOf("value" to "")).doValidate())
+            val symbolSets = listOf(SymbolSet("value", ""))
+
+            assertThat(SymbolSetSettings(symbolSets).doValidate())
                 .isEqualTo("Symbol set `value` should contain at least one symbol.")
         }
     }

--- a/src/test/kotlin/com/fwdekker/randomness/string/SymbolSetSettingsTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/string/SymbolSetSettingsTest.kt
@@ -11,15 +11,15 @@ import org.spekframework.spek2.style.specification.describe
 object SymbolSetSettingsTest : Spek({
     describe("emoji compatibility") {
         it("serializes emoji") {
-            val settings = SymbolSetSettings().also { it.symbolSets = mapOf("emoji" to "💆") }
+            val settings = SymbolSetSettings().also { it.symbolSets = listOf(SymbolSet("emoji", "💆")) }
 
-            assertThat(settings.serializedSymbolSets["emoji"]).isEqualTo(":massage:")
+            assertThat(settings.serializedSymbolSets.single { it.first == "emoji" }.second).isEqualTo(":massage:")
         }
 
         it("deserializes emoji") {
-            val settings = SymbolSetSettings(mapOf("emoji" to ":couple_with_heart_man_man:"))
+            val settings = SymbolSetSettings(listOf("emoji" to ":couple_with_heart_man_man:"))
 
-            assertThat(settings.symbolSets["emoji"]).isEqualTo("👨‍❤️‍👨")
+            assertThat(settings.symbolSets.single { it.name == "emoji" }.symbols).isEqualTo("👨‍❤️‍👨")
         }
     }
 
@@ -30,16 +30,21 @@ object SymbolSetSettingsTest : Spek({
         }
 
         it("fails if no symbol sets are defined") {
-            assertThat(SymbolSetSettings(emptyMap()).doValidate()).isEqualTo("Add at least one symbol set.")
+            assertThat(SymbolSetSettings(emptyList()).doValidate()).isEqualTo("Add at least one symbol set.")
         }
 
         it("fails if a symbol set does not have a name") {
-            assertThat(SymbolSetSettings(mapOf("" to "hAA76o")).doValidate())
+            assertThat(SymbolSetSettings(listOf("" to "hAA76o")).doValidate())
                 .isEqualTo("All symbol sets should have a name.")
         }
 
+        it("fails if two symbol sets have the same name") {
+            assertThat(SymbolSetSettings(listOf("seldom" to "K0A6pdHk", "seldom" to "sllfXObM")).doValidate())
+                .isEqualTo("Multiple symbol sets with name 'seldom'.")
+        }
+
         it("fails if a symbol set has no symbols") {
-            assertThat(SymbolSetSettings(mapOf("value" to "")).doValidate())
+            assertThat(SymbolSetSettings(listOf("value" to "")).doValidate())
                 .isEqualTo("Symbol set `value` should contain at least one symbol.")
         }
     }

--- a/src/test/kotlin/com/fwdekker/randomness/string/SymbolSetTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/string/SymbolSetTest.kt
@@ -28,49 +28,6 @@ object SymbolSetTest : Spek({
     }
 
     describe("utility methods") {
-        describe("toMap") {
-            it("converts an empty list to an empty map") {
-                val symbolSets = emptyList<SymbolSet>()
-
-                assertThat(symbolSets.toMap()).isEmpty()
-            }
-
-            it("converts a single symbol set to a single map entry") {
-                val symbolSets = listOf(SymbolSet("name", "abc"))
-
-                assertThat(symbolSets.toMap())
-                    .hasSize(1)
-                    .containsAllEntriesOf(mapOf("name" to "abc"))
-            }
-
-            it("collapses symbol sets with the same name") {
-                val symbolSets = listOf(SymbolSet("name", "abc"), SymbolSet("name", "def"))
-
-                assertThat(symbolSets.toMap()).hasSize(1)
-            }
-
-            it("retains the order of the symbol sets") {
-                val symbolSets = listOf(SymbolSet.ALPHABET, SymbolSet.DIGITS)
-
-                assertThat(symbolSets.toMap().toSymbolSets())
-                    .containsExactlyElementsOf(symbolSets.reversed().toMap().toSymbolSets().reversed())
-            }
-        }
-
-        describe("toSymbolSets") {
-            it("converts an empty map to an empty list") {
-                val map = emptyMap<String, String>()
-
-                assertThat(map.toSymbolSets()).isEmpty()
-            }
-
-            it("converts a single map entry to a single symbol set") {
-                val map = mapOf("name" to "abc")
-
-                assertThat(map.toSymbolSets()).containsExactly(SymbolSet("name", "abc"))
-            }
-        }
-
         describe("sum") {
             it("does nothing when a symbol set is added to itself") {
                 assertThat(listOf(SymbolSet.SPECIAL, SymbolSet.SPECIAL).sum())

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateListEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateListEditorTest.kt
@@ -538,7 +538,7 @@ object TemplateListEditorTest : Spek({
                     editor.loadState(
                         SettingsState(
                             templateList = TemplateList.from(StringScheme(), StringScheme()),
-                            symbolSetSettings = SymbolSetSettings(listOf("pocket" to "0MLnYk5"))
+                            symbolSetSettings = SymbolSetSettings(listOf(SymbolSet("pocket", "0MLnYk5")))
                         )
                     )
                 }
@@ -747,7 +747,7 @@ object TemplateListEditorTest : Spek({
                 editor.loadState(
                     SettingsState(
                         templateList = TemplateList.from(StringScheme(), name = "Yes"),
-                        symbolSetSettings = SymbolSetSettings(listOf("fish" to "Z5a0"))
+                        symbolSetSettings = SymbolSetSettings(listOf(SymbolSet("fish", "Z5a0")))
                     )
                 )
             }

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateListEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateListEditorTest.kt
@@ -294,10 +294,10 @@ object TemplateListEditorTest : Spek({
                     symbolSetTable().addRow(EditableDatum(active = true, SymbolSet("bottom", "nJmXN1N")))
                 }
 
-                assertThat(editor.readState().symbolSetSettings.symbolSets).containsKey("bottom")
+                assertThat(editor.readState().symbolSetSettings.symbolSets.map { it.name }).contains("bottom")
                 GuiActionRunner.execute { frame.clickActionButton("Reset") }
 
-                assertThat(editor.readState().symbolSetSettings.symbolSets).doesNotContainKey("bottom")
+                assertThat(editor.readState().symbolSetSettings.symbolSets.map { it.name }).doesNotContain("bottom")
             }
 
             it("resets changes to the dictionary settings") {
@@ -453,7 +453,7 @@ object TemplateListEditorTest : Spek({
                     symbolSetTable().addRow(EditableDatum(active = true, SymbolSet("ancient", "Fq9ohzV8")))
                 }
 
-                assertThat(editor.originalState.symbolSetSettings.symbolSets).doesNotContainKey("ancient")
+                assertThat(editor.originalState.symbolSetSettings.symbolSets.map { it.name }).doesNotContain("ancient")
             }
 
             it("does not change the original dictionaries when a word scheme is changed") {
@@ -538,7 +538,7 @@ object TemplateListEditorTest : Spek({
                     editor.loadState(
                         SettingsState(
                             templateList = TemplateList.from(StringScheme(), StringScheme()),
-                            symbolSetSettings = SymbolSetSettings(mapOf("pocket" to "0MLnYk5"))
+                            symbolSetSettings = SymbolSetSettings(listOf("pocket" to "0MLnYk5"))
                         )
                     )
                 }
@@ -584,7 +584,7 @@ object TemplateListEditorTest : Spek({
 
             GuiActionRunner.execute { editor.applyState() }
 
-            assertThat(editor.originalState.symbolSetSettings.symbolSets).containsKey("thumb")
+            assertThat(editor.originalState.symbolSetSettings.symbolSets.map { it.name }).contains("thumb")
         }
 
         it("does not apply changes to symbol sets after a reset") {
@@ -595,7 +595,7 @@ object TemplateListEditorTest : Spek({
 
             GuiActionRunner.execute { editor.reset() }
 
-            assertThat(editor.originalState.symbolSetSettings.symbolSets).doesNotContainKey("tell")
+            assertThat(editor.originalState.symbolSetSettings.symbolSets.map { it.name }).doesNotContain("tell")
         }
 
         it("applies changes to dictionaries") {
@@ -747,7 +747,7 @@ object TemplateListEditorTest : Spek({
                 editor.loadState(
                     SettingsState(
                         templateList = TemplateList.from(StringScheme(), name = "Yes"),
-                        symbolSetSettings = SymbolSetSettings(mapOf("fish" to "Z5a0"))
+                        symbolSetSettings = SymbolSetSettings(listOf("fish" to "Z5a0"))
                     )
                 )
             }

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateListEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateListEditorTest.kt
@@ -84,8 +84,16 @@ object TemplateListEditorTest : Spek({
 
 
     describe("buttons") {
-        xdescribe("add") {
-            // TODO: Find a way to test the addition popup
+        describe("add") {
+            it("adds a template if nothing is currently selected") {
+                GuiActionRunner.execute {
+                    frame.tree().target().clearSelection()
+                    frame.clickActionButton("Add")
+                }
+
+                assertThat(editor.readState().templateList.templates.map { it.name })
+                    .containsExactly("Further", "Enclose", "Student", "Template")
+            }
         }
 
         describe("remove") {
@@ -288,10 +296,10 @@ object TemplateListEditorTest : Spek({
                     .isEqualTo(0)
             }
 
-            it("resets changes to the symbol set settings") {
+            it("resets changes to the symbol set settings if a string scheme is selected") {
                 GuiActionRunner.execute {
                     frame.tree().target().setSelectionRow(7)
-                    symbolSetTable().addRow(EditableDatum(active = true, SymbolSet("bottom", "nJmXN1N")))
+                    symbolSetTable().addRow(EditableDatum(active = false, SymbolSet("bottom", "nJmXN1N")))
                 }
 
                 assertThat(editor.readState().symbolSetSettings.symbolSets.map { it.name }).contains("bottom")
@@ -303,7 +311,7 @@ object TemplateListEditorTest : Spek({
             it("resets changes to the dictionary settings") {
                 GuiActionRunner.execute {
                     frame.tree().target().setSelectionRow(5)
-                    dictionaryTable().addRow(EditableDatum(active = true, UserDictionary("people.dic")))
+                    dictionaryTable().addRow(EditableDatum(active = false, UserDictionary("people.dic")))
                 }
 
                 assertThat(editor.readState().dictionarySettings.dictionaries)

--- a/src/test/kotlin/com/fwdekker/randomness/word/DictionarySettingsTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/word/DictionarySettingsTest.kt
@@ -23,16 +23,26 @@ object DictionarySettingsTest : Spek({
             assertThat(DictionarySettings().doValidate()).isNull()
         }
 
+        it("fails if multiple dictionaries have the same name") {
+            val file = tempFileHelper.createFile("express\ntube", ".dic")
+
+            val settings = DictionarySettings(
+                listOf(UserDictionary(file.absolutePath), UserDictionary(file.absolutePath))
+            )
+
+            assertThat(settings.doValidate()).matches("Duplicate dictionary '.*\\.dic'\\.")
+        }
+
         it("fails if a dictionary of a now-deleted file is given") {
             val file = tempFileHelper.createFile("noon\nreason\n", ".dic").also { it.delete() }
 
-            val settings = DictionarySettings(setOf(UserDictionary(file.absolutePath)))
+            val settings = DictionarySettings(listOf(UserDictionary(file.absolutePath)))
 
             assertThat(settings.doValidate()).matches("Dictionary '.*\\.dic' is invalid: File not found\\.")
         }
 
         it("fails if one of the dictionaries is invalid") {
-            val settings = DictionarySettings(setOf(UserDictionary("does_not_exist.dic")))
+            val settings = DictionarySettings(listOf(UserDictionary("does_not_exist.dic")))
 
             assertThat(settings.doValidate()).isEqualTo("Dictionary 'does_not_exist.dic' is invalid: File not found.")
         }
@@ -40,7 +50,7 @@ object DictionarySettingsTest : Spek({
         it("fails if one the dictionaries is empty") {
             val file = tempFileHelper.createFile("", ".dic")
 
-            val settings = DictionarySettings(setOf(UserDictionary(file.absolutePath)))
+            val settings = DictionarySettings(listOf(UserDictionary(file.absolutePath)))
 
             assertThat(settings.doValidate()).matches("Dictionary '.*\\.dic' is empty\\.")
         }
@@ -49,7 +59,7 @@ object DictionarySettingsTest : Spek({
             val file = tempFileHelper.createFile("rapid\ncloth", ".dic")
             val dictionary = UserDictionary(file.absolutePath)
 
-            val settings = DictionarySettings(setOf(dictionary))
+            val settings = DictionarySettings(listOf(dictionary))
             dictionary.words // Force cache load
             file.writeText("")
 
@@ -71,16 +81,16 @@ object DictionarySettingsTest : Spek({
         }
 
         it("contains an independent list of dictionaries") {
-            val settings = DictionarySettings(setOf(BundledDictionary("wait.dic")))
+            val settings = DictionarySettings(listOf(BundledDictionary("wait.dic")))
 
             val copy = settings.deepCopy()
-            copy.dictionaries = setOf(BundledDictionary("upright.dic"))
+            copy.dictionaries = listOf(BundledDictionary("upright.dic"))
 
             assertThat(settings.dictionaries).containsExactly(BundledDictionary("wait.dic"))
         }
 
         it("contains a list of independent dictionaries") {
-            val settings = DictionarySettings(setOf(BundledDictionary("wait.dic")))
+            val settings = DictionarySettings(listOf(BundledDictionary("wait.dic")))
 
             val copy = settings.deepCopy()
             (copy.dictionaries.first() as BundledDictionary).filename = "defense.dic"

--- a/src/test/kotlin/com/fwdekker/randomness/word/WordSchemeEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/word/WordSchemeEditorTest.kt
@@ -106,13 +106,13 @@ object WordSchemeEditorTest : Spek({
         }
 
         it("loads the scheme's bundled dictionaries") {
-            val allDictionaries = setOf(UserDictionary("dictionary1.dic"), UserDictionary("dictionary2.dic"))
+            val allDictionaries = listOf(UserDictionary("dictionary1.dic"), UserDictionary("dictionary2.dic"))
             val activeDictionaries = setOf(UserDictionary("dictionary1.dic"))
 
             GuiActionRunner.execute {
                 editor.loadState(
-                    WordScheme(activeDictionaries = activeDictionaries.toSet())
-                        .also { it.dictionarySettings += DictionarySettings(allDictionaries.toSet()) }
+                    WordScheme(activeDictionaries = activeDictionaries)
+                        .also { it.dictionarySettings += DictionarySettings(allDictionaries) }
                 )
             }
 

--- a/src/test/kotlin/com/fwdekker/randomness/word/WordSchemeTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/word/WordSchemeTest.kt
@@ -118,7 +118,7 @@ object WordSchemeTest : Spek({
             it("fails if the dictionary settings are invalid") {
                 val file = tempFileHelper.createFile("heavenly\npet\n", ".dic").also { it.delete() }
 
-                dictionarySettings.dictionaries = setOf(UserDictionary(file.absolutePath))
+                dictionarySettings.dictionaries = listOf(UserDictionary(file.absolutePath))
 
                 assertThat(wordScheme.doValidate()).isNotNull()
             }
@@ -160,10 +160,10 @@ object WordSchemeTest : Spek({
         }
 
         it("creates an independent copy of the dictionary settings") {
-            (+wordScheme.dictionarySettings).dictionaries = setOf(UserDictionary("classify.dic"))
+            (+wordScheme.dictionarySettings).dictionaries = listOf(UserDictionary("classify.dic"))
 
             val copy = wordScheme.deepCopy()
-            (+copy.dictionarySettings).dictionaries = setOf(UserDictionary("decay.dic"))
+            (+copy.dictionarySettings).dictionaries = listOf(UserDictionary("decay.dic"))
 
             assertThat((+wordScheme.dictionarySettings).dictionaries).containsExactly(UserDictionary("classify.dic"))
         }
@@ -202,12 +202,12 @@ object WordSchemeTest : Spek({
         }
 
         it("writes a deep copy of the given scheme's dictionary settings into the target") {
-            val otherSettings = DictionarySettings(setOf(UserDictionary("complain.dic")))
+            val otherSettings = DictionarySettings(listOf(UserDictionary("complain.dic")))
             val otherScheme = WordScheme()
             otherScheme.dictionarySettings += otherSettings
 
             wordScheme.copyFrom(otherScheme)
-            (+otherScheme.dictionarySettings).dictionaries = setOf(UserDictionary("spit.dic"))
+            (+otherScheme.dictionarySettings).dictionaries = listOf(UserDictionary("spit.dic"))
 
             assertThat((+wordScheme.dictionarySettings).dictionaries).containsExactly(UserDictionary("complain.dic"))
         }


### PR DESCRIPTION
* Turns symbol sets and dictionaries into lists so that changes in order can be detected.
* Fixes some miscellaneous bugs with incorrect detection of when symbol sets are changed.
* Allows changing capitalisation mode of literals.