### PR TITLE
Update CI action dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,8 @@ jobs:
       matrix:
         os: [ ubuntu-latest, windows-latest ]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-java@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: '11'
@@ -37,7 +37,7 @@ jobs:
         run: |
           ./gradlew --no-daemon check
           ./gradlew --stop
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v3
         if: success() && matrix.os == 'ubuntu-latest'
         with:
           fail_ci_if_error: true


### PR DESCRIPTION
Some of the dependencies of the GitHub CI action were a bit outdated, resulting in deprecation warnings in the build logs. I have bumped them to the next version. I'm mostly sure it should all still work.