### PR TITLE
Escape at in custom list

### DIFF
--- a/src/main/kotlin/com/fwdekker/randomness/BracketsDescriptor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/BracketsDescriptor.kt
@@ -1,0 +1,47 @@
+package com.fwdekker.randomness
+
+
+/**
+ * A description of brackets surrounding a string.
+ *
+ * @property descriptor The description of brackets into which a string can be inserted with [interpolate]. Here, `'\'`
+ * is the escape character (which also escapes itself), and each unescaped `'@'` is replaced with the inserted string.
+ * If the descriptor does not contain an unescaped `'@'`, then the entire descriptor is placed both in front of and
+ * after the inserted string. For example, inserting `"word"` into `"(@)"` gives `"(word)"`, and inserting `"word"` into
+ * `"()"` gives `"()word()"`.
+ */
+data class BracketsDescriptor(val descriptor: String) {
+    /**
+     * Validates the [descriptor], and indicates whether and why it is invalid.
+     *
+     * @return `null` if the [descriptor] is valid, or a string explaining why the [descriptor] is invalid
+     */
+    fun doValidate(): String? =
+        if (!descriptor.fold(false) { escaped, char -> if (char == '\\') !escaped else false }) null
+        else Bundle("brackets.error.trailing_escape")
+
+    /**
+     * Replaces each unescaped `'@'` in [descriptor] with [insert], and interprets escaped characters.
+     *
+     * @param insert the string to insert into [descriptor]
+     * @return the [descriptor] with [insert] inserted and escape characters interpreted
+     * @throws DataGenerationException if the [descriptor] is invalid according to [doValidate]
+     * @see descriptor
+     */
+    fun interpolate(insert: String): String {
+        doValidate()?.also { throw DataGenerationException(it) }
+
+        return descriptor
+            .fold(Triple("", false, false)) { (builtString, escaped, inserted), char ->
+                when (char) {
+                    '\\' -> Triple(builtString + if (escaped) char else "", !escaped, inserted)
+                    '@' -> Triple(builtString + if (escaped) "@" else insert, false, inserted || !escaped)
+                    else -> Triple(builtString + char, false, inserted)
+                }
+            }
+            .let { (builtString, _, inserted) ->
+                if (inserted) builtString
+                else builtString + insert + builtString
+            }
+    }
+}

--- a/src/main/kotlin/com/fwdekker/randomness/array/ArrayDecorator.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/array/ArrayDecorator.kt
@@ -37,23 +37,26 @@ data class ArrayDecorator(
     override fun generateUndecoratedStrings(count: Int): List<String> {
         if (!enabled) return generator(count)
 
-        val partCount = random.nextInt(minCount, maxCount + 1)
-        val generatedParts = generator(count * partCount)
         val separator = separator + if (isSpaceAfterSeparator && separator !== "\n") " " else ""
 
-        return generatedParts.chunked(partCount) { parts ->
-            parts.joinToString(
-                separator = separator,
-                prefix = brackets.takeWhile { it != '@' },
-                postfix = brackets.takeLastWhile { it != '@' }
-            )
-        }
+        val partsPerString = random.nextInt(minCount, maxCount + 1)
+        val parts = generator(count * partsPerString)
+        val stringsWithoutBrackets = parts.chunked(partsPerString) { it.joinToString(separator = separator) }
+
+        val bracketGroups =
+            if (!brackets.contains(SUBSTITUTION_MARK_REGEX))
+                List(2) { brackets.collapseEscapes() }
+            else
+                brackets.splitByCapturesOf(SUBSTITUTION_MARK_REGEX)
+
+        return stringsWithoutBrackets.map { bracketGroups.joinToString(separator = it) }
     }
 
 
     override fun doValidate() =
         if (minCount < MIN_MIN_COUNT) Bundle("array.error.min_count_too_low", MIN_MIN_COUNT)
         else if (maxCount < minCount) Bundle("array.error.min_count_above_max")
+        else if (brackets.contains(Regex("""(?<!\\)(?:\\\\)*(\\)(?![\\@])"""))) Bundle("array.error.unmatched_escape")
         else null
 
     override fun deepCopy(retainUuid: Boolean) = copy().also { if (retainUuid) it.uuid = this.uuid }
@@ -107,5 +110,44 @@ data class ArrayDecorator(
          * The default value of the [isSpaceAfterSeparator] field.
          */
         const val DEFAULT_SPACE_AFTER_SEPARATOR = true
+
+        /**
+         * Regex that matches an unescaped substitution mark, i.e. an `@` that is preceded by an event amount of `\`s.
+         */
+        private val SUBSTITUTION_MARK_REGEX = Regex("""(?<!\\)(?:\\\\)*(@)""")
     }
 }
+
+
+/**
+ * Collapses escaped symbols into the symbols they escape, e.g. with `\\` turned into `\`.
+ *
+ * @return the string with escaped symbols collapsed
+ */
+private fun String.collapseEscapes() = this.replace("\\@", "@").replace("\\\\", "\\")
+
+/**
+ * Similar to `String#split`, except that it splits only at the capturing groups, rather than at all groups.
+ *
+ * @param regex the regex with which to split
+ */
+private fun String.splitByCapturesOf(regex: Regex) =
+    regex.findAll(this)
+        .flatMap { match -> match.groups.drop(1).mapNotNull { it?.range } }
+        .invert(this.length)
+        .map { this.slice(it).collapseEscapes() }
+
+/**
+ * Assuming `this` is a sequence of consecutive non-overlapping `IntRange`s with all values below [max], returns the
+ * sequence of consecutive non-overlapping `IntRange`s that fill the gaps between the `IntRange`s of `this`, starting at
+ * `0` and ending at [max].
+ *
+ * @param max the value at which the last returned `IntRange` should end
+ */
+private fun Sequence<IntRange>.invert(max: Int) =
+    this.fold(listOf(0..max)) { acc, range ->
+        acc.dropLast(1) + listOf(
+            acc.last().first until range.first,
+            (range.last + 1) until max
+        )
+    }

--- a/src/main/kotlin/com/fwdekker/randomness/array/ArrayDecorator.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/array/ArrayDecorator.kt
@@ -1,5 +1,6 @@
 package com.fwdekker.randomness.array
 
+import com.fwdekker.randomness.BracketsDescriptor
 import com.fwdekker.randomness.Bundle
 import com.fwdekker.randomness.OverlayIcon
 import com.fwdekker.randomness.OverlayedIcon
@@ -38,26 +39,20 @@ data class ArrayDecorator(
         if (!enabled) return generator(count)
 
         val separator = separator + if (isSpaceAfterSeparator && separator !== "\n") " " else ""
+        val bracketsDescriptor = BracketsDescriptor(brackets)
 
         val partsPerString = random.nextInt(minCount, maxCount + 1)
         val parts = generator(count * partsPerString)
         val stringsWithoutBrackets = parts.chunked(partsPerString) { it.joinToString(separator = separator) }
 
-        val bracketGroups =
-            if (!brackets.contains(SUBSTITUTION_MARK_REGEX))
-                List(2) { brackets.collapseEscapes() }
-            else
-                brackets.splitByCapturesOf(SUBSTITUTION_MARK_REGEX)
-
-        return stringsWithoutBrackets.map { bracketGroups.joinToString(separator = it) }
+        return stringsWithoutBrackets.map { bracketsDescriptor.interpolate(it) }
     }
 
 
     override fun doValidate() =
         if (minCount < MIN_MIN_COUNT) Bundle("array.error.min_count_too_low", MIN_MIN_COUNT)
         else if (maxCount < minCount) Bundle("array.error.min_count_above_max")
-        else if (brackets.contains(Regex("""(?<!\\)(?:\\\\)*(\\)(?![\\@])"""))) Bundle("array.error.unmatched_escape")
-        else null
+        else BracketsDescriptor(brackets).doValidate()
 
     override fun deepCopy(retainUuid: Boolean) = copy().also { if (retainUuid) it.uuid = this.uuid }
 
@@ -110,44 +105,5 @@ data class ArrayDecorator(
          * The default value of the [isSpaceAfterSeparator] field.
          */
         const val DEFAULT_SPACE_AFTER_SEPARATOR = true
-
-        /**
-         * Regex that matches an unescaped substitution mark, i.e. an `@` that is preceded by an event amount of `\`s.
-         */
-        private val SUBSTITUTION_MARK_REGEX = Regex("""(?<!\\)(?:\\\\)*(@)""")
     }
 }
-
-
-/**
- * Collapses escaped symbols into the symbols they escape, e.g. with `\\` turned into `\`.
- *
- * @return the string with escaped symbols collapsed
- */
-private fun String.collapseEscapes() = this.replace("\\@", "@").replace("\\\\", "\\")
-
-/**
- * Similar to `String#split`, except that it splits only at the capturing groups, rather than at all groups.
- *
- * @param regex the regex with which to split
- */
-private fun String.splitByCapturesOf(regex: Regex) =
-    regex.findAll(this)
-        .flatMap { match -> match.groups.drop(1).mapNotNull { it?.range } }
-        .invert(this.length)
-        .map { this.slice(it).collapseEscapes() }
-
-/**
- * Assuming `this` is a sequence of consecutive non-overlapping `IntRange`s with all values below [max], returns the
- * sequence of consecutive non-overlapping `IntRange`s that fill the gaps between the `IntRange`s of `this`, starting at
- * `0` and ending at [max].
- *
- * @param max the value at which the last returned `IntRange` should end
- */
-private fun Sequence<IntRange>.invert(max: Int) =
-    this.fold(listOf(0..max)) { acc, range ->
-        acc.dropLast(1) + listOf(
-            acc.last().first until range.first,
-            (range.last + 1) until max
-        )
-    }

--- a/src/main/kotlin/com/fwdekker/randomness/string/StringSchemeEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/string/StringSchemeEditor.kt
@@ -64,7 +64,7 @@ class StringSchemeEditor(scheme: StringScheme = StringScheme()) : StateEditor<St
 
         patternHelpButton = BrowserLink(
             Bundle("string.ui.pattern_help"),
-            "https://github.com/curious-odd-man/RgxGen/tree/1.3#supported-syntax"
+            "https://github.com/curious-odd-man/RgxGen/tree/1.4#supported-syntax"
         )
 
         removeLookAlikeSymbolsCheckBox = JBCheckBox(Bundle("string.ui.remove_look_alike"))

--- a/src/main/resources/randomness.properties
+++ b/src/main/resources/randomness.properties
@@ -1,5 +1,6 @@
 array.error.min_count_too_low=Minimum count should be at least %1$s.
 array.error.min_count_above_max=Minimum count should be less than or equal to maximum count.
+array.error.unmatched_escape=Each \\ should be followed by an @ or by another \\.
 array.title=Array
 array.ui.brackets.comment=If the brackets contain a @, the @ is replaced with the generated data. Otherwise, the brackets are placed before and after the data.
 array.ui.brackets.none=None

--- a/src/main/resources/randomness.properties
+++ b/src/main/resources/randomness.properties
@@ -1,8 +1,7 @@
 array.error.min_count_too_low=Minimum count should be at least %1$s.
 array.error.min_count_above_max=Minimum count should be less than or equal to maximum count.
-array.error.unmatched_escape=Each \\ should be followed by an @ or by another \\.
 array.title=Array
-array.ui.brackets.comment=If the brackets contain a @, the @ is replaced with the generated data. Otherwise, the brackets are placed before and after the data.
+array.ui.brackets.comment=The @ symbol is replaced with the data that goes between the brackets. Write \\@ for a literal @, and write \\\\ for a literal \\. If you do not include an unescaped @, the custom brackets are placed before and after the generated data.
 array.ui.brackets.none=None
 array.ui.brackets.option=Brackets:
 array.ui.enabled=&Enabled
@@ -11,6 +10,7 @@ array.ui.max_count_option=Max co&unt:
 array.ui.separator.none=None
 array.ui.separator.option=Separator:
 array.ui.space_after_separator=Space after separator
+brackets.error.trailing_escape=The last \\ in the brackets descriptor does not escape anything. Remove it, or add a symbol to escape.
 datetime.error.min_datetime_above_max=Minimum date-time should be less than or equal to maximum date-time.
 datetime.title=Date-Time
 datetime.ui.pattern_comment=Escape characters by enclosing them in single quotes.

--- a/src/test/kotlin/com/fwdekker/randomness/BracketsDescriptorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/BracketsDescriptorTest.kt
@@ -1,0 +1,65 @@
+package com.fwdekker.randomness
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+
+/**
+ * Unit tests for [BracketsDescriptor].
+ */
+object BracketsDescriptorTest : Spek({
+    data class Param(
+        val description: String,
+        val descriptor: String,
+        val isValid: Boolean,
+        val output: String,
+    )
+
+
+    val data = "DATA"
+    val tests = listOf(
+        Param("empty descriptor", "", true, data),
+        Param("a descriptor without @ or \\", "txEcxUhK", true, "txEcxUhK${data}txEcxUhK"),
+        Param("a descriptor with @ without \\", "IwO@kCWtGUB", true, "IwO${data}kCWtGUB"),
+        Param("a descriptor with multiple @s without \\", "cqQOZV@NZh@H", true, "cqQOZV${data}NZh${data}H"),
+        Param("a descriptor without @ with an escaped \\", "ixjM\\\\Vlzh", true, "ixjM\\Vlzh${data}ixjM\\Vlzh"),
+        Param("a descriptor with an escaped \\@", "BCDs\\@MTe", true, "BCDs@MTe${data}BCDs@MTe"),
+        Param("a descriptor with an escaped character other than @ or \\", "Hf\\bP", true, "HfbP${data}HfbP"),
+        Param(
+            "a descriptor with escaped @, \\, and other, and multiple @s",
+            "I\\Pnv@OH\\\\gil@wKa@Kh\\@cx",
+            true,
+            "IPnv${data}OH\\gil${data}wKa${data}Kh@cx"
+        ),
+        Param("a descriptor with an escaped \\ at the end", "xHH@LrZ\\\\", true, "xHH${data}LrZ\\"),
+        Param("a descriptor with an unescaped \\ at the end", "NcMtGvIpC\\", false, "invalid-case"),
+    )
+
+
+    describe("doValidate") {
+        tests.forEach { (description, descriptor, isValid, _) ->
+            it("returns ${if (isValid) "null" else "non-null"} for $description") {
+                if (isValid)
+                    assertThat(BracketsDescriptor(descriptor).doValidate()).isNull()
+                else
+                    assertThat(BracketsDescriptor(descriptor).doValidate()).isNotNull
+            }
+        }
+    }
+
+    describe("interpolate") {
+        tests.forEach { (description, descriptor, isValid, output) ->
+            if (isValid)
+                it("generates the given string for $description") {
+                    assertThat(BracketsDescriptor(descriptor).interpolate(data)).isEqualTo(output)
+                }
+            else
+                it("throws an exception for $description") {
+                    assertThatThrownBy { BracketsDescriptor(descriptor).interpolate(data) }
+                        .isInstanceOf(DataGenerationException::class.java)
+                }
+        }
+    }
+})

--- a/src/test/kotlin/com/fwdekker/randomness/array/ArrayDecoratorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/array/ArrayDecoratorTest.kt
@@ -90,7 +90,7 @@ object ArrayDecoratorTest : Spek({
                 assertThat(dummyScheme.generateStrings()).containsExactly("ElvishhStridehElvishhStride")
             }
 
-            it("returns an array-like string with the brackets on both sides of the output") {
+            it("puts brackets on both sides of the output if there is no @ in the brackets") {
                 arrayDecorator.minCount = 2
                 arrayDecorator.maxCount = 2
                 arrayDecorator.brackets = "yn"
@@ -99,13 +99,58 @@ object ArrayDecoratorTest : Spek({
                 assertThat(dummyScheme.generateStrings()).containsExactly("ynFatten, Acrossyn")
             }
 
-            it("returns an array-like string with the different brackets surrounding the input") {
+            it("substitutes the @ in the brackets with the output") {
                 arrayDecorator.minCount = 2
                 arrayDecorator.maxCount = 2
                 arrayDecorator.brackets = "wl@ga"
                 dummyScheme.literals = listOf("Cloud", "Taxi")
 
                 assertThat(dummyScheme.generateStrings()).containsExactly("wlCloud, Taxiga")
+            }
+
+            it("substitutes the @ multiple times in the brackets with the output") {
+                arrayDecorator.minCount = 2
+                arrayDecorator.maxCount = 2
+                arrayDecorator.brackets = "th@rt@en"
+                dummyScheme.literals = listOf("Complete", "Summer")
+
+                assertThat(dummyScheme.generateStrings()).containsExactly("thComplete, SummerrtComplete, Summeren")
+            }
+
+            it("does not substitute the @ in the brackets if it is escaped by a backslash") {
+                arrayDecorator.minCount = 3
+                arrayDecorator.maxCount = 3
+                arrayDecorator.brackets = "e\\@x"
+                dummyScheme.literals = listOf("Sink", "Castle", "Until")
+
+                assertThat(dummyScheme.generateStrings()).containsExactly("e@xSink, Castle, Untile@x")
+            }
+
+            it("substitutes an escaped backslash in the brackets with a backslash") {
+                arrayDecorator.minCount = 2
+                arrayDecorator.maxCount = 2
+                arrayDecorator.brackets = "q\\\\z"
+                dummyScheme.literals = listOf("Coarse", "Noun")
+
+                assertThat(dummyScheme.generateStrings()).containsExactly("q\\zCoarse, Nounq\\z")
+            }
+
+            it("substitutes the @ in the brackets if it is preceded by an escaped backslash") {
+                arrayDecorator.minCount = 2
+                arrayDecorator.maxCount = 2
+                arrayDecorator.brackets = "dbGn\\\\@VrX"
+                dummyScheme.literals = listOf("Cry", "Ribbon")
+
+                assertThat(dummyScheme.generateStrings()).containsExactly("dbGn\\Cry, RibbonVrX")
+            }
+
+            it("substitutes the @ if it is the only symbol in the brackets") {
+                arrayDecorator.minCount = 2
+                arrayDecorator.maxCount = 2
+                arrayDecorator.brackets = "@"
+                dummyScheme.literals = listOf("Advice", "Line")
+
+                assertThat(dummyScheme.generateStrings()).containsExactly("Advance, Line")
             }
         }
 
@@ -188,6 +233,71 @@ object ArrayDecoratorTest : Spek({
 
                 assertThat(arrayDecorator.doValidate())
                     .isEqualTo("Minimum count should be less than or equal to maximum count.")
+            }
+        }
+
+        describe("brackets") {
+            it("passes for only an escaped \\") {
+                arrayDecorator.brackets = "\\\\"
+
+                assertThat(arrayDecorator.doValidate()).isNull()
+            }
+
+            it("passes for only a @") {
+                arrayDecorator.brackets = "@"
+
+                assertThat(arrayDecorator.doValidate()).isNull()
+            }
+
+            it("passes for an @ with some characters around") {
+                arrayDecorator.brackets = "vUF@Qhr"
+
+                assertThat(arrayDecorator.doValidate()).isNull()
+            }
+
+            it("passes for multiple @s") {
+                arrayDecorator.brackets = "@@"
+
+                assertThat(arrayDecorator.doValidate()).isNull()
+            }
+
+            it("passes for multiple @s with some characters around") {
+                arrayDecorator.brackets = "fl@wNZ@v"
+
+                assertThat(arrayDecorator.doValidate()).isNull()
+            }
+
+            it("passes for an escaped @") {
+                arrayDecorator.brackets = "\\@"
+
+                assertThat(arrayDecorator.doValidate()).isNull()
+            }
+
+            it("passes for an @ with an escaped \\ in front") {
+                arrayDecorator.brackets = "\\\\@"
+
+                assertThat(arrayDecorator.doValidate()).isNull()
+            }
+
+            it("fails for an unmatched \\") {
+                arrayDecorator.brackets = "\\"
+
+                assertThat(arrayDecorator.doValidate())
+                    .isEqualTo("Each \\ should be followed by an @ or by another \\.")
+            }
+
+            it("fails for an escaped \\ preceded by an unmatched \\") {
+                arrayDecorator.brackets = "\\\\\\"
+
+                assertThat(arrayDecorator.doValidate())
+                    .isEqualTo("Each \\ should be followed by an @ or by another \\.")
+            }
+
+            it("fails for an escaped @ preceded by an unmatched \\") {
+                arrayDecorator.brackets = "\\\\@"
+
+                assertThat(arrayDecorator.doValidate())
+                    .isEqualTo("Each \\ should be followed by an @ or by another \\.")
             }
         }
     }

--- a/src/test/kotlin/com/fwdekker/randomness/array/ArrayDecoratorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/array/ArrayDecoratorTest.kt
@@ -102,55 +102,10 @@ object ArrayDecoratorTest : Spek({
             it("substitutes the @ in the brackets with the output") {
                 arrayDecorator.minCount = 2
                 arrayDecorator.maxCount = 2
-                arrayDecorator.brackets = "wl@ga"
+                arrayDecorator.brackets = "(@)"
                 dummyScheme.literals = listOf("Cloud", "Taxi")
 
-                assertThat(dummyScheme.generateStrings()).containsExactly("wlCloud, Taxiga")
-            }
-
-            it("substitutes the @ multiple times in the brackets with the output") {
-                arrayDecorator.minCount = 2
-                arrayDecorator.maxCount = 2
-                arrayDecorator.brackets = "th@rt@en"
-                dummyScheme.literals = listOf("Complete", "Summer")
-
-                assertThat(dummyScheme.generateStrings()).containsExactly("thComplete, SummerrtComplete, Summeren")
-            }
-
-            it("does not substitute the @ in the brackets if it is escaped by a backslash") {
-                arrayDecorator.minCount = 3
-                arrayDecorator.maxCount = 3
-                arrayDecorator.brackets = "e\\@x"
-                dummyScheme.literals = listOf("Sink", "Castle", "Until")
-
-                assertThat(dummyScheme.generateStrings()).containsExactly("e@xSink, Castle, Untile@x")
-            }
-
-            it("substitutes an escaped backslash in the brackets with a backslash") {
-                arrayDecorator.minCount = 2
-                arrayDecorator.maxCount = 2
-                arrayDecorator.brackets = "q\\\\z"
-                dummyScheme.literals = listOf("Coarse", "Noun")
-
-                assertThat(dummyScheme.generateStrings()).containsExactly("q\\zCoarse, Nounq\\z")
-            }
-
-            it("substitutes the @ in the brackets if it is preceded by an escaped backslash") {
-                arrayDecorator.minCount = 2
-                arrayDecorator.maxCount = 2
-                arrayDecorator.brackets = "dbGn\\\\@VrX"
-                dummyScheme.literals = listOf("Cry", "Ribbon")
-
-                assertThat(dummyScheme.generateStrings()).containsExactly("dbGn\\Cry, RibbonVrX")
-            }
-
-            it("substitutes the @ if it is the only symbol in the brackets") {
-                arrayDecorator.minCount = 2
-                arrayDecorator.maxCount = 2
-                arrayDecorator.brackets = "@"
-                dummyScheme.literals = listOf("Advice", "Line")
-
-                assertThat(dummyScheme.generateStrings()).containsExactly("Advance, Line")
+                assertThat(dummyScheme.generateStrings()).containsExactly("(Cloud, Taxi)")
             }
         }
 
@@ -237,67 +192,16 @@ object ArrayDecoratorTest : Spek({
         }
 
         describe("brackets") {
-            it("passes for only an escaped \\") {
-                arrayDecorator.brackets = "\\\\"
+            it("passes for valid brackets") {
+                arrayDecorator.brackets = "dVN(An@)\\yk"
 
                 assertThat(arrayDecorator.doValidate()).isNull()
             }
 
-            it("passes for only a @") {
-                arrayDecorator.brackets = "@"
+            it("fails for invalid brackets") {
+                arrayDecorator.brackets = "zFT<pgaQH@\\"
 
-                assertThat(arrayDecorator.doValidate()).isNull()
-            }
-
-            it("passes for an @ with some characters around") {
-                arrayDecorator.brackets = "vUF@Qhr"
-
-                assertThat(arrayDecorator.doValidate()).isNull()
-            }
-
-            it("passes for multiple @s") {
-                arrayDecorator.brackets = "@@"
-
-                assertThat(arrayDecorator.doValidate()).isNull()
-            }
-
-            it("passes for multiple @s with some characters around") {
-                arrayDecorator.brackets = "fl@wNZ@v"
-
-                assertThat(arrayDecorator.doValidate()).isNull()
-            }
-
-            it("passes for an escaped @") {
-                arrayDecorator.brackets = "\\@"
-
-                assertThat(arrayDecorator.doValidate()).isNull()
-            }
-
-            it("passes for an @ with an escaped \\ in front") {
-                arrayDecorator.brackets = "\\\\@"
-
-                assertThat(arrayDecorator.doValidate()).isNull()
-            }
-
-            it("fails for an unmatched \\") {
-                arrayDecorator.brackets = "\\"
-
-                assertThat(arrayDecorator.doValidate())
-                    .isEqualTo("Each \\ should be followed by an @ or by another \\.")
-            }
-
-            it("fails for an escaped \\ preceded by an unmatched \\") {
-                arrayDecorator.brackets = "\\\\\\"
-
-                assertThat(arrayDecorator.doValidate())
-                    .isEqualTo("Each \\ should be followed by an @ or by another \\.")
-            }
-
-            it("fails for an escaped @ preceded by an unmatched \\") {
-                arrayDecorator.brackets = "\\\\@"
-
-                assertThat(arrayDecorator.doValidate())
-                    .isEqualTo("Each \\ should be followed by an @ or by another \\.")
+                assertThat(arrayDecorator.doValidate()).isNotNull()
             }
         }
     }


### PR DESCRIPTION
When providing custom brackets for an array, the user can now escape the `@` with a `\` (and escape a `\` with `\\`). This is achieved with the `BracketsDescriptor` class. The UI tooltip has been updated accordingly.