### PR TITLE
Simplify error reporter

### DIFF
--- a/src/main/kotlin/com/fwdekker/randomness/ErrorReporter.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/ErrorReporter.kt
@@ -2,10 +2,8 @@ package com.fwdekker.randomness
 
 import com.intellij.ide.BrowserUtil
 import com.intellij.ide.DataManager
-import com.intellij.ide.plugins.IdeaPluginDescriptor
 import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.application.ApplicationInfo
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.ErrorReportSubmitter
 import com.intellij.openapi.diagnostic.IdeaLoggingEvent
 import com.intellij.openapi.diagnostic.SubmittedReportInfo
@@ -13,16 +11,15 @@ import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.Task.Backgroundable
 import com.intellij.util.Consumer
 import java.awt.Component
-import java.net.IDN
-import java.net.URI
-import java.net.URL
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 
 
 /**
  * A report submitter that opens a pre-filled issue creation form on Randomness' GitHub repository.
  *
  * This class pertains to reports of exceptions that are not caught by the plugin and end up being shown to the user
- * as a notification by IntelliJ.
+ * as a notification by the IDE.
  */
 class ErrorReporter : ErrorReportSubmitter() {
     /**
@@ -33,9 +30,9 @@ class ErrorReporter : ErrorReportSubmitter() {
     override fun getReportActionText() = Bundle("reporter.report")
 
     /**
-     * Submits the exception as desired by the user.
+     * Submits the exception by opening the browser to create an issue on GitHub.
      *
-     * @param events the events that caused the exception
+     * @param events ignored
      * @param additionalInfo additional information provided by the user
      * @param parentComponent ignored
      * @param consumer ignored
@@ -50,16 +47,14 @@ class ErrorReporter : ErrorReportSubmitter() {
         val project = CommonDataKeys.PROJECT.getData(DataManager.getInstance().getDataContext(parentComponent))
         object : Backgroundable(project, Bundle("reporter.opening")) {
             override fun run(indicator: ProgressIndicator) {
-                BrowserUtil.open(getIssueUrl(events, additionalInfo))
-                ApplicationManager.getApplication().invokeLater {
-                    consumer.consume(
-                        SubmittedReportInfo(
-                            "https://github.com/FWDekker/intellij-randomness/issues",
-                            Bundle("reporter.issue"),
-                            SubmittedReportInfo.SubmissionStatus.NEW_ISSUE
-                        )
+                BrowserUtil.open(getIssueUrl(additionalInfo))
+                consumer.consume(
+                    SubmittedReportInfo(
+                        "https://github.com/FWDekker/intellij-randomness/issues",
+                        Bundle("reporter.issue"),
+                        SubmittedReportInfo.SubmissionStatus.NEW_ISSUE
                     )
-                }
+                )
             }
         }.queue()
         return true
@@ -70,42 +65,34 @@ class ErrorReporter : ErrorReportSubmitter() {
      *
      * @return the privacy notice text
      */
-    override fun getPrivacyNoticeText() =
-        """
-        Pressing the Report button will open a form on a web page with the details of this error filled in.
-        Submitting the form requires a GitHub account and is subject to <a href="https://github.com/site/privacy">
-        GitHub's privacy policy</a>.
-        """.trimIndent()
+    override fun getPrivacyNoticeText() = Bundle("reporter.privacy_notice")
 
 
     /**
      * Constructs a URL to create an issue with [additionalInfo] that is below the maximum URL limit.
      *
-     * @param events the events that caused the exception
-     * @param additionalInfo additional information provided by the user
+     * @param additionalInfo additional information about the exception provided by the user
      * @return a URL to create an issue with [additionalInfo] that is below the maximum URL limit
      */
-    // Public for testability
-    fun getIssueUrl(events: Array<out IdeaLoggingEvent>, additionalInfo: String?): String {
+    fun getIssueUrl(additionalInfo: String?): String {
         val baseUrl = "https://github.com/FWDekker/intellij-randomness/issues/new?body="
+
         val additionalInfoSection = createMarkdownSection(
             "Additional info",
-            if (additionalInfo.isNullOrBlank()) "_No additional information provided._"
-            else additionalInfo
+            if (additionalInfo.isNullOrBlank()) MORE_DETAIL_MESSAGE else additionalInfo
         )
-        val stackTracesSection = createMarkdownSection("Stacktraces", formatEvents(events))
-        val versionSection = createMarkdownSection("Version information", getFormattedVersionInformation())
+        val stacktraceSection = createMarkdownSection(
+            "Stacktraces",
+            STACKTRACE_MESSAGE
+        )
+        val versionSection = createMarkdownSection(
+            "Version information",
+            getFormattedVersionInformation()
+        )
 
-        val candidates = listOf(
-            additionalInfoSection + stackTracesSection + versionSection,
-            additionalInfoSection + versionSection,
-            stackTracesSection + versionSection,
-            versionSection,
-            ""
-        )
-        return baseUrl + candidates.first { encodeUrl(baseUrl + it).length <= MAX_URL_LENGTH }
-            .replace(' ', '+')
-            .filterNot { it in listOf('#', '&', ';') }
+        return URLEncoder.encode(additionalInfoSection + stacktraceSection + versionSection, StandardCharsets.UTF_8)
+            .replace("%2B", "+")
+            .let { baseUrl + it }
     }
 
     /**
@@ -119,71 +106,17 @@ class ErrorReporter : ErrorReportSubmitter() {
     private fun createMarkdownSection(title: String, contents: String) = "**${title.trim()}**\n${contents.trim()}\n\n"
 
     /**
-     * Formats IDEA events as Markdown-style code blocks inside spoilers.
-     *
-     * @param events the events to format
-     */
-    private fun formatEvents(events: Array<out IdeaLoggingEvent>) =
-        events.mapIndexed { i, event ->
-            wrapInMarkdownSpoiler(
-                title = "Stacktrace ${i + 1}/${events.size}",
-                contents = wrapInCodeBlock(contents = event.throwableText.trim(), language = "java")
-            )
-        }.joinToString("\n\n")
-
-    /**
-     * Creates a Markdown-style code block for [language].
-     *
-     * @param contents the contents of the code block
-     * @param language the language of the contents
-     * @return a Markdown-style code block for [language]
-     */
-    private fun wrapInCodeBlock(contents: String, language: String = "") = "```$language\n$contents\n```"
-
-    /**
-     * Creates a Markdown-style spoiler with [title] and [contents].
-     *
-     * @param title the title, which is the only thing that is displayed when the contents are hidden
-     * @param contents the contents which are initially hidden
-     * @return a Markdown-style spoiler [title] and [contents]
-     */
-    private fun wrapInMarkdownSpoiler(title: String, contents: String) =
-        "<details>\n<summary>$title</summary>\n<p>\n\n$contents\n\n</p>\n</details>"
-
-    /**
-     * Returns the version number of Randomness, or `null` if it could not be determined.
-     *
-     * @return the version number of Randomness, or `null` if it could not be determined
-     */
-    private fun getPluginVersion() =
-        if (pluginDescriptor is IdeaPluginDescriptor) (pluginDescriptor as IdeaPluginDescriptor).version
-        else null
-
-    /**
      * Returns version information on the user's environment as a Markdown-style list.
      *
      * @return version information on the user's environment as a Markdown-style list
      */
     private fun getFormattedVersionInformation() =
-        listOf(
-            Pair("Randomness version", getPluginVersion() ?: "_Unknown_"),
-            Pair("IDE version", ApplicationInfo.getInstance().apiVersion),
-            Pair("Operating system", System.getProperty("os.name")),
-            Pair("Java version", System.getProperty("java.version"))
-        ).joinToString("\n") { "- ${it.first}: ${it.second}" }
-
-    /**
-     * Correctly encodes a string describing a URL.
-     *
-     * Taken from https://stackoverflow.com/a/25735202.
-     *
-     * @param urlString the string to encode
-     * @return an encoded URL
-     */
-    private fun encodeUrl(urlString: String) =
-        URL(urlString.replace(' ', '+'))
-            .let { URI(it.protocol, it.userInfo, IDN.toASCII(it.host), it.port, it.path, it.query, it.ref) }
-            .toASCIIString()
+        """
+        - Randomness version: ${pluginDescriptor?.version ?: "_Unknown_"}
+        - IDE version: ${ApplicationInfo.getInstance().apiVersion}
+        - Operating system: ${System.getProperty("os.name")}
+        - Java version: ${System.getProperty("java.version")}
+        """.trimIndent()
 
 
     /**
@@ -191,8 +124,15 @@ class ErrorReporter : ErrorReportSubmitter() {
      */
     companion object {
         /**
-         * Maximum URL length supported by GitHub, experimentally verified.
+         * Message asking the user to provide more information about the exception.
          */
-        const val MAX_URL_LENGTH = 8000
+        const val MORE_DETAIL_MESSAGE =
+            "Please describe your issue in more detail here. What were you doing when the exception occurred?"
+
+        /**
+         * Message asking the user to provide stacktrace information.
+         */
+        const val STACKTRACE_MESSAGE =
+            "Please paste the full stacktrace from the IDE's error popup below.\n```java\n\n```"
     }
 }

--- a/src/main/resources/randomness.properties
+++ b/src/main/resources/randomness.properties
@@ -72,6 +72,7 @@ reference.ui.empty=Cannot reference any other template without causing recursion
 reference.title=Reference
 reporter.issue=Issue on GitHub
 reporter.opening=Opening GitHub in browser
+reporter.privacy_notice=Pressing the Report button will open a form on a web page with the details of this error filled in. Submitting the form requires a GitHub account and is subject to <a href="https://github.com/site/privacy">GitHub's privacy policy</a>.
 reporter.report=Report on GitHub
 shared.action.add=Add
 shared.action.copy=Copy

--- a/src/test/kotlin/com/fwdekker/randomness/ErrorReporterTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/ErrorReporterTest.kt
@@ -1,6 +1,5 @@
 package com.fwdekker.randomness
 
-import com.intellij.openapi.diagnostic.IdeaLoggingEvent
 import com.intellij.testFramework.fixtures.IdeaTestFixture
 import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
 import org.assertj.core.api.Assertions.assertThat
@@ -29,92 +28,17 @@ object ErrorReporterTest : Spek({
         }
 
 
-        describe("issue url") {
-            it("includes all components if they fit in the URL") {
-                val url = reporter.getIssueUrl(
-                    arrayOf(IdeaLoggingEvent("", Exception("EXCEPTION"))),
-                    "ADDITIONAL_INFO"
-                )
+        it("replaces whitespace with a plus") {
+            assertThat(reporter.getIssueUrl("safe verb")).contains("safe+verb")
+        }
 
-                assertThat(url)
-                    .contains("ADDITIONAL_INFO")
-                    .contains("EXCEPTION")
-                    .contains("Randomness+version")
-            }
+        it("escapes # and & in the additional info") {
+            assertThat(reporter.getIssueUrl("a&b")).doesNotContain("a&b")
+            assertThat(reporter.getIssueUrl("a#b")).doesNotContain("a#b")
+        }
 
-            it("excludes the stacktraces if they are too long") {
-                val url = reporter.getIssueUrl(
-                    arrayOf(IdeaLoggingEvent("", Exception("EXCEPTION_${List(10_000) { "A" }}"))),
-                    "ADDITIONAL_INFO"
-                )
-
-                assertThat(url)
-                    .contains("ADDITIONAL_INFO")
-                    .doesNotContain("EXCEPTION")
-                    .contains("Randomness+version")
-            }
-
-            it("excludes the additional info if they are too long") {
-                val url = reporter.getIssueUrl(
-                    arrayOf(IdeaLoggingEvent("", Exception("EXCEPTION"))),
-                    "ADDITIONAL_INFO_${List(10_000) { "A" }}"
-                )
-
-                assertThat(url)
-                    .doesNotContain("ADDITIONAL_INFO")
-                    .contains("EXCEPTION")
-                    .contains("Randomness+version")
-            }
-
-            it("excludes both additional info and stacktraces if either is too long") {
-                val url = reporter.getIssueUrl(
-                    arrayOf(IdeaLoggingEvent("", Exception("EXCEPTION_${List(10_000) { "A" }}"))),
-                    "ADDITIONAL_INFO_${List(10_000) { "A" }}"
-                )
-
-                assertThat(url)
-                    .doesNotContain("ADDITIONAL_INFO")
-                    .doesNotContain("EXCEPTION")
-                    .contains("Randomness+version")
-            }
-
-            describe("encoding") {
-                it("includes all parts that are not expanded due to encoding") {
-                    val url = reporter.getIssueUrl(
-                        arrayOf(IdeaLoggingEvent("", Exception("EXCEPTION"))),
-                        "ADDITIONAL_INFO_${List(1000) { "A" }}"
-                    )
-
-                    assertThat(url)
-                        .contains("ADDITIONAL_INFO")
-                        .contains("EXCEPTION")
-                        .contains("Randomness+version")
-                }
-
-                it("does not expand whitespace") {
-                    val url = reporter.getIssueUrl(
-                        arrayOf(IdeaLoggingEvent("", Exception("EXCEPTION"))),
-                        "ADDITIONAL_INFO_${List(1000) { " " }}_" // Trailing `_` to prevent trimming
-                    )
-
-                    assertThat(url)
-                        .contains("ADDITIONAL_INFO")
-                        .contains("EXCEPTION")
-                        .contains("Randomness+version")
-                }
-
-                it("excludes parts that are expanded") {
-                    val url = reporter.getIssueUrl(
-                        arrayOf(IdeaLoggingEvent("", Exception("EXCEPTION"))),
-                        "ADDITIONAL_INFO_${List(2000) { "\n" }}"
-                    )
-
-                    assertThat(url)
-                        .doesNotContain("ADDITIONAL_INFO")
-                        .contains("EXCEPTION")
-                        .contains("Randomness+version")
-                }
-            }
+        it("asks the user to provide additional information if none was provided") {
+            assertThat(reporter.getIssueUrl(null)).contains("Please+describe+your+issue")
         }
     }
 })


### PR DESCRIPTION
Fixes #411.

Looking at their code, perhaps I was mistaken that TeXiFy doesn't include stacktraces. But either way I've always felt that my code was very finnicky and I fear that the error reporter sometimes breaks, which is of course not a good thing. So to be on the safe side, the error reporter is now much less complex and simply asks the user to copy the stacktrace into GitHub. A bit more work for the user, but I think it's less prone to crashing this way.

If GitHub had a better way of doing this I would have used it, but I can't really imagine how that would work without authentication.