### PR TITLE
Preset word list

### DIFF
--- a/packages.md
+++ b/packages.md
@@ -40,4 +40,4 @@ Scheme for random UUIDs.
 
 # Package com.fwdekker.randomness.word
 
-Scheme for random words selected from dictionaries.
+Scheme for random words selected from word lists.

--- a/src/main/kotlin/com/fwdekker/randomness/template/TemplateListEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/template/TemplateListEditor.kt
@@ -19,7 +19,6 @@ import com.fwdekker.randomness.uuid.UuidSchemeEditor
 import com.fwdekker.randomness.word.WordScheme
 import com.fwdekker.randomness.word.WordSchemeEditor
 import com.intellij.openapi.ui.Splitter
-import com.intellij.openapi.util.Disposer
 import com.intellij.ui.OnePixelSplitter
 import com.intellij.ui.components.JBScrollPane
 import com.intellij.util.ui.JBEmptyBorder
@@ -77,7 +76,7 @@ class TemplateListEditor(settings: SettingsState = SettingsState.default) : Stat
 
             if (selectedNode.state is Template) selectedNode.state
             else parentNode.state as Template
-        }.also { Disposer.register(this, it) }
+        }
         addChangeListener { previewPanel.updatePreview() }
         schemeEditorPanel.border = JBEmptyBorder(EDITOR_PANEL_MARGIN)
         schemeEditorPanel.add(previewPanel.rootComponent, BorderLayout.SOUTH)
@@ -104,8 +103,6 @@ class TemplateListEditor(settings: SettingsState = SettingsState.default) : Stat
 
         schemeEditor = createEditor(selectedState)
             .also { editor ->
-                Disposer.register(this, editor)
-
                 editor.addChangeListener {
                     editor.applyState()
                     templateTree.myModel.fireNodeStructureChanged(selectedNode)
@@ -179,9 +176,15 @@ class TemplateListEditor(settings: SettingsState = SettingsState.default) : Stat
         }
     }
 
+
     override fun addChangeListener(listener: () -> Unit) {
         templateTree.model.addTreeModelListener(SimpleTreeModelListener { listener() })
         templateTree.addTreeSelectionListener { listener() }
+    }
+
+    override fun dispose() {
+        schemeEditor?.dispose()
+        previewPanel.dispose()
     }
 
 

--- a/src/main/kotlin/com/fwdekker/randomness/ui/PreviewPanel.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/ui/PreviewPanel.kt
@@ -7,6 +7,7 @@ import com.fwdekker.randomness.Timely.generateTimely
 import com.intellij.icons.AllIcons
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.runWriteAction
+import com.intellij.openapi.command.undo.UndoUtil
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.EditorFactory
@@ -70,6 +71,7 @@ class PreviewPanel(private val getScheme: () -> Scheme) : Disposable {
 
         val factory = EditorFactory.getInstance()
         previewDocument = factory.createDocument(Bundle("preview.placeholder"))
+        UndoUtil.disableUndoFor(previewDocument)
         previewEditor = factory.createViewer(previewDocument)
         previewComponent = previewEditor.component
     }

--- a/src/main/kotlin/com/fwdekker/randomness/word/DefaultWordList.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/word/DefaultWordList.kt
@@ -2,6 +2,7 @@ package com.fwdekker.randomness.word
 
 import com.fwdekker.randomness.Bundle
 import java.io.IOException
+import java.util.concurrent.ConcurrentHashMap
 
 
 /**
@@ -17,19 +18,27 @@ data class DefaultWordList(val name: String, val filename: String) {
      * @throws IOException if the resource file could not be found
      */
     @get:Throws(IOException::class)
-    val words: List<String>
-        get() =
+    val words: List<String> by lazy {
+        cache.getOrPut(filename) {
             (javaClass.classLoader.getResource(filename) ?: throw IOException(Bundle("word_list.error.file_not_found")))
                 .openStream()
                 .bufferedReader()
                 .readLines()
                 .filterNot { it.isBlank() }
+        }
+    }
 
 
     /**
      * Holds constants.
      */
     companion object {
+        /**
+         * Retains word lists that have previously been looked up.
+         */
+        @get:Synchronized
+        private val cache = ConcurrentHashMap<String, List<String>>()
+
         /**
          * The list of all available word lists.
          */

--- a/src/main/kotlin/com/fwdekker/randomness/word/DefaultWordList.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/word/DefaultWordList.kt
@@ -1,0 +1,46 @@
+package com.fwdekker.randomness.word
+
+import com.fwdekker.randomness.Bundle
+import java.io.IOException
+
+
+/**
+ * A list of words read from a bundled file.
+ *
+ * @property name The name of the file as presented and understood by the end user.
+ * @property filename The location of the resource file containing the words.
+ */
+data class DefaultWordList(val name: String, val filename: String) {
+    /**
+     * The words in this list.
+     *
+     * @throws IOException if the resource file could not be found
+     */
+    @get:Throws(IOException::class)
+    val words: List<String>
+        get() =
+            (javaClass.classLoader.getResource(filename) ?: throw IOException(Bundle("word_list.error.file_not_found")))
+                .openStream()
+                .bufferedReader()
+                .readLines()
+                .filterNot { it.isBlank() }
+
+
+    /**
+     * Holds constants.
+     */
+    companion object {
+        /**
+         * The list of all available word lists.
+         */
+        val wordLists = listOf(
+            DefaultWordList("Names", "word-lists/names.txt"),
+            DefaultWordList("Places", "word-lists/places.txt")
+        )
+
+        /**
+         * The available [wordLists] as indexed by [name].
+         */
+        val wordListMap = wordLists.associateBy { it.name }
+    }
+}

--- a/src/main/kotlin/com/fwdekker/randomness/word/WordSchemeEditor.form
+++ b/src/main/kotlin/com/fwdekker/randomness/word/WordSchemeEditor.form
@@ -8,7 +8,7 @@
     <properties/>
     <border type="none"/>
     <children>
-      <grid id="3ace5" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="3ace5" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="7" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -22,9 +22,17 @@
             </constraints>
             <properties/>
           </component>
+          <component id="a49c2" class="com.intellij.openapi.ui.ComboBox" binding="wordListBox" custom-create="true">
+            <constraints>
+              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="0" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <name value="wordListBox"/>
+            </properties>
+          </component>
           <component id="598e5" class="javax.swing.JComponent" binding="wordListComponent" custom-create="true">
             <constraints>
-              <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false">
+              <grid row="1" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false">
                 <preferred-size width="10" height="260"/>
               </grid>
             </constraints>

--- a/src/main/kotlin/com/fwdekker/randomness/word/WordSchemeEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/word/WordSchemeEditor.kt
@@ -17,8 +17,10 @@ import com.intellij.openapi.application.runWriteAction
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.EditorFactory
+import com.intellij.openapi.ui.ComboBox
 import com.intellij.ui.SeparatorFactory
 import com.intellij.ui.TitledSeparator
+import com.intellij.ui.components.JBLabel
 import javax.swing.ButtonGroup
 import javax.swing.JComponent
 import javax.swing.JLabel
@@ -37,6 +39,7 @@ class WordSchemeEditor(scheme: WordScheme = WordScheme()) : StateEditor<WordSche
         get() = capitalizationLabel.labelFor as JComponent
 
     private lateinit var wordListSeparator: TitledSeparator
+    private lateinit var wordListBox: ComboBox<DefaultWordList>
     private lateinit var wordListDocument: Document
     private lateinit var wordListEditor: Editor
     private lateinit var wordListComponent: JComponent
@@ -76,6 +79,14 @@ class WordSchemeEditor(scheme: WordScheme = WordScheme()) : StateEditor<WordSche
     @Suppress("UnusedPrivateMember") // Used by scene builder
     private fun createUIComponents() {
         wordListSeparator = SeparatorFactory.createSeparator(Bundle("word.ui.word_list"), null)
+
+        wordListBox = ComboBox(arrayOf(PRESET_ITEM) + DefaultWordList.wordLists)
+        wordListBox.setRenderer { _, value, _, _, _ -> JBLabel(value.name) }
+        wordListBox.addActionListener {
+            if (wordListBox.selectedIndex != 0)
+                wordList = (wordListBox.selectedItem as DefaultWordList).words
+        }
+
         val factory = EditorFactory.getInstance()
         wordListDocument = factory.createDocument("")
         wordListEditor = factory.createEditor(wordListDocument)
@@ -121,6 +132,18 @@ class WordSchemeEditor(scheme: WordScheme = WordScheme()) : StateEditor<WordSche
             wordListDocument, capitalizationGroup, quotationGroup, customQuotation, arrayDecoratorEditor,
             listener = listener
         )
+
+
+    /**
+     * Holds constants.
+     */
+    companion object {
+        /**
+         * The "header" item inserted at the top of the [wordListBox].
+         */
+        val PRESET_ITEM
+            get() = DefaultWordList("<html><i>${Bundle("word_list.ui.select_preset")}</i>", "")
+    }
 }
 
 

--- a/src/main/kotlin/com/fwdekker/randomness/word/WordSchemeEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/word/WordSchemeEditor.kt
@@ -5,6 +5,7 @@ import com.fwdekker.randomness.CapitalizationMode.Companion.getMode
 import com.fwdekker.randomness.StateEditor
 import com.fwdekker.randomness.array.ArrayDecoratorEditor
 import com.fwdekker.randomness.ui.MaxLengthDocumentFilter
+import com.fwdekker.randomness.ui.SimpleJBDocumentListener
 import com.fwdekker.randomness.ui.UIConstants
 import com.fwdekker.randomness.ui.VariableLabelRadioButton
 import com.fwdekker.randomness.ui.addChangeListenerTo
@@ -17,6 +18,7 @@ import com.intellij.openapi.application.runWriteAction
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.EditorFactory
+import com.intellij.openapi.roots.ui.whenItemSelected
 import com.intellij.openapi.ui.ComboBox
 import com.intellij.ui.SeparatorFactory
 import com.intellij.ui.TitledSeparator
@@ -57,7 +59,7 @@ class WordSchemeEditor(scheme: WordScheme = WordScheme()) : StateEditor<WordSche
      */
     private var wordList: List<String>
         get() = wordListDocument.text.split('\n').filterNot { it.isBlank() }
-        set(value) = runWriteAction { wordListDocument.setText(value.joinToString(separator = "\n")) }
+        set(value) = runWriteAction { wordListDocument.setText(value.joinToString(separator = "\n", postfix = "\n")) }
 
 
     init {
@@ -82,15 +84,18 @@ class WordSchemeEditor(scheme: WordScheme = WordScheme()) : StateEditor<WordSche
 
         wordListBox = ComboBox(arrayOf(PRESET_ITEM) + DefaultWordList.wordLists)
         wordListBox.setRenderer { _, value, _, _, _ -> JBLabel(value.name) }
-        wordListBox.addActionListener {
-            if (wordListBox.selectedIndex != 0)
-                wordList = (wordListBox.selectedItem as DefaultWordList).words
-        }
+        wordListBox.whenItemSelected { if (it != PRESET_ITEM) wordList = it.words }
 
         val factory = EditorFactory.getInstance()
         wordListDocument = factory.createDocument("")
         wordListEditor = factory.createEditor(wordListDocument)
         wordListComponent = wordListEditor.component
+        wordListDocument.addDocumentListener(
+            SimpleJBDocumentListener {
+                if (wordListBox.selectedIndex != 0 && wordList != wordListBox.item.words)
+                    wordListBox.selectedIndex = 0
+            }
+        )
 
         appearanceSeparator = SeparatorFactory.createSeparator(Bundle("word.ui.appearance"), null)
         customQuotation = VariableLabelRadioButton(UIConstants.WIDTH_TINY, MaxLengthDocumentFilter(2))
@@ -110,6 +115,7 @@ class WordSchemeEditor(scheme: WordScheme = WordScheme()) : StateEditor<WordSche
     override fun loadState(state: WordScheme) {
         super.loadState(state)
 
+        wordListBox.selectedIndex = DefaultWordList.wordLists.map { it.words }.indexOf(state.words) + 1
         wordList = state.words
         customQuotation.label = state.customQuotation
         quotationGroup.setValue(state.quotation)

--- a/src/main/resources/randomness.properties
+++ b/src/main/resources/randomness.properties
@@ -166,3 +166,5 @@ word.ui.capitalization_option=&Capitalization:
 word.ui.quotation_marks.option=&Quotation marks:
 word.ui.quotation_marks.none=None
 word.ui.word_list=Word List
+word_list.error.file_not_found=File not found.
+word_list.ui.select_preset=Insert preset

--- a/src/main/resources/word-lists/names.txt
+++ b/src/main/resources/word-lists/names.txt
@@ -1,0 +1,4 @@
+Jake
+Jane
+John
+José

--- a/src/main/resources/word-lists/places.txt
+++ b/src/main/resources/word-lists/places.txt
@@ -1,0 +1,3 @@
+Amsterdam
+Delft
+Rotterdam

--- a/src/test/kotlin/com/fwdekker/randomness/word/DefaultWordListTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/word/DefaultWordListTest.kt
@@ -1,0 +1,42 @@
+package com.fwdekker.randomness.word
+
+import com.fwdekker.randomness.Bundle
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.io.IOException
+
+
+/**
+ * Unit tests for [DefaultWordList].
+ */
+class DefaultWordListTest : Spek({
+    describe("words") {
+        it("throws an exception if the file does not exist") {
+            val list = DefaultWordList("throw", "word-lists/does-not-exist.txt")
+
+            assertThatThrownBy { list.words }
+                .isInstanceOf(IOException::class.java)
+                .hasMessage(Bundle("word_list.error.file_not_found"))
+        }
+
+        it("returns an empty list of words if the file is empty") {
+            val list = DefaultWordList("tailor", "word-lists/empty-list.txt")
+
+            assertThat(list.words).isEmpty()
+        }
+
+        it("returns the list of words from the file") {
+            val list = DefaultWordList("off", "word-lists/non-empty-list.txt")
+
+            assertThat(list.words).containsExactly("lorem", "ipsum", "dolor")
+        }
+
+        it("does not return blank lines") {
+            val list = DefaultWordList("wander", "word-lists/with-blank-lines.txt")
+
+            assertThat(list.words).containsExactly("afraid", "dive", "snow", "enemy")
+        }
+    }
+})

--- a/src/test/kotlin/com/fwdekker/randomness/word/WordSchemeEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/word/WordSchemeEditorTest.kt
@@ -54,7 +54,7 @@ object WordSchemeEditorTest : Spek({
         it("loads the scheme's words") {
             GuiActionRunner.execute { editor.loadState(WordScheme(words = listOf("summer", "another"))) }
 
-            assertThat(wordsEditor.text).isEqualTo("summer\nanother")
+            assertThat(wordsEditor.text).isEqualTo("summer\nanother\n")
         }
 
         it("loads the scheme's quotation") {
@@ -162,7 +162,7 @@ object WordSchemeEditorTest : Spek({
 
             GuiActionRunner.execute { frame.comboBox("wordListBox").target().selectedIndex = 0 }
 
-            assertThat(wordsEditor.text).isEqualTo("street\nsell")
+            assertThat(wordsEditor.text).isEqualTo("street\nsell\n")
         }
 
         it("inserts the words of the selected entry") {
@@ -171,7 +171,7 @@ object WordSchemeEditorTest : Spek({
             GuiActionRunner.execute { frame.comboBox("wordListBox").target().selectedIndex = 1 }
 
             val expectedList = frame.comboBox("wordListBox").target().getItemAt(1) as DefaultWordList
-            assertThat(wordsEditor.text).isEqualTo(expectedList.words.joinToString("\n"))
+            assertThat(wordsEditor.text).isEqualTo(expectedList.words.joinToString(separator = "\n", postfix = "\n"))
         }
     }
 

--- a/src/test/kotlin/com/fwdekker/randomness/word/WordSchemeEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/word/WordSchemeEditorTest.kt
@@ -156,6 +156,26 @@ object WordSchemeEditorTest : Spek({
     }
 
 
+    describe("word list insertion") {
+        it("does nothing if the first entry is selected") {
+            GuiActionRunner.execute { editor.loadState(WordScheme(words = listOf("street", "sell"))) }
+
+            GuiActionRunner.execute { frame.comboBox("wordListBox").target().selectedIndex = 0 }
+
+            assertThat(wordsEditor.text).isEqualTo("street\nsell")
+        }
+
+        it("inserts the words of the selected entry") {
+            GuiActionRunner.execute { editor.loadState(WordScheme(words = listOf("grow", "trip"))) }
+
+            GuiActionRunner.execute { frame.comboBox("wordListBox").target().selectedIndex = 1 }
+
+            val expectedList = frame.comboBox("wordListBox").target().getItemAt(1) as DefaultWordList
+            assertThat(wordsEditor.text).isEqualTo(expectedList.words.joinToString("\n"))
+        }
+    }
+
+
     describe("addChangeListener") {
         it("invokes the listener if a field changes") {
             var listenerInvoked = false

--- a/src/test/resources/word-lists/non-empty-list.txt
+++ b/src/test/resources/word-lists/non-empty-list.txt
@@ -1,0 +1,3 @@
+lorem
+ipsum
+dolor

--- a/src/test/resources/word-lists/timing-test-global.txt
+++ b/src/test/resources/word-lists/timing-test-global.txt
@@ -1,0 +1,6 @@
+escape
+marriage
+invent
+account
+side
+daughter

--- a/src/test/resources/word-lists/timing-test-instance.txt
+++ b/src/test/resources/word-lists/timing-test-instance.txt
@@ -1,0 +1,5 @@
+cage
+shelter
+inquire
+know
+pastry

--- a/src/test/resources/word-lists/with-blank-lines.txt
+++ b/src/test/resources/word-lists/with-blank-lines.txt
@@ -1,0 +1,6 @@
+afraid
+
+dive
+snow
+
+enemy


### PR DESCRIPTION
Sort-of re-introduces the "dictionary" in the sense that users can select from a pre-defined list of word lists to paste into their word list editor. As before, word lists are cached appropriately. Currently, the available word lists are just placeholders.

Also
* disables undo actions for the preview, as this would cause exceptions when pressing Ctrl+Z while looking at the preview,
* adds newlines at the end of loaded word lists, and
* resolves an issue where editors would get disposed multiple times.