### PR TITLE
Bump

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -89,7 +89,6 @@ tasks {
 
     // Tests/coverage
     test {
-        systemProperty("java.awt.headless", "false")
         systemProperty("spek2.execution.test.timeout", 0)
 
         useJUnitPlatform {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,15 +7,14 @@ fun properties(key: String) = project.findProperty(key).toString()
 /// Plugins
 plugins {
     // Compilation
-    // TODO: Update to Kotlin 1.5.30 once https://github.com/jacoco/jacoco/issues/1182 has been fixed
-    id("org.jetbrains.kotlin.jvm") version "1.5.21"  // See also `gradle.properties`
-    id("org.jetbrains.intellij") version "1.3.0"
+    id("org.jetbrains.kotlin.jvm") version "1.6.20"  // See also `gradle.properties`
+    id("org.jetbrains.intellij") version "1.5.2"
 
     // Tests/coverage
     id("jacoco")
 
     // Static analysis
-    id("io.gitlab.arturbosch.detekt") version "1.19.0"  // See also `gradle.properties`
+    id("io.gitlab.arturbosch.detekt") version "1.20.0"  // See also `gradle.properties`
 
     // Documentation
     id("org.jetbrains.dokka") version "1.6.0"

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,20 +2,20 @@ group=com.fwdekker
 version=3.0.0-dev
 
 # Compatibility
-# * If latest is 20xx.y, then support at least [20xx-1].[y+1].
+# * If latest is 20xx.y, then support at least [20xx-1].[y+1]
 #   e.g., if latest is 2020.3, support at least 2019.4 (aka 2020.1).
 #   See also https://data.services.jetbrains.com/products?fields=name,releases.version,releases.build&code=IC,CL.
-pluginSinceBuild=211.0
-intellijVersion=2021.3
-pluginVerifierIdeVersions=IC-2021.1.3, IC-2021.2.2, IC-2021.3.1, CL-2021.1.3, CL-2021.2.2, CL-2021.3
+pluginSinceBuild=212.0
+intellijVersion=2022.1
+pluginVerifierIdeVersions=IC-2021.2.2, IC-2021.3.1, IC-2022.1.1, CL-2021.2.2, CL-2021.3, CL-2022.1
 
 # Targets
 # * `javaVersion` is the same as `jvmVersion`.
 # * Kotlin should also be updated in `plugins` block.
 javaVersion=11
 jvmVersion=11
-kotlinVersion=1.5
-kotlinApiVersion=1.5
+kotlinVersion=1.6
+kotlinApiVersion=1.6
 
 # Dependencies
 # * Detekt should also be updated in `plugins` block.
@@ -23,7 +23,7 @@ kotlinApiVersion=1.5
 assertjVersion=3.17.2
 assertjSwingVersion=3.17.1
 dateparserVersion=1.0.7
-detektVersion=1.19.0
+detektVersion=1.20.0
 emojiVersion=5.1.1
 jacocoVersion=0.8.7
 junitVersion=5.8.2

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-all.zip

--- a/src/main/kotlin/com/fwdekker/randomness/CapitalizationMode.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/CapitalizationMode.kt
@@ -77,24 +77,24 @@ enum class CapitalizationMode(val descriptor: String, private val transformer: (
         fun getMode(descriptor: String) =
             values().firstOrNull { it.descriptor == descriptor }
                 ?: throw IllegalArgumentException(Bundle("shared.capitalization.error.name_not_found", descriptor))
-
-
-        /**
-         * Randomly converts this character to uppercase or lowercase.
-         *
-         * @param random the source of randomness to use
-         * @return the uppercase or lowercase version of this character
-         */
-        private fun Char.toRandomCase(random: Random) =
-            if (random.nextBoolean()) this.lowercaseChar()
-            else this.uppercaseChar()
-
-        /**
-         * Turns the first character uppercase while all other characters become lowercase.
-         *
-         * @return the sentence-case form of this string
-         */
-        private fun String.toSentenceCase() =
-            this.lowercase(Locale.getDefault()).replaceFirstChar { it.uppercaseChar() }
     }
 }
+
+
+/**
+ * Randomly converts this character to uppercase or lowercase.
+ *
+ * @param random the source of randomness to use
+ * @return the uppercase or lowercase version of this character
+ */
+private fun Char.toRandomCase(random: Random) =
+    if (random.nextBoolean()) this.lowercaseChar()
+    else this.uppercaseChar()
+
+/**
+ * Turns the first character uppercase while all other characters become lowercase.
+ *
+ * @return the sentence-case form of this string
+ */
+private fun String.toSentenceCase() =
+    this.lowercase(Locale.getDefault()).replaceFirstChar { it.uppercaseChar() }

--- a/src/main/kotlin/com/fwdekker/randomness/RandomnessIcons.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/RandomnessIcons.kt
@@ -18,57 +18,57 @@ object RandomnessIcons {
     /**
      * The main icon of Randomness.
      */
-    val RANDOMNESS = IconLoader.findIcon("/icons/randomness.svg")!!
+    val RANDOMNESS = IconLoader.findIcon("/icons/randomness.svg", this.javaClass.classLoader)!!
 
     /**
      * The template icon for template icons.
      */
-    val TEMPLATE = IconLoader.findIcon("/icons/template.svg")!!
+    val TEMPLATE = IconLoader.findIcon("/icons/template.svg", this.javaClass.classLoader)!!
 
     /**
      * The template icon for scheme icons.
      */
-    val SCHEME = IconLoader.findIcon("/icons/scheme.svg")!!
+    val SCHEME = IconLoader.findIcon("/icons/scheme.svg", this.javaClass.classLoader)!!
 
     /**
      * An icon for settings.
      */
-    val SETTINGS = IconLoader.findIcon("/icons/settings.svg")!!
+    val SETTINGS = IconLoader.findIcon("/icons/settings.svg", this.javaClass.classLoader)!!
 
     /**
      * A filled-in version of [SETTINGS].
      */
-    val SETTINGS_FILLED = IconLoader.findIcon("/icons/settings-filled.svg")!!
+    val SETTINGS_FILLED = IconLoader.findIcon("/icons/settings-filled.svg", this.javaClass.classLoader)!!
 
     /**
      * An icon for arrays.
      */
-    val ARRAY = IconLoader.findIcon("/icons/array.svg")!!
+    val ARRAY = IconLoader.findIcon("/icons/array.svg", this.javaClass.classLoader)!!
 
     /**
      * A filled-in version of [ARRAY].
      */
-    val ARRAY_FILLED = IconLoader.findIcon("/icons/array-filled.svg")!!
+    val ARRAY_FILLED = IconLoader.findIcon("/icons/array-filled.svg", this.javaClass.classLoader)!!
 
     /**
      * An icon for references.
      */
-    val REFERENCE = IconLoader.findIcon("/icons/reference.svg")!!
+    val REFERENCE = IconLoader.findIcon("/icons/reference.svg", this.javaClass.classLoader)!!
 
     /**
      * A filled-in version of [REFERENCE].
      */
-    val REFERENCE_FILLED = IconLoader.findIcon("/icons/reference-filled.svg")!!
+    val REFERENCE_FILLED = IconLoader.findIcon("/icons/reference-filled.svg", this.javaClass.classLoader)!!
 
     /**
      * An icon for repeated insertions.
      */
-    val REPEAT = IconLoader.findIcon("/icons/repeat.svg")!!
+    val REPEAT = IconLoader.findIcon("/icons/repeat.svg", this.javaClass.classLoader)!!
 
     /**
      * A filled-in version of [REPEAT].
      */
-    val REPEAT_FILLED = IconLoader.findIcon("/icons/repeat-filled.svg")!!
+    val REPEAT_FILLED = IconLoader.findIcon("/icons/repeat-filled.svg", this.javaClass.classLoader)!!
 }
 
 

--- a/src/main/kotlin/com/fwdekker/randomness/template/Template.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/template/Template.kt
@@ -34,7 +34,7 @@ data class Template(
             WordScheme::class,
             UuidScheme::class,
             DateTimeScheme::class,
-            TemplateReference::class,
+            TemplateReference::class
         ]
     )
     var schemes: List<Scheme> = DEFAULT_SCHEMES.toMutableList(),

--- a/src/main/kotlin/com/fwdekker/randomness/template/TemplateJTree.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/template/TemplateJTree.kt
@@ -110,6 +110,7 @@ class TemplateJTree(
 
         emptyText.text = Bundle("template_list.ui.empty")
         isRootVisible = false
+        showsRootHandles = true
         selectionModel.selectionMode = TreeSelectionModel.SINGLE_TREE_SELECTION
         setCellRenderer(CellRenderer())
         addTreeWillExpandListener(object : TreeWillExpandListener {

--- a/src/test/kotlin/com/fwdekker/randomness/SchemeTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/SchemeTest.kt
@@ -94,7 +94,7 @@ object SchemeTest : Spek({
         it("applies decorators on each other in ascending order") {
             scheme.decorators = listOf(
                 ArrayDecorator(enabled = true, minCount = 2, maxCount = 2),
-                ArrayDecorator(enabled = true, minCount = 3, maxCount = 3),
+                ArrayDecorator(enabled = true, minCount = 3, maxCount = 3)
             )
             scheme.literals = listOf("save")
 

--- a/src/test/kotlin/com/fwdekker/randomness/integer/IntegerSchemeTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/integer/IntegerSchemeTest.kt
@@ -36,7 +36,7 @@ object IntegerSchemeTest : Spek({
                 Pair(488L, 488L) to "488",
                 Pair(-876L, -876L) to "-876",
                 Pair(Long.MIN_VALUE, Long.MIN_VALUE) to Long.MIN_VALUE.toString(),
-                Pair(Long.MAX_VALUE, Long.MAX_VALUE) to Long.MAX_VALUE.toString(),
+                Pair(Long.MAX_VALUE, Long.MAX_VALUE) to Long.MAX_VALUE.toString()
             ).forEach { (minValue, maxValue), expectedString ->
                 it("generates $expectedString") {
                     integerScheme.minValue = minValue
@@ -96,7 +96,7 @@ object IntegerSchemeTest : Spek({
             mapOf(
                 Param(624L, 10, "", CapitalizationMode.UPPER) to "624",
                 Param(254L, 16, "", CapitalizationMode.UPPER) to "FE",
-                Param(254L, 16, "0x", CapitalizationMode.FIRST_LETTER) to "0xFe",
+                Param(254L, 16, "0x", CapitalizationMode.FIRST_LETTER) to "0xFe"
             ).forEach { (value, base, prefix, capitalization), expectedString ->
                 it("generates $expectedString") {
                     integerScheme.minValue = value


### PR DESCRIPTION
Updates a bunch of dependencies, including IDEA and Kotlin, and ensures that they work correctly. Several tools were not working correctly anymore and I had to work around them, such as:

* The Gradle IntelliJ plugin v1.5.3 does not work with UI design forms, so I used v1.5.2 for now
* Headless tests were behaving weirdly (see the corresponding commit message)

I also updated some minor things, but really, end users won't notice a thing!

---

Unfortunately, the major coverage drop is a result of updating Kotlin, since all usages of all lateinits (which are a lot in the UI) are now incorrectly considered not covered. See also jacoco/jacoco#1182.