### PR TITLE
Bump dependencies, code quality, fix minor bugs

### DIFF
--- a/.config/detekt/.detekt.yml
+++ b/.config/detekt/.detekt.yml
@@ -1,69 +1,79 @@
 comments:
-    # License in each file is unnecessary.
-    AbsentOrWrongFileLicense:
-        active: false
-    # Nothing wrong with documenting private methods.
-    CommentOverPrivateFunction:
-        active: false
-    # Nothing wrong with documenting private properties.
-    CommentOverPrivateProperty:
-        active: false
+  # [Disagree] License in each file is unnecessary.
+  AbsentOrWrongFileLicense:
+    active: false
+  # [Disagree] Simple private functions should be documented too.
+  CommentOverPrivateFunction:
+    active: false
+  # [Disagree] Simple private properties should be documented too.
+  CommentOverPrivateProperty:
+    active: false
 
 complexity:
-    # Acceptable if used sparingly.
-    LabeledExpression:
-      active: false
-    # Solved using resource bundles. All remaining duplicates are resource identifiers.
-    StringLiteralDuplication:
-      active: false
+  # [Disagree] Acceptable if used sparingly.
+  LabeledExpression:
+    active: false
+  # [False Positive] Solved using resource bundles. All remaining duplicates are resource identifiers.
+  StringLiteralDuplication:
+    active: false
 
 formatting:
-    # Experimental. Too many false positives.
-    ArgumentListWrapping:
-        active: false
-    # Placing expression functions on one line makes it harder to understand.
-    FunctionSignature:
-        active: false
-    # That's part of my code style.
-    NoConsecutiveBlankLines:
-        active: false
-    # Acceptable because of auto-formatting.
-    MultiLineIfElse:
-        active: false
-    # Only if function takes vararg.
-    TrailingCommaOnCallSite:
-        active: false
+  # [Disagree] Acceptable for many short arguments.
+  ArgumentListWrapping:
+    active: false
+  # [Bug] Incorrectly detects violation if semicolon is followed by more than one newline.
+  EnumWrapping:
+    active: false
+  # [Disagree] Multi-line expressions are easier to understand if they start on the next line.
+  FunctionSignature:
+    active: false
+  # [Disagree] Short one-liners are easier to understand.
+  IfElseWrapping:
+    active: false
+  # [Bug] Causes ugly indentation when using named multiline arguments to a function.
+  MultilineExpressionWrapping:
+    active: false
+  # [Disagree] Braces use unnecessary extra space.
+  MultiLineIfElse:
+    active: false
+  # [Disagree] Consecutive blank lines are used consistently to group blocks of code.
+  NoConsecutiveBlankLines:
+    active: false
+  # [Disagree] Unnecessary, except for calls with vararg.
+  TrailingCommaOnCallSite:
+    active: false
 
-naming:
-    # Too many false positives in JUnit 4 tests.
-    FunctionMaxLength:
-        active: false
+potential-bugs:
+  # [Exception] Initialised by scene builder.
+  LateinitUsage:
+    ignoreOnClassesPattern: ".*Editor"
 
 style:
-    # `apply` is confusing with namespaces.
-    AlsoCouldBeApply:
-        active: false
-    # Those functions are added as conscious design decisions.
-    DataClassContainsFunctions:
-        active: false
-    # Not if they're settings objects.
-    DataClassShouldBeImmutable:
-        active: false
-    # Acceptable in parameterized tests.
-    DestructuringDeclarationWithTooManyEntries:
-        active: false
-    # Comments indicating TODOs are acceptable.
-    ForbiddenComment:
-        active: false
-    # One more is fine in my opinion.
-    LoopWithTooManyJumpStatements:
-        maxJumpCount: 2
-    # No braces are easier to read.
-    MandatoryBracesIfStatements:
-        active: false
-    # Three is fine.
-    ReturnCount:
-        max: 3
-    # False positives when there are two newlines after the imports.
-    SpacingBetweenPackageAndImports:
-        active: false
+  # [Disagree] `apply` is confusing to use because of namespace conflicts.
+  AlsoCouldBeApply:
+    active: false
+  # [Disagree] Braces use unnecessary extra space.
+  BracesOnIfStatements:
+    multiLine: consistent
+  # [Disagree] Functions on data classes are useful.
+  DataClassContainsFunctions:
+    active: false
+  # [Disagree] Mutable data classes are useful.
+  DataClassShouldBeImmutable:
+    active: false
+  # [Exception] Acceptable in (parameterized) tests.
+  DestructuringDeclarationWithTooManyEntries:
+    excludes:
+      - '**/test/**'
+  # [Bug] Fails when used as function expression body.
+  MultilineRawStringIndentation:
+    active: false
+  # [Bug] False positives when there are two newlines after the imports.
+  SpacingBetweenPackageAndImports:
+    active: false
+  # [Bug] Suggests using raw string in constant, but then `trimIndent` is not possible, resulting in weird indenting.
+  StringShouldBeRawString:
+    active: false
+  # [Exception] Used by scene builder.
+  UnusedPrivateMember:
+    allowedNames: "createUIComponents"

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Pull requests that do not meet the following guidelines are **fine**; these are 
 
 ### 📚 Documentation
 Always update related documentation, both code documentation and user instructions such as the [README](../README.md).
-Additionally, make sure you update the [change notes](../src/main/resources/META-INF/change-notes.html) if necessary.
+Additionally, make sure you update the [change notes](../CHANGELOG.md) if necessary.
 
 ### 🧪 Tests
 If you fixed a bug or added a new feature, make sure you add tests that cover this.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,10 +24,10 @@ assignees: FWDekker
 <!-- If applicable, add screenshots to help explain your problem. -->
 
 **Version information**
- - Randomness version [e.g. 2.7.2]: <!-- Check `Settings -> Plugins` in your IDE and search for `Randomness` -->
- - IDE version [e.g. IntelliJ Community 2021.1.2]: <!-- Check `Help -> About` in your IDE -->
- - Operating system [e.g. Windows 10, Ubuntu 20.04, macOS 11.4]: <!-- Use a search engine for help if you don't know -->
- - Java version [e.g. 1.8.291, 11.0.11]: <!-- Run `java -version` in a terminal or check https://www.java.com/en/download/help/version_manual.xml -->
+ - Randomness version [e.g. 2.7.7]: <!-- Check `Settings -> Plugins` in your IDE and search for `Randomness` -->
+ - IDE version [e.g. IntelliJ Community 2023.1.3]: <!-- Check `Help -> About` in your IDE -->
+ - Operating system [e.g. Windows 11, Ubuntu 22.04.2, macOS 13.4.1]: <!-- Use a search engine for help if you don't know -->
+ - Java version [e.g. 17.0.5, 19.0.2]: <!-- Run `java -version` in a terminal or check https://www.java.com/en/download/help/version_manual.xml -->
 
 **Additional context**
 <!-- Add any other context about the problem here. -->

--- a/.github/RELEASE_CHECKLIST.md
+++ b/.github/RELEASE_CHECKLIST.md
@@ -1,17 +1,20 @@
 # Release checklist
 ## Documentation
 * Bump the version number according to [Semantic Versioning](https://semver.org/).
-* Update `README.md`, `change-notes.html`, and `description.html` if necessary.
-  * Make sure to preview the change notes in the IDE by loading the plugin.
+* Update [`README.md`](../README.md), [`CHANGELOG.md`](../CHANGELOG.md), and
+  [`description.html`](../src/main/resources/META-INF/description.html) if necessary.
+    * Make sure to preview the change notes in the IDE by loading the plugin.
+    * Make sure the list of acknowledgements is up-to-date.
 * Update screenshots and GIFs in `.github/img/` and on the plugin repository if necessary.
-  * Distance between bottom of "Refresh" button and top of button bar at bottom is 50 pixels, or the original distance,
-    whichever is smaller.
-  * On Linux, the screen can be recorded using [peek](https://github.com/phw/peek).
-* Ensure documentation generates without errors and push documentation to `gh-pages` branch.
+    * Distance between bottom of "Refresh" button and top of button bar at bottom is 50 pixels, or the original
+      distance, whichever is smaller.
+    * On Linux, the screen can be recorded using [peek](https://github.com/phw/peek) or
+      [SimpleScreenRecorder](https://www.maartenbaert.be/simplescreenrecorder/).
+* Ensure documentation generates without errors, and push the documentation to the `gh-pages` branch.
 
 ## Verification
 * Run tests and static analysis one more time.
 * Try out the plugin yourself and check that old and new features work properly.
 * Run the plugin verifier.
-  * Make sure the latest IDE version is in the plugin verifier's configuration.
+    * Make sure the latest IDE version is in the plugin verifier's configuration.
 * Ensure settings from the previous version correctly load into the new version.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,6 +1,8 @@
 # Security policy
 ## Supported versions
-Only the [latest version](https://github.com/FWDekker/intellij-randomness/releases/latest) is ever supported and supplied with security patches.
+Only the [latest version](https://github.com/FWDekker/intellij-randomness/releases/latest) is ever supported and
+supplied with security patches.
 
 ## Reporting a vulnerability
-To report a security vulnerability, send an email to security@fwdekker.com instead of using the issue tracker. You will be contacted as soon as possible.
+To report a security vulnerability, email `security@fwdekker.com` instead of using the issue tracker.
+You will be contacted as soon as possible.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
           cache: 'gradle'
       - name: Run checks (Ubuntu)
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,4 +41,4 @@ jobs:
         if: success() && matrix.os == 'ubuntu-latest'
         with:
           fail_ci_if_error: true
-          files: build/reports/kover/xml/report.xml
+          files: build/reports/kover/report.xml

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 # Package Files #
 *.jar
 *.war
+*.nar
 *.ear
 *.zip
 *.tar.gz
@@ -21,13 +22,14 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+replay_pid*
 
 
 
 ## Gradle
 .gradle
-/build/
-/out/
+**/build/
+!src/**/build/
 
 # Ignore Gradle GUI config
 gradle-app.setting
@@ -35,8 +37,14 @@ gradle-app.setting
 # Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
 !gradle-wrapper.jar
 
+# Avoid ignore Gradle wrappper properties
+!gradle-wrapper.properties
+
 # Cache of project
 .gradletasknamecache
 
-# Work around https://youtrack.jetbrains.com/issue/IDEA-116898
-gradle/wrapper/gradle-wrapper.properties
+# Eclipse Gradle plugin generated files
+# Eclipse Core
+.project
+# JDT-specific (Eclipse Java Development Tools)
+.classpath

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,10 +27,20 @@ Check the plugin description for more details and animated usage examples.
 * Changelogs are now kept in [keep a changelog](https://keepachangelog.com/en/1.0.0/) style.
 
 ### Deprecated
-* Minimum IDE version has been increased to 2022.1.
+* Minimum IDE version has been increased to 2022.3.
 
 ### Fixed
 * The settings-only popup is now also shown when editing a read-only file.
+
+
+## 2.7.7 -- 2023-06-30
+### Breaking changes
+Minimum IDE version has been increased to 2022.2.
+
+### Fixes
+Resolve compatibility issues with upcoming IDE versions.
+([#459](https://github.com/FWDekker/intellij-randomness/issues/459))
+([#460](https://github.com/FWDekker/intellij-randomness/issues/460))
 
 
 ## 2.7.6 -- 2022-12-14

--- a/README.md
+++ b/README.md
@@ -110,12 +110,14 @@ $ gradlew dokkaHtml  # Generate documentation
 ```
 
 ### 🖼 Icons
-The icons used by the plugin are found in the [.sketch](.github/img/icons.sketch) file.
+The icons used by the plugin are found in [the file `icons.sketch`](.github/img/icons.sketch).
 You can open this file with [Sketch](https://www.sketch.com/) (macOS), [Lunacy](https://icons8.com/lunacy) (Windows), or
 [Figma](https://github.com/Figma-Linux/figma-linux) (Linux).
 
 
 ## 🙏 Acknowledgements
+I want to thank everyone who contributed something to Randomness, no matter the size of that contribution.
+
 In chronological order of contribution:
 * Thanks to [Casper Boone](https://github.com/casperboone) for
   [reporting a bug](https://github.com/FWDekker/intellij-randomness/issues/25) and for
@@ -124,7 +126,7 @@ In chronological order of contribution:
   [suggesting the array data type](https://github.com/FWDekker/intellij-randomness/issues/54)!
 * Thanks to [Georgios Andreadis](https://github.com/gandreadis) for the
   [original logo](https://github.com/FWDekker/intellij-randomness/pull/86)!
-* Thanks to [Oleksii K.](https://github.com/ok3141) for
+* Thanks to [Oleksii](https://github.com/ok3141) for
   [suggesting the UUID data type](https://github.com/FWDekker/intellij-randomness/issues/88) and for
   [suggesting the hex symbol set](https://github.com/FWDekker/intellij-randomness/issues/89)!
 * Thanks to [Meilina Reksoprodjo](https://github.com/meilinar) for help with macOS user testing!
@@ -142,7 +144,7 @@ In chronological order of contribution:
   [suggesting a configurable popup](https://github.com/FWDekker/intellij-randomness/issues/305#issuecomment-661530711)!
 * Thanks to [Alex Pernot](https://github.com/AlexPernot) for
   [participating in the data type discussion](https://github.com/FWDekker/intellij-randomness/issues/305#issuecomment-662499058)!
-* Thanks to [solonovamax](https://github.com/solonovamax) for
+* Thanks to [solo](https://github.com/solonovamax) for
   [his contributions](https://github.com/FWDekker/intellij-randomness/issues/305#issuecomment-804415489)
   [to the data type discussion](https://github.com/FWDekker/intellij-randomness/issues/363#issuecomment-804976008)
   [in several places](https://github.com/FWDekker/intellij-randomness/issues/365#issuecomment-805052007),
@@ -152,7 +154,7 @@ In chronological order of contribution:
   [reporting that symbol sets didn't get saved](https://github.com/FWDekker/intellij-randomness/issues/382)!
 * Thanks to [Aleksey Bobyr](https://github.com/Alexsey) for
   [reporting a critical UI bug in WebStorm EAP](https://github.com/FWDekker/intellij-randomness/issues/418)!
-* Thanks to [LukasAppleFan](https://github.com/LukasAppleFan) for
+* Thanks to [Lukas](https://github.com/LukasAppleFan) for
   [helping me find a bug in IntelliJ](https://github.com/FWDekker/intellij-randomness/issues/421)!
 * Thanks to [Pascal](https://github.com/theMunichDev) for
   [reporting a bug with custom shortcuts](https://github.com/FWDekker/intellij-randomness/issues/423)!
@@ -166,5 +168,9 @@ In chronological order of contribution:
   [reporting an issue with slow actions during indexing](https://github.com/FWDekker/intellij-randomness/issues/445)!
 * Thanks to [Luc Everse](https://github.com/cmpsb) for
   [suggesting generating non-matching strings](https://github.com/FWDekker/intellij-randomness/issues/447)!
+* Thanks to [ForNeVeR](https://github.com/ForNeVeR) for
+  [reporting a compatibility issue with the IntelliJ EAP](https://github.com/FWDekker/intellij-randomness/issues/459)!
+* Thanks to [Vitaly Provodin](https://github.com/vprovodin) for
+  [also reporting that compatibility issue](https://github.com/FWDekker/intellij-randomness/issues/460)!
 
 If I should add, remove, or change anything here, just open an issue or email me!

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,18 +10,18 @@ fun properties(key: String) = project.findProperty(key).toString()
 /// Plugins
 plugins {
     // Compilation
-    id("org.jetbrains.kotlin.jvm") version "1.6.20"  // See also `gradle.properties`
-    id("org.jetbrains.intellij") version "1.11.0"
+    id("org.jetbrains.kotlin.jvm") version "1.8.22"  // See also `gradle.properties`
+    id("org.jetbrains.intellij") version "1.14.2"
 
     // Tests/coverage
-    id("org.jetbrains.kotlinx.kover") version "0.6.1"
+    id("org.jetbrains.kotlinx.kover") version "0.7.2"
 
     // Static analysis
-    id("io.gitlab.arturbosch.detekt") version "1.22.0"  // See also `gradle.properties`
+    id("io.gitlab.arturbosch.detekt") version "1.23.0"  // See also `gradle.properties`
 
     // Documentation
-    id("org.jetbrains.changelog") version "2.0.0"
-    id("org.jetbrains.dokka") version "1.7.20"  // See also `gradle.properties
+    id("org.jetbrains.changelog") version "2.1.0"
+    id("org.jetbrains.dokka") version "1.8.20"  // See also `gradle.properties
 }
 
 
@@ -111,21 +111,21 @@ tasks {
             exceptionFormat = TestExceptionFormat.FULL
         }
 
-        finalizedBy(koverReport)
+        finalizedBy(koverXmlReport)
     }
 
-    kover {
-        htmlReport { onCheck.set(true) }
-        xmlReport { onCheck.set(true) }
+    koverReport {
+        defaults {
+            html { onCheck = false }
+            xml { onCheck = false }
+        }
     }
 
 
     // Static analysis
     detekt {
-        toolVersion = properties("detektVersion")
-
         allRules = true
-        config = files(".config/detekt/.detekt.yml")
+        config.setFrom(".config/detekt/.detekt.yml")
     }
 
     runPluginVerifier {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,8 +42,7 @@ dependencies {
     testRuntimeOnly("org.junit.platform:junit-platform-runner:${properties("junitRunnerVersion")}")
     testImplementation("org.junit.jupiter:junit-jupiter-api:${properties("junitVersion")}")
     testImplementation("org.junit.jupiter:junit-jupiter-engine:${properties("junitVersion")}")
-    testImplementation("org.spekframework.spek2:spek-dsl-jvm:${properties("spekVersion")}")
-    testRuntimeOnly("org.spekframework.spek2:spek-runner-junit5:${properties("spekVersion")}")
+    testImplementation("io.kotest:kotest-runner-junit5:${properties("kotestVersion")}")
 
     detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:${properties("detektVersion")}")
 }
@@ -100,10 +99,10 @@ tasks {
 
     // Tests/coverage
     test {
-        systemProperty("spek2.execution.test.timeout", 0)
+        systemProperty("java.awt.headless", "false")
 
         useJUnitPlatform {
-            includeEngines("junit-vintage", "junit-jupiter", "spek2")
+            includeEngines("junit-vintage", "junit-jupiter", "kotest")
         }
 
         testLogging {

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,16 +7,21 @@ version=3.0.0-beta.3
 #   e.g., if latest is 2020.3, support at least 2019.4 (aka 2020.1).
 #   See also https://data.services.jetbrains.com/products?fields=name,releases.version,releases.build&code=IC,CL.
 # * For `intellijVersion`, use the oldest supported version, because that's what the plugin will be compiled against.
-pluginSinceBuild=221.0
-intellijVersion=2022.1
-pluginVerifierIdeVersions=IC-2022.1.1, IC-2022.2.4, IC-2022.3.1, CL-2022.1.1, CL-2022.2.4, CL-2022.3
+pluginSinceBuild=222.0
+intellijVersion=2022.2
+pluginVerifierIdeVersions=IC-2022.2.5, IC-2022.3.3, IC-2023.1.3, CL-2022.2.5, CL-2022.3.3, CL-2023.1.4
 
 # Targets
-# * Java version should also be updated in `.github/workflows/ci.yml`.
-# * Kotlin version should also be updated in `plugins` block.
-# * Kotlin version should match the oldest supported build in `pluginSinceBuild`.
-#   See also https://plugins.jetbrains.com/docs/intellij/using-kotlin.html#kotlin-standard-library.
-javaVersion=11
+# * Java
+#   * Java version should be the one used by the oldest Randomness-supported version of IntelliJ, as listed in
+#     https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html#intellij-platform-based-products-of-recent-ide-versions
+#
+# * Kotlin
+#   * `kotlinVersion` is the same as `kotlinApiVersion`.
+#   * Kotlin should also be updated in `plugins` block.
+#   * Kotlin version should be bundled stdlib version of oldest supported IntelliJ version listed in
+#     https://plugins.jetbrains.com/docs/intellij/using-kotlin.html#kotlin-standard-library
+javaVersion=17
 kotlinVersion=1.6
 kotlinApiVersion=1.6
 
@@ -27,10 +32,10 @@ kotlinApiVersion=1.6
 assertjVersion=3.17.2
 assertjSwingVersion=3.17.1
 dateparserVersion=1.0.11
-detektVersion=1.22.0
+detektVersion=1.23.0
 emojiVersion=5.1.1
-junitVersion=5.9.1
-junitRunnerVersion=1.9.1
+junitVersion=5.9.3
+junitRunnerVersion=1.9.3
 rgxgenVersion=1.4
 spekVersion=2.0.19
 uuidGeneratorVersion=3.3.0
@@ -38,3 +43,4 @@ uuidGeneratorVersion=3.3.0
 # Kotlin
 kotlin.code.style=official
 kotlin.stdlib.default.dependency=false
+kotlin.incremental.useClasspathSnapshot=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.fwdekker
-# Also remove `beta` from `TemplateSettings` storage file!
+# TODO: Also remove `beta` from `TemplateSettings` storage file!
 version=3.0.0-beta.3
 
 # Compatibility
@@ -36,11 +36,16 @@ detektVersion=1.23.0
 emojiVersion=5.1.1
 junitVersion=5.9.3
 junitRunnerVersion=1.9.3
+kotestVersion=5.6.2
 rgxgenVersion=1.4
-spekVersion=2.0.19
 uuidGeneratorVersion=3.3.0
+
+# Gradle
+org.gradle.caching=true
+org.gradle.configuration-cache=true
 
 # Kotlin
 kotlin.code.style=official
 kotlin.stdlib.default.dependency=false
+# TODO: Workaround for https://jb.gg/intellij-platform-kotlin-oom
 kotlin.incremental.useClasspathSnapshot=false

--- a/gradle/scripts/verifier.gradle
+++ b/gradle/scripts/verifier.gradle
@@ -1,4 +1,0 @@
-// WARNING! The plugin verifier script is deprecated. The runPluginVerifier task is built into the
-// gradle-intellij-plugin as of version 0.6.0. For more information, see
-// https://github.com/JetBrains/gradle-intellij-plugin/issues/385#issuecomment-718796665.
-// This file will be removed from the intellij-random repository on 2022-12-20.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-all.zip

--- a/src/main/kotlin/com/fwdekker/randomness/Bundle.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/Bundle.kt
@@ -10,7 +10,7 @@ object Bundle {
     /**
      * The main bundle for Randomness.
      */
-    private val resourceBundle = ResourceBundle.getBundle("randomness")
+    private val RESOURCE_BUNDLE = ResourceBundle.getBundle("randomness")
 
 
     /**
@@ -21,7 +21,7 @@ object Bundle {
      * @param key the key of the string to return
      * @return the string at [key]
      */
-    operator fun invoke(key: String): String = resourceBundle.getString(key)
+    operator fun invoke(key: String): String = RESOURCE_BUNDLE.getString(key)
 
     /**
      * Returns the string at [key] formatted with [arguments].
@@ -32,5 +32,5 @@ object Bundle {
      * @param arguments the arguments to insert into the template
      * @return the string at [key] formatted with [arguments]
      */
-    operator fun invoke(key: String, vararg arguments: Any?): String = resourceBundle.getString(key).format(*arguments)
+    operator fun invoke(key: String, vararg arguments: Any?): String = RESOURCE_BUNDLE.getString(key).format(*arguments)
 }

--- a/src/main/kotlin/com/fwdekker/randomness/CapitalizationMode.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/CapitalizationMode.kt
@@ -44,7 +44,8 @@ enum class CapitalizationMode(val descriptor: String, private val transformer: (
     /**
      * Unused in production code.
      */
-    DUMMY("dummy", { string, _ -> string }), ;
+    DUMMY("dummy", { string, _ -> string }),
+    ;
 
 
     /**

--- a/src/main/kotlin/com/fwdekker/randomness/ErrorReporter.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/ErrorReporter.kt
@@ -103,7 +103,11 @@ class ErrorReporter : ErrorReportSubmitter() {
      * @param contents the contents of the section
      * @return a Markdown "section" with the [title] and [contents]
      */
-    private fun createMarkdownSection(title: String, contents: String) = "**${title.trim()}**\n${contents.trim()}\n\n"
+    private fun createMarkdownSection(title: String, contents: String) =
+        """
+        **${title.trim()}**
+        ${contents.trim()}
+        """.trimIndent()
 
     /**
      * Returns version information on the user's environment as a Markdown-style list.
@@ -112,10 +116,10 @@ class ErrorReporter : ErrorReportSubmitter() {
      */
     private fun getFormattedVersionInformation() =
         """
-            - Randomness version: ${pluginDescriptor?.version ?: "_Unknown_"}
-            - IDE version: ${ApplicationInfo.getInstance().apiVersion}
-            - Operating system: ${System.getProperty("os.name")}
-            - Java version: ${System.getProperty("java.version")}
+        - Randomness version: ${pluginDescriptor?.version ?: "_Unknown_"}
+        - IDE version: ${ApplicationInfo.getInstance().apiVersion}
+        - Operating system: ${System.getProperty("os.name")}
+        - Java version: ${System.getProperty("java.version")}
         """.trimIndent()
 
 

--- a/src/main/kotlin/com/fwdekker/randomness/InsertAction.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/InsertAction.kt
@@ -2,6 +2,7 @@ package com.fwdekker.randomness
 
 import com.fwdekker.randomness.Timely.generateTimely
 import com.intellij.codeInsight.hint.HintManager
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
@@ -38,6 +39,13 @@ abstract class InsertAction(
 
 
     /**
+     * Specifies the thread in which [update] is invoked.
+     *
+     * @return the thread in which [update] is invoked
+     */
+    override fun getActionUpdateThread() = ActionUpdateThread.EDT
+
+    /**
      * Sets the title of this action and disables this action if no editor is currently opened.
      *
      * @param event carries contextual information
@@ -54,7 +62,7 @@ abstract class InsertAction(
      *
      * @param event carries contextual information
      */
-    @Suppress("ReturnCount") // Result of null checks at start
+    @Suppress("detekt:ReturnCount") // Result of null checks at start
     override fun actionPerformed(event: AnActionEvent) {
         val editor = event.getData(CommonDataKeys.EDITOR) ?: return
         val project = event.getData(CommonDataKeys.PROJECT) ?: return

--- a/src/main/kotlin/com/fwdekker/randomness/PopupAction.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/PopupAction.kt
@@ -4,6 +4,7 @@ import com.fwdekker.randomness.template.TemplateGroupAction
 import com.fwdekker.randomness.template.TemplateSettings
 import com.fwdekker.randomness.template.TemplateSettingsAction
 import com.intellij.openapi.actionSystem.ActionGroup
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
@@ -26,6 +27,13 @@ class PopupAction : AnAction(RandomnessIcons.RANDOMNESS) {
      */
     private var isEditable: Boolean = true
 
+
+    /**
+     * Specifies the thread in which [update] is invoked.
+     *
+     * @return the thread in which [update] is invoked
+     */
+    override fun getActionUpdateThread() = ActionUpdateThread.EDT
 
     /**
      * Sets the icon of this action.
@@ -74,7 +82,7 @@ class PopupAction : AnAction(RandomnessIcons.RANDOMNESS) {
      * @param event the event on which the title should be based
      * @return the desired title for the popup given [event]
      */
-    @Suppress("ComplexMethod") // Cannot be simplified
+    @Suppress("detekt:ComplexMethod") // Cannot be simplified
     private fun captionModifier(event: ActionEvent?): String {
         val modifiers = event?.modifiers ?: 0
         val altPressed = modifiers and ActionEvent.ALT_MASK != 0
@@ -205,7 +213,7 @@ fun ListPopupImpl.registerModifierActions(captionModifier: (ActionEvent?) -> Str
             }
         )
 
-        @Suppress("MagicNumber") // Not worth a constant
+        @Suppress("detekt:MagicNumber") // Not worth a constant
         for (key in 0..9) {
             registerAction(
                 "${a}${b}${c}invokeAction$key",

--- a/src/main/kotlin/com/fwdekker/randomness/SettingsConfigurable.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/SettingsConfigurable.kt
@@ -8,7 +8,7 @@ import javax.swing.JComponent
 /**
  * Tells IntelliJ how to use a [StateEditor] in the settings dialog.
  */
-@Suppress("LateinitUsage") // `createComponent` is invoked before any of the other methods
+@Suppress("detekt:LateinitUsage") // `createComponent` is invoked before any of the other methods
 abstract class SettingsConfigurable : Configurable {
     /**
      * The user interface for changing the settings, displayed in IntelliJ's settings window.

--- a/src/main/kotlin/com/fwdekker/randomness/SettingsState.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/SettingsState.kt
@@ -46,6 +46,6 @@ data class SettingsState(
         /**
          * The persistent [SettingsState] instance.
          */
-        val default: SettingsState by lazy { SettingsState(TemplateSettings.default.state) }
+        val DEFAULT: SettingsState by lazy { SettingsState(TemplateSettings.default.state) }
     }
 }

--- a/src/main/kotlin/com/fwdekker/randomness/array/ArrayDecoratorEditor.form
+++ b/src/main/kotlin/com/fwdekker/randomness/array/ArrayDecoratorEditor.form
@@ -245,10 +245,10 @@
       <member id="cc46b"/>
     </group>
     <group name="separatorGroup" bound="true">
+      <member id="d45e4"/>
       <member id="6b534"/>
       <member id="61c87"/>
       <member id="66c28"/>
-      <member id="d45e4"/>
     </group>
   </buttonGroups>
 </form>

--- a/src/main/kotlin/com/fwdekker/randomness/array/ArrayDecoratorEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/array/ArrayDecoratorEditor.kt
@@ -33,7 +33,6 @@ import javax.swing.event.ChangeEvent
  * `false`, [readState] will return a decorator which is always enabled.
  * @param showSeparator `true` if and only if a titled separator should be shown at the top
  */
-@Suppress("LateinitUsage") // Initialized by scene builder
 class ArrayDecoratorEditor(
     settings: ArrayDecorator,
     disablable: Boolean = true,
@@ -95,7 +94,6 @@ class ArrayDecoratorEditor(
      *
      * This method is called by the scene builder at the start of the constructor.
      */
-    @Suppress("UnusedPrivateMember") // Used by scene builder
     private fun createUIComponents() {
         separator = SeparatorFactory.createSeparator(Bundle("array.title"), null)
 

--- a/src/main/kotlin/com/fwdekker/randomness/datetime/DateTimeSchemeEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/datetime/DateTimeSchemeEditor.kt
@@ -23,7 +23,6 @@ import javax.swing.SwingConstants
  *
  * @param scheme the scheme to edit in the component
  */
-@Suppress("LateinitUsage") // Initialized by scene builder
 class DateTimeSchemeEditor(scheme: DateTimeScheme = DateTimeScheme()) : StateEditor<DateTimeScheme>(scheme) {
     override lateinit var rootComponent: JPanel private set
     override val preferredFocusedComponent
@@ -50,7 +49,6 @@ class DateTimeSchemeEditor(scheme: DateTimeScheme = DateTimeScheme()) : StateEdi
      *
      * This method is called by the scene builder at the start of the constructor.
      */
-    @Suppress("UnusedPrivateMember") // Used by scene builder
     private fun createUIComponents() {
         valueSeparator = SeparatorFactory.createSeparator(Bundle("datetime.ui.value_separator"), null)
 

--- a/src/main/kotlin/com/fwdekker/randomness/decimal/DecimalSchemeEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/decimal/DecimalSchemeEditor.kt
@@ -33,7 +33,6 @@ import javax.swing.event.ChangeEvent
  *
  * @param scheme the scheme to edit in the component
  */
-@Suppress("LateinitUsage") // Initialized by scene builder
 class DecimalSchemeEditor(scheme: DecimalScheme = DecimalScheme()) : StateEditor<DecimalScheme>(scheme) {
     override lateinit var rootComponent: JPanel private set
     override val preferredFocusedComponent
@@ -77,7 +76,6 @@ class DecimalSchemeEditor(scheme: DecimalScheme = DecimalScheme()) : StateEditor
      *
      * This method is called by the scene builder at the start of the constructor.
      */
-    @Suppress("UnusedPrivateMember") // Used by scene builder
     private fun createUIComponents() {
         valueSeparator = SeparatorFactory.createSeparator(Bundle("decimal.ui.value_separator"), null)
 

--- a/src/main/kotlin/com/fwdekker/randomness/fixedlength/FixedLengthDecoratorEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/fixedlength/FixedLengthDecoratorEditor.kt
@@ -20,7 +20,6 @@ import javax.swing.text.PlainDocument
  *
  * @param settings the settings to edit in the component
  */
-@Suppress("LateinitUsage") // Initialized by scene builder
 class FixedLengthDecoratorEditor(settings: FixedLengthDecorator) : StateEditor<FixedLengthDecorator>(settings) {
     override lateinit var rootComponent: JPanel private set
     override val preferredFocusedComponent
@@ -52,7 +51,6 @@ class FixedLengthDecoratorEditor(settings: FixedLengthDecorator) : StateEditor<F
      *
      * This method is called by the scene builder at the start of the constructor.
      */
-    @Suppress("UnusedPrivateMember") // Used by scene builder
     private fun createUIComponents() {
         separator = SeparatorFactory.createSeparator(Bundle("fixed_length.title"), null)
 

--- a/src/main/kotlin/com/fwdekker/randomness/integer/IntegerSchemeEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/integer/IntegerSchemeEditor.kt
@@ -32,7 +32,6 @@ import javax.swing.event.ChangeEvent
  *
  * @param scheme the scheme to edit in the component
  */
-@Suppress("LateinitUsage") // Initialized by scene builder
 class IntegerSchemeEditor(scheme: IntegerScheme = IntegerScheme()) : StateEditor<IntegerScheme>(scheme) {
     override lateinit var rootComponent: JPanel private set
     override val preferredFocusedComponent
@@ -78,7 +77,6 @@ class IntegerSchemeEditor(scheme: IntegerScheme = IntegerScheme()) : StateEditor
      *
      * This method is called by the scene builder at the start of the constructor.
      */
-    @Suppress("UnusedPrivateMember") // Used by scene builder
     private fun createUIComponents() {
         valueSeparator = SeparatorFactory.createSeparator(Bundle("integer.ui.value_separator"), null)
 

--- a/src/main/kotlin/com/fwdekker/randomness/string/StringScheme.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/string/StringScheme.kt
@@ -78,10 +78,10 @@ data class StringScheme(
         when {
             !isRegex -> arrayDecorator.doValidate()
             pattern.takeLastWhile { it == '\\' }.length.mod(2) != 0 -> Bundle("string.error.trailing_backslash")
-            pattern == "{}" || pattern.contains(Regex("[^\\\\]\\{}")) -> Bundle("string.error.empty_curly")
-            pattern == "[]" || pattern.contains(Regex("[^\\\\]\\[]")) -> Bundle("string.error.empty_square")
+            pattern == "{}" || pattern.contains(Regex("""[^\\]\{}""")) -> Bundle("string.error.empty_curly")
+            pattern == "[]" || pattern.contains(Regex("""[^\\]\[]""")) -> Bundle("string.error.empty_square")
             else ->
-                @Suppress("TooGenericExceptionCaught") // Consequence of incomplete validation in RgxGen
+                @Suppress("detekt:TooGenericExceptionCaught") // Consequence of incomplete validation in RgxGen
                 try {
                     RgxGen(pattern).generate()
                     arrayDecorator.doValidate()

--- a/src/main/kotlin/com/fwdekker/randomness/string/StringSchemeEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/string/StringSchemeEditor.kt
@@ -27,7 +27,6 @@ import javax.swing.JTextField
  *
  * @param scheme the scheme to edit in the component
  */
-@Suppress("LateinitUsage") // Initialized by scene builder
 class StringSchemeEditor(scheme: StringScheme = StringScheme()) : StateEditor<StringScheme>(scheme) {
     override lateinit var rootComponent: JPanel private set
     override val preferredFocusedComponent
@@ -58,7 +57,6 @@ class StringSchemeEditor(scheme: StringScheme = StringScheme()) : StateEditor<St
      *
      * This method is called by the scene builder at the start of the constructor.
      */
-    @Suppress("UnusedPrivateMember") // Used by scene builder
     private fun createUIComponents() {
         valueSeparator = SeparatorFactory.createSeparator(Bundle("string.ui.value_separator"), null)
 

--- a/src/main/kotlin/com/fwdekker/randomness/template/TemplateActionLoader.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/template/TemplateActionLoader.kt
@@ -7,7 +7,7 @@ import com.intellij.openapi.actionSystem.impl.DynamicActionConfigurationCustomiz
 /**
  * Registers and unregisters actions for the user's [Template]s so that they can be inserted using shortcuts.
  */
-object TemplateActionLoader : DynamicActionConfigurationCustomizer {
+class TemplateActionLoader : DynamicActionConfigurationCustomizer {
     /**
      * Shorthand to return all the user's stored [Template]s.
      */

--- a/src/main/kotlin/com/fwdekker/randomness/template/TemplateActions.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/template/TemplateActions.kt
@@ -9,12 +9,12 @@ import com.fwdekker.randomness.array.ArrayDecorator
 import com.fwdekker.randomness.array.ArrayDecoratorEditor
 import com.fwdekker.randomness.ui.PreviewPanel
 import com.intellij.openapi.actionSystem.ActionGroup
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.options.Configurable
 import com.intellij.openapi.options.ShowSettingsUtil
 import java.awt.BorderLayout
-import java.awt.event.ActionEvent
 import javax.swing.JPanel
 
 
@@ -40,6 +40,14 @@ class TemplateGroupAction(private val template: Template) :
 
 
     /**
+     * Specifies the thread in which [update] is invoked.
+     *
+     * @return the thread in which [update] is invoked
+     */
+    override fun getActionUpdateThread() = ActionUpdateThread.EDT
+
+
+    /**
      * Update the presentation of the action.
      *
      * @param event the event to set the presentation on
@@ -58,9 +66,9 @@ class TemplateGroupAction(private val template: Template) :
      */
     override fun actionPerformed(event: AnActionEvent) =
         getActionByModifier(
-            array = event.modifiers and event.modifiers and ActionEvent.SHIFT_MASK != 0,
-            repeat = event.modifiers and event.modifiers and ActionEvent.ALT_MASK != 0,
-            settings = event.modifiers and event.modifiers and ActionEvent.CTRL_MASK != 0
+            array = event.inputEvent?.isShiftDown ?: false,
+            repeat = event.inputEvent?.isAltDown ?: false,
+            settings = event.inputEvent?.isControlDown ?: false
         ).actionPerformed(event)
 
     /**
@@ -198,7 +206,7 @@ class TemplateInsertAction(
 class TemplateSettingsAction(private val template: Template? = null) : AnAction(
     if (template == null) Bundle("template.name.settings")
     else Bundle("template.name.settings_suffix", template.name),
-    if (template == null) null else Bundle("template.description.settings", template.name),
+    template?.let { Bundle("template.description.settings", it.name) },
     template?.icon?.plusOverlay(OverlayIcon.SETTINGS) ?: RandomnessIcons.SETTINGS
 ) {
     /**

--- a/src/main/kotlin/com/fwdekker/randomness/template/TemplateEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/template/TemplateEditor.kt
@@ -11,7 +11,6 @@ import javax.swing.JTextField
  *
  * @param template the template to edit
  */
-@Suppress("LateinitUsage") // Initialized by scene builder
 class TemplateEditor(template: Template) : StateEditor<Template>(template) {
     override lateinit var rootComponent: JPanel private set
     override val preferredFocusedComponent

--- a/src/main/kotlin/com/fwdekker/randomness/template/TemplateJTree.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/template/TemplateJTree.kt
@@ -11,6 +11,7 @@ import com.fwdekker.randomness.uuid.UuidScheme
 import com.fwdekker.randomness.word.WordScheme
 import com.intellij.icons.AllIcons
 import com.intellij.openapi.actionSystem.ActionToolbarPosition
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.ui.popup.JBPopupFactory
 import com.intellij.openapi.ui.popup.ListSeparator
@@ -410,24 +411,11 @@ class TemplateJTree(
      */
     private inner class AddButton : AnActionButton(Bundle("shared.action.add"), AllIcons.General.Add) {
         /**
-         * Displays a popup to add a scheme, or immediately adds a template if nothing is currently selected.
+         * Specifies the thread in which [update] is invoked.
          *
-         * @param event ignored
+         * @return the thread in which [update] is invoked
          */
-        override fun actionPerformed(event: AnActionEvent) =
-            JBPopupFactory.getInstance()
-                .createListPopup(
-                    if (selectedNodeNotRoot == null) DefaultTemplatesPopupStep()
-                    else MainPopupStep()
-                )
-                .show(preferredPopupPoint)
-
-        /**
-         * Returns the shortcut for this action.
-         *
-         * @return the shortcut for this action
-         */
-        override fun getShortcut() = CommonActionsPanel.getCommonShortcut(CommonActionsPanel.Buttons.ADD)
+        override fun getActionUpdateThread() = ActionUpdateThread.EDT
 
         /**
          * Updates the presentation of the button.
@@ -441,6 +429,26 @@ class TemplateJTree(
                 if (selectedNodeNotRoot == null) AllIcons.General.Add
                 else LayeredIcon.ADD_WITH_DROPDOWN
         }
+
+        /**
+         * Returns the shortcut for this action.
+         *
+         * @return the shortcut for this action
+         */
+        override fun getShortcut() = CommonActionsPanel.getCommonShortcut(CommonActionsPanel.Buttons.ADD)
+
+        /**
+         * Displays a popup to add a scheme, or immediately adds a template if nothing is currently selected.
+         *
+         * @param event ignored
+         */
+        override fun actionPerformed(event: AnActionEvent) =
+            JBPopupFactory.getInstance()
+                .createListPopup(
+                    if (selectedNodeNotRoot == null) DefaultTemplatesPopupStep()
+                    else MainPopupStep()
+                )
+                .show(preferredPopupPoint)
 
 
         /**
@@ -478,9 +486,12 @@ class TemplateJTree(
              * @param finalChoice ignored
              * @return `null`, or the `PopupStep` that is nested under this entry
              */
-            override fun onChosen(value: Scheme?, finalChoice: Boolean): PopupStep<*>? =
-                if (value == null) null
-                else addScheme(value.deepCopy().also { it.setSettingsState(currentState) }).let { null }
+            override fun onChosen(value: Scheme?, finalChoice: Boolean): PopupStep<*>? {
+                if (value != null)
+                    addScheme(value.deepCopy().also { it.setSettingsState(currentState) })
+
+                return null
+            }
 
             /**
              * Returns `true`.
@@ -563,11 +574,11 @@ class TemplateJTree(
      */
     private inner class RemoveButton : AnActionButton(Bundle("shared.action.remove"), AllIcons.General.Remove) {
         /**
-         * Removes the selected scheme from the tree.
+         * Specifies the thread in which [update] is invoked.
          *
-         * @param event ignored
+         * @return the thread in which [update] is invoked
          */
-        override fun actionPerformed(event: AnActionEvent) = removeScheme(selectedScheme!!)
+        override fun getActionUpdateThread() = ActionUpdateThread.EDT
 
         /**
          * Returns `true` if and only if this action is enabled.
@@ -582,12 +593,33 @@ class TemplateJTree(
          * @return the shortcut for this action
          */
         override fun getShortcut() = CommonActionsPanel.getCommonShortcut(CommonActionsPanel.Buttons.REMOVE)
+
+        /**
+         * Removes the selected scheme from the tree.
+         *
+         * @param event ignored
+         */
+        override fun actionPerformed(event: AnActionEvent) = removeScheme(selectedScheme!!)
     }
 
     /**
      * Copies the selected scheme in the tree.
      */
     private inner class CopyButton : AnActionButton(Bundle("shared.action.copy"), AllIcons.Actions.Copy) {
+        /**
+         * Specifies the thread in which [update] is invoked.
+         *
+         * @return the thread in which [update] is invoked
+         */
+        override fun getActionUpdateThread() = ActionUpdateThread.EDT
+
+        /**
+         * Returns `true` if and only if this action is enabled.
+         *
+         * @return `true` if and only if this action is enabled
+         */
+        override fun isEnabled() = selectedNodeNotRoot != null
+
         /**
          * Copies the selected scheme in the tree.
          *
@@ -599,13 +631,6 @@ class TemplateJTree(
 
             addScheme(copy)
         }
-
-        /**
-         * Returns `true` if and only if this action is enabled.
-         *
-         * @return `true` if and only if this action is enabled
-         */
-        override fun isEnabled() = selectedNodeNotRoot != null
     }
 
     /**
@@ -613,11 +638,11 @@ class TemplateJTree(
      */
     private inner class UpButton : AnActionButton(Bundle("shared.action.up"), AllIcons.Actions.MoveUp) {
         /**
-         * Moves the selected scheme up by one position in the tree.
+         * Specifies the thread in which [update] is invoked.
          *
-         * @param event ignored
+         * @return the thread in which [update] is invoked
          */
-        override fun actionPerformed(event: AnActionEvent) = moveSchemeByOnePosition(selectedScheme!!, moveDown = false)
+        override fun getActionUpdateThread() = ActionUpdateThread.EDT
 
         /**
          * Returns `true` if and only if this action is enabled.
@@ -632,6 +657,13 @@ class TemplateJTree(
          * @return the shortcut for this action
          */
         override fun getShortcut() = CommonActionsPanel.getCommonShortcut(CommonActionsPanel.Buttons.UP)
+
+        /**
+         * Moves the selected scheme up by one position in the tree.
+         *
+         * @param event ignored
+         */
+        override fun actionPerformed(event: AnActionEvent) = moveSchemeByOnePosition(selectedScheme!!, moveDown = false)
     }
 
     /**
@@ -639,11 +671,11 @@ class TemplateJTree(
      */
     private inner class DownButton : AnActionButton(Bundle("shared.action.down"), AllIcons.Actions.MoveDown) {
         /**
-         * Moves the selected scheme down by one position in the tree.
+         * Specifies the thread in which [update] is invoked.
          *
-         * @param event ignored
+         * @return the thread in which [update] is invoked
          */
-        override fun actionPerformed(event: AnActionEvent) = moveSchemeByOnePosition(selectedScheme!!, moveDown = true)
+        override fun getActionUpdateThread() = ActionUpdateThread.EDT
 
         /**
          * Returns `true` if and only if this action is enabled.
@@ -658,12 +690,33 @@ class TemplateJTree(
          * @return the shortcut for this action
          */
         override fun getShortcut() = CommonActionsPanel.getCommonShortcut(CommonActionsPanel.Buttons.DOWN)
+
+        /**
+         * Moves the selected scheme down by one position in the tree.
+         *
+         * @param event ignored
+         */
+        override fun actionPerformed(event: AnActionEvent) = moveSchemeByOnePosition(selectedScheme!!, moveDown = true)
     }
 
     /**
      * Resets the selected scheme to its original state, or removes it if it has no original state.
      */
     private inner class ResetButton : AnActionButton(Bundle("shared.action.reset"), AllIcons.General.Reset) {
+        /**
+         * Specifies the thread in which [update] is invoked.
+         *
+         * @return the thread in which [update] is invoked
+         */
+        override fun getActionUpdateThread() = ActionUpdateThread.EDT
+
+        /**
+         * Returns `true` if and only if this action is enabled.
+         *
+         * @return `true` if and only if this action is enabled
+         */
+        override fun isEnabled() = selectedScheme?.let { isModified(it) } ?: false
+
         /**
          * Resets the selected scheme to its original state, or removes it if it has no original state.
          *
@@ -686,13 +739,6 @@ class TemplateJTree(
             clearSelection()
             myModel.expandAndSelect(StateNode(toReset))
         }
-
-        /**
-         * Returns `true` if and only if this action is enabled.
-         *
-         * @return `true` if and only if this action is enabled
-         */
-        override fun isEnabled() = selectedScheme?.let { isModified(it) } ?: false
     }
 
 

--- a/src/main/kotlin/com/fwdekker/randomness/template/TemplateJTreeModel.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/template/TemplateJTreeModel.kt
@@ -27,7 +27,7 @@ import javax.swing.tree.TreePath
  *
  * @param list the list to be modeled
  */
-@Suppress("TooManyFunctions") // Normal for Swing implementations
+@Suppress("detekt:TooManyFunctions") // Normal for Swing implementations
 class TemplateJTreeModel(list: TemplateList = TemplateList(emptyList())) : TreeModel, EditableModel {
     /**
      * The listeners that are informed when the state of the tree changes.

--- a/src/main/kotlin/com/fwdekker/randomness/template/TemplateList.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/template/TemplateList.kt
@@ -126,21 +126,21 @@ data class TemplateList(
                 Template(
                     "Name",
                     listOf(
-                        WordScheme(words = DefaultWordList.wordListMap["Forenames"]!!.words),
+                        WordScheme(words = DefaultWordList.WORD_LIST_MAP["Forenames"]!!.words),
                         StringScheme(pattern = " ", isRegex = false),
-                        WordScheme(words = DefaultWordList.wordListMap["Surnames"]!!.words)
+                        WordScheme(words = DefaultWordList.WORD_LIST_MAP["Surnames"]!!.words)
                     )
                 ),
                 Template(
                     "Lorem Ipsum",
                     listOf(
                         WordScheme(
-                            words = DefaultWordList.wordListMap["Lorem"]!!.words,
+                            words = DefaultWordList.WORD_LIST_MAP["Lorem"]!!.words,
                             capitalization = CapitalizationMode.FIRST_LETTER
                         ),
                         StringScheme(pattern = " ", isRegex = false),
                         WordScheme(
-                            words = DefaultWordList.wordListMap["Lorem"]!!.words,
+                            words = DefaultWordList.WORD_LIST_MAP["Lorem"]!!.words,
                             arrayDecorator = ArrayDecorator(
                                 enabled = true,
                                 minCount = 3,

--- a/src/main/kotlin/com/fwdekker/randomness/template/TemplateListEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/template/TemplateListEditor.kt
@@ -44,7 +44,7 @@ import javax.swing.SwingUtilities
  * @param settings the settings containing the templates to edit
  * @see TemplateSettingsConfigurable
  */
-class TemplateListEditor(settings: SettingsState = SettingsState.default) : StateEditor<SettingsState>(settings) {
+class TemplateListEditor(settings: SettingsState = SettingsState.DEFAULT) : StateEditor<SettingsState>(settings) {
     override val rootComponent = JPanel(BorderLayout())
 
     private val currentState: SettingsState = SettingsState()
@@ -62,7 +62,7 @@ class TemplateListEditor(settings: SettingsState = SettingsState.default) : Stat
 
 
     init {
-        val splitter = CREATE_SPLITTER(false, SPLITTER_PROPORTION_KEY, DEFAULT_SPLITTER_PROPORTION)
+        val splitter = createSplitter(false, SPLITTER_PROPORTION_KEY, DEFAULT_SPLITTER_PROPORTION)
         rootComponent.add(splitter, BorderLayout.CENTER)
 
         // Left half
@@ -171,7 +171,7 @@ class TemplateListEditor(settings: SettingsState = SettingsState.default) : Stat
         super.applyState()
         val newList = originalState.templateList.templates.toSet()
 
-        TemplateActionLoader.updateActions(oldList, newList)
+        TemplateActionLoader().updateActions(oldList, newList)
     }
 
 
@@ -223,7 +223,7 @@ class TemplateListEditor(settings: SettingsState = SettingsState.default) : Stat
          * For some reason, `OnePixelSplitter` does not work in tests. Therefore, tests overwrite this field to inject a
          * different constructor.
          */
-        var CREATE_SPLITTER: (Boolean, String, Float) -> Splitter =
+        var createSplitter: (Boolean, String, Float) -> Splitter =
             { vertical, proportionKey, defaultProportion ->
                 OnePixelSplitter(vertical, proportionKey, defaultProportion)
             }

--- a/src/main/kotlin/com/fwdekker/randomness/template/TemplateReferenceEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/template/TemplateReferenceEditor.kt
@@ -33,7 +33,6 @@ import javax.swing.ListSelectionModel
  *
  * @param reference the reference to edit
  */
-@Suppress("LateinitUsage") // Initialized by scene builder
 class TemplateReferenceEditor(reference: TemplateReference) : StateEditor<TemplateReference>(reference) {
     override lateinit var rootComponent: JPanel private set
     override val preferredFocusedComponent
@@ -69,7 +68,6 @@ class TemplateReferenceEditor(reference: TemplateReference) : StateEditor<Templa
      *
      * This method is called by the scene builder at the start of the constructor.
      */
-    @Suppress("UnusedPrivateMember") // Used by scene builder
     private fun createUIComponents() {
         templateListSeparator = SeparatorFactory.createSeparator(Bundle("reference.ui.template_list"), null)
 

--- a/src/main/kotlin/com/fwdekker/randomness/ui/ListenerHelper.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/ui/ListenerHelper.kt
@@ -27,7 +27,7 @@ import com.intellij.openapi.editor.event.DocumentListener as JBDocumentListener
  * @param components the components to add the listener to
  * @param listener the listener to invoke whenever any of the given components changes state
  */
-@Suppress("SpreadOperator") // Acceptable because this method is called rarely
+@Suppress("detekt:SpreadOperator") // Acceptable because this method is called rarely
 fun addChangeListenerTo(vararg components: Any, listener: () -> Unit) {
     components.forEach { component ->
         when (component) {

--- a/src/main/kotlin/com/fwdekker/randomness/ui/PreviewPanel.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/ui/PreviewPanel.kt
@@ -31,7 +31,7 @@ import kotlin.random.Random
  *
  * @property getScheme Returns a scheme that generates previews. Its random source will be changed.
  */
-@Suppress("LateinitUsage") // Initialized by scene builder
+@Suppress("detekt:LateinitUsage") // Initialized by scene builder
 class PreviewPanel(private val getScheme: () -> Scheme) : Disposable {
     /**
      * The root panel containing the preview elements.
@@ -61,7 +61,6 @@ class PreviewPanel(private val getScheme: () -> Scheme) : Disposable {
      *
      * This method is called by the scene builder at the start of the constructor.
      */
-    @Suppress("UnusedPrivateMember") // Used by scene builder
     private fun createUIComponents() {
         separator = SeparatorFactory.createSeparator(Bundle("preview.title"), null)
         refreshButton = InplaceButton(Bundle("shared.action.refresh"), AllIcons.Actions.Refresh) {

--- a/src/main/kotlin/com/fwdekker/randomness/uuid/UuidSchemeEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/uuid/UuidSchemeEditor.kt
@@ -28,7 +28,6 @@ import javax.swing.JPanel
  *
  * @param scheme the scheme to edit in the component
  */
-@Suppress("LateinitUsage") // Initialized by scene builder
 class UuidSchemeEditor(scheme: UuidScheme = UuidScheme()) : StateEditor<UuidScheme>(scheme) {
     override lateinit var rootComponent: JPanel private set
     override val preferredFocusedComponent
@@ -65,7 +64,6 @@ class UuidSchemeEditor(scheme: UuidScheme = UuidScheme()) : StateEditor<UuidSche
      *
      * This method is called by the scene builder at the start of the constructor.
      */
-    @Suppress("UnusedPrivateMember") // Used by scene builder
     private fun createUIComponents() {
         valueSeparator = SeparatorFactory.createSeparator(Bundle("uuid.ui.value_separator"), null)
 

--- a/src/main/kotlin/com/fwdekker/randomness/word/DefaultWordList.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/word/DefaultWordList.kt
@@ -19,7 +19,7 @@ data class DefaultWordList(val name: String, val filename: String) {
      */
     @get:Throws(IOException::class)
     val words: List<String> by lazy {
-        cache.getOrPut(filename) {
+        CACHE.getOrPut(filename) {
             (javaClass.classLoader.getResource(filename) ?: throw IOException(Bundle("word_list.error.file_not_found")))
                 .openStream()
                 .bufferedReader()
@@ -37,20 +37,20 @@ data class DefaultWordList(val name: String, val filename: String) {
          * Retains word lists that have previously been looked up.
          */
         @get:Synchronized
-        private val cache = ConcurrentHashMap<String, List<String>>()
+        private val CACHE = ConcurrentHashMap<String, List<String>>()
 
         /**
          * The list of all available word lists.
          */
-        val wordLists = listOf(
+        val WORD_LISTS = listOf(
             DefaultWordList("Forenames", "word-lists/forenames.txt"),
             DefaultWordList("Lorem", "word-lists/lorem.txt"),
             DefaultWordList("Surnames", "word-lists/surnames.txt")
         )
 
         /**
-         * The available [wordLists] as indexed by [name].
+         * The available [WORD_LISTS] as indexed by [name].
          */
-        val wordListMap = wordLists.associateBy { it.name }
+        val WORD_LIST_MAP = WORD_LISTS.associateBy { it.name }
     }
 }

--- a/src/main/kotlin/com/fwdekker/randomness/word/WordSchemeEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/word/WordSchemeEditor.kt
@@ -37,7 +37,6 @@ import javax.swing.JPanel
  *
  * @param scheme the scheme to edit in the component
  */
-@Suppress("LateinitUsage") // Initialized by scene builder
 class WordSchemeEditor(scheme: WordScheme = WordScheme()) : StateEditor<WordScheme>(scheme) {
     override lateinit var rootComponent: JPanel private set
     override val preferredFocusedComponent
@@ -83,11 +82,10 @@ class WordSchemeEditor(scheme: WordScheme = WordScheme()) : StateEditor<WordSche
      *
      * This method is called by the scene builder at the start of the constructor.
      */
-    @Suppress("UnusedPrivateMember") // Used by scene builder
     private fun createUIComponents() {
         wordListSeparator = SeparatorFactory.createSeparator(Bundle("word.ui.word_list"), null)
 
-        wordListBox = ComboBox(arrayOf(PRESET_ITEM) + DefaultWordList.wordLists)
+        wordListBox = ComboBox(arrayOf(PRESET_ITEM) + DefaultWordList.WORD_LISTS)
         wordListBox.setRenderer { _, value, _, _, _ -> JBLabel(value.name) }
         wordListBox.addItemListener {
             if (it.stateChange == ItemEvent.SELECTED) {
@@ -125,7 +123,7 @@ class WordSchemeEditor(scheme: WordScheme = WordScheme()) : StateEditor<WordSche
     override fun loadState(state: WordScheme) {
         super.loadState(state)
 
-        wordListBox.selectedIndex = DefaultWordList.wordLists.map { it.words }.indexOf(state.words) + 1
+        wordListBox.selectedIndex = DefaultWordList.WORD_LISTS.map { it.words }.indexOf(state.words) + 1
         wordList = state.words
         customQuotation.label = state.customQuotation
         quotationGroup.setValue(state.quotation)

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -12,13 +12,13 @@
         <applicationService serviceImplementation="com.fwdekker.randomness.template.TemplateSettings" />
 
         <!-- Settings window -->
-        <applicationConfigurable instance="com.fwdekker.randomness.template.TemplateSettingsConfigurable"
+        <applicationConfigurable parentId="tools"
+                                 instance="com.fwdekker.randomness.template.TemplateSettingsConfigurable"
                                  id="com.fwdekker.randomness.template.TemplateSettingsConfigurable"
-                                 groupId="tools"
-                                 bundle="randomness" />
+                                 displayName="Randomness" />
 
         <!-- Dynamically loads, unloads, and updates template actions -->
-        <dynamicActionConfigurationCustomizer implementation="com.fwdekker.randomness.template.TemplateActionLoader"/>
+        <dynamicActionConfigurationCustomizer implementation="com.fwdekker.randomness.template.TemplateActionLoader" />
     </extensions>
 
     <!-- Non-dynamic actions -->

--- a/src/test/kotlin/com/fwdekker/randomness/ActionToolbarHelper.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/ActionToolbarHelper.kt
@@ -1,7 +1,6 @@
 package com.fwdekker.randomness
 
 import com.intellij.openapi.actionSystem.impl.ActionButton
-import com.intellij.ui.AnActionButton
 import org.assertj.swing.fixture.FrameFixture
 
 
@@ -13,14 +12,6 @@ import org.assertj.swing.fixture.FrameFixture
 fun FrameFixture.getActionButton(accessibleName: String): ActionButton =
     robot().finder()
         .find(matcher(ActionButton::class.java) { it.isValid && it.accessibleContext.accessibleName == accessibleName })
-
-/**
- * Returns the `AnActionButton` in the `ActionButton` that has [accessibleName].
- *
- * @param accessibleName the name of the button action to return
- */
-fun FrameFixture.getAnActionButton(accessibleName: String) =
-    getActionButton(accessibleName).action as AnActionButton
 
 /**
  * Clicks the `ActionButton` that has [accessibleName].

--- a/src/test/kotlin/com/fwdekker/randomness/BoxTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/BoxTest.kt
@@ -1,14 +1,13 @@
 package com.fwdekker.randomness
 
+import io.kotest.core.spec.style.DescribeSpec
 import org.assertj.core.api.Assertions.assertThat
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
 
 
 /**
  * Unit tests for [Box].
  */
-object BoxTest : Spek({
+object BoxTest : DescribeSpec({
     describe("box") {
         it("returns the generator's value when de-referenced") {
             assertThat(+Box({ "needle" })).isEqualTo("needle")

--- a/src/test/kotlin/com/fwdekker/randomness/BracketsDescriptorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/BracketsDescriptorTest.kt
@@ -1,15 +1,14 @@
 package com.fwdekker.randomness
 
+import io.kotest.core.spec.style.DescribeSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
 
 
 /**
  * Unit tests for [BracketsDescriptor].
  */
-object BracketsDescriptorTest : Spek({
+object BracketsDescriptorTest : DescribeSpec({
     data class Param(
         val description: String,
         val descriptor: String,

--- a/src/test/kotlin/com/fwdekker/randomness/BundleTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/BundleTest.kt
@@ -1,16 +1,15 @@
 package com.fwdekker.randomness
 
+import io.kotest.core.spec.style.DescribeSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
 import java.util.MissingResourceException
 
 
 /**
  * Unit tests for [Bundle].
  */
-object BundleTest : Spek({
+object BundleTest : DescribeSpec({
     describe("get (no arguments)") {
         it("throws an exception if the key could not be found") {
             assertThatThrownBy { Bundle("this_key_does_not_exist") }.isInstanceOf(MissingResourceException::class.java)

--- a/src/test/kotlin/com/fwdekker/randomness/CapitalizationModeTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/CapitalizationModeTest.kt
@@ -1,16 +1,15 @@
 package com.fwdekker.randomness
 
+import io.kotest.core.spec.style.DescribeSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
 import kotlin.random.Random
 
 
 /**
  * Unit tests for [CapitalizationMode].
  */
-object CapitalizationModeTest : Spek({
+object CapitalizationModeTest : DescribeSpec({
     describe("transform") {
         describe("retain mode") {
             it("does nothing to a string") {

--- a/src/test/kotlin/com/fwdekker/randomness/ErrorReporterTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/ErrorReporterTest.kt
@@ -2,28 +2,27 @@ package com.fwdekker.randomness
 
 import com.intellij.testFramework.fixtures.IdeaTestFixture
 import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
+import io.kotest.core.spec.style.DescribeSpec
 import org.assertj.core.api.Assertions.assertThat
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
 
 
 /**
  * Unit tests for [ErrorReporter].
  */
-object ErrorReporterTest : Spek({
+object ErrorReporterTest : DescribeSpec({
     describe("error reporter") {
         lateinit var ideaFixture: IdeaTestFixture
         lateinit var reporter: ErrorReporter
 
 
-        beforeEachTest {
+        beforeEach {
             ideaFixture = IdeaTestFixtureFactory.getFixtureFactory().createBareFixture()
             ideaFixture.setUp()
 
             reporter = ErrorReporter()
         }
 
-        afterEachTest {
+        afterEach {
             ideaFixture.tearDown()
         }
 

--- a/src/test/kotlin/com/fwdekker/randomness/InsertActionTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/InsertActionTest.kt
@@ -13,6 +13,7 @@ import org.assertj.core.api.Assertions.assertThat
 /**
  * Integration tests for [InsertAction].
  */
+@Suppress("detekt:FunctionName", "detekt:FunctionMaxLength") // Makes JUnit tests easier to read
 class InsertActionTest : BasePlatformTestCase() {
     private lateinit var document: Document
     private lateinit var caretModel: CaretModel
@@ -33,7 +34,7 @@ class InsertActionTest : BasePlatformTestCase() {
         insertAction = DummyInsertAction { insertValue++.toString() }
     }
 
-    @Suppress("SwallowedException") // Intentional
+    @Suppress("detekt:SwallowedException") // Intentional
     override fun tearDown() {
         try {
             super.tearDown()

--- a/src/test/kotlin/com/fwdekker/randomness/RandomnessIconsTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/RandomnessIconsTest.kt
@@ -1,10 +1,9 @@
 package com.fwdekker.randomness
 
+import io.kotest.core.spec.style.DescribeSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.swing.edt.GuiActionRunner
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
 import java.awt.Color
 import java.awt.Component
 import java.awt.Graphics
@@ -16,7 +15,7 @@ import javax.swing.JLabel
 /**
  * Unit tests for [TypeIcon].
  */
-object TypeIconTest : Spek({
+object TypeIconTest : DescribeSpec({
     describe("constructor") {
         it("fails if no colors are given") {
             assertThatThrownBy { TypeIcon(PlainIcon(), "relief", emptyList()) }
@@ -85,7 +84,7 @@ object TypeIconTest : Spek({
 /**
  * Unit tests for [OverlayIcon].
  */
-object OverlayIconTest : Spek({
+object OverlayIconTest : DescribeSpec({
     describe("paintIcon") {
         it("paints nothing if the component is null") {
             val i = BufferedImage(32, 32, BufferedImage.TYPE_INT_ARGB)
@@ -141,7 +140,7 @@ object OverlayIconTest : Spek({
 /**
  * Unit tests for [OverlayedIcon].
  */
-object OverlayedIconTest : Spek({
+object OverlayedIconTest : DescribeSpec({
     describe("constructor") {
         it("fails if the base image is not square") {
             assertThatThrownBy { OverlayedIcon(PlainIcon(186, 132), emptyList()) }
@@ -213,7 +212,7 @@ object OverlayedIconTest : Spek({
 /**
  * Unit tests for [RadialColorReplacementFilter].
  */
-object RadialColorReplacementFilterTest : Spek({
+object RadialColorReplacementFilterTest : DescribeSpec({
     describe("constructor") {
         it("fails if no colors are given") {
             assertThatThrownBy { RadialColorReplacementFilter(emptyList(), Pair(0, 0)) }

--- a/src/test/kotlin/com/fwdekker/randomness/SchemeTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/SchemeTest.kt
@@ -1,20 +1,19 @@
 package com.fwdekker.randomness
 
 import com.fwdekker.randomness.array.ArrayDecorator
+import io.kotest.core.spec.style.DescribeSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
 
 
 /**
  * Unit tests for [Scheme].
  */
-object SchemeTest : Spek({
+object SchemeTest : DescribeSpec({
     lateinit var scheme: DummyScheme
 
 
-    beforeEachTest {
+    beforeEach {
         scheme = DummyScheme()
     }
 

--- a/src/test/kotlin/com/fwdekker/randomness/SettingsConfigurableTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/SettingsConfigurableTest.kt
@@ -3,20 +3,19 @@ package com.fwdekker.randomness
 import com.intellij.openapi.options.ConfigurationException
 import com.intellij.testFramework.fixtures.IdeaTestFixture
 import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
+import io.kotest.core.spec.style.DescribeSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.swing.edt.FailOnThreadViolationRepaintManager
 import org.assertj.swing.edt.GuiActionRunner
 import org.assertj.swing.fixture.Containers
 import org.assertj.swing.fixture.FrameFixture
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
 
 
 /**
  * Unit tests for [SettingsConfigurable].
  */
-object SettingsConfigurableTest : Spek({
+object SettingsConfigurableTest : DescribeSpec({
     lateinit var ideaFixture: IdeaTestFixture
     lateinit var scheme: DummyScheme
     lateinit var editor: DummySchemeEditor
@@ -24,11 +23,11 @@ object SettingsConfigurableTest : Spek({
     lateinit var frame: FrameFixture
 
 
-    beforeGroup {
+    beforeContainer {
         FailOnThreadViolationRepaintManager.install()
     }
 
-    beforeEachTest {
+    beforeEach {
         ideaFixture = IdeaTestFixtureFactory.getFixtureFactory().createBareFixture()
         ideaFixture.setUp()
 
@@ -39,7 +38,7 @@ object SettingsConfigurableTest : Spek({
         frame = Containers.showInFrame(editor.rootComponent)
     }
 
-    afterEachTest {
+    afterEach {
         ideaFixture.tearDown()
         frame.cleanUp()
     }

--- a/src/test/kotlin/com/fwdekker/randomness/SettingsStateTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/SettingsStateTest.kt
@@ -3,20 +3,19 @@ package com.fwdekker.randomness
 import com.fwdekker.randomness.template.Template
 import com.fwdekker.randomness.template.TemplateList
 import com.fwdekker.randomness.template.TemplateReference
+import io.kotest.core.spec.style.DescribeSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
 
 
 /**
  * Unit tests for [SettingsState].
  */
-object SettingsStateTest : Spek({
+object SettingsStateTest : DescribeSpec({
     lateinit var state: SettingsState
 
 
-    beforeEachTest {
+    beforeEach {
         state = SettingsState()
     }
 

--- a/src/test/kotlin/com/fwdekker/randomness/StateEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/StateEditorTest.kt
@@ -2,19 +2,18 @@ package com.fwdekker.randomness
 
 import com.intellij.testFramework.fixtures.IdeaTestFixture
 import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
+import io.kotest.core.spec.style.DescribeSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.swing.edt.FailOnThreadViolationRepaintManager
 import org.assertj.swing.edt.GuiActionRunner
 import org.assertj.swing.fixture.Containers
 import org.assertj.swing.fixture.FrameFixture
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
 
 
 /**
  * Unit tests for [StateEditor].
  */
-object StateEditorTest : Spek({
+object StateEditorTest : DescribeSpec({
     lateinit var ideaFixture: IdeaTestFixture
     lateinit var frame: FrameFixture
 
@@ -22,11 +21,11 @@ object StateEditorTest : Spek({
     lateinit var editor: DummySchemeEditor
 
 
-    beforeGroup {
+    beforeContainer {
         FailOnThreadViolationRepaintManager.install()
     }
 
-    beforeEachTest {
+    beforeEach {
         ideaFixture = IdeaTestFixtureFactory.getFixtureFactory().createBareFixture()
         ideaFixture.setUp()
 
@@ -35,7 +34,7 @@ object StateEditorTest : Spek({
         frame = Containers.showInFrame(editor.rootComponent)
     }
 
-    afterEachTest {
+    afterEach {
         frame.cleanUp()
         ideaFixture.tearDown()
     }

--- a/src/test/kotlin/com/fwdekker/randomness/TimelyTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/TimelyTest.kt
@@ -2,17 +2,16 @@ package com.fwdekker.randomness
 
 import com.fwdekker.randomness.Timely.GENERATOR_TIMEOUT
 import com.fwdekker.randomness.Timely.generateTimely
+import io.kotest.core.spec.style.DescribeSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
 
 
 /**
  * Unit tests for the extension functions in `TimelyKt`.
  */
 @Suppress("detekt:TooGenericExceptionThrown") // Acceptable for tests
-object TimelyTest : Spek({
+object TimelyTest : DescribeSpec({
     describe("timely") {
         it("returns output if generator finished within time") {
             assertThat(generateTimely { "neck" }).isEqualTo("neck")

--- a/src/test/kotlin/com/fwdekker/randomness/TimelyTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/TimelyTest.kt
@@ -11,7 +11,7 @@ import org.spekframework.spek2.style.specification.describe
 /**
  * Unit tests for the extension functions in `TimelyKt`.
  */
-@Suppress("TooGenericExceptionThrown") // Acceptable for tests
+@Suppress("detekt:TooGenericExceptionThrown") // Acceptable for tests
 object TimelyTest : Spek({
     describe("timely") {
         it("returns output if generator finished within time") {

--- a/src/test/kotlin/com/fwdekker/randomness/array/ArrayDecoratorEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/array/ArrayDecoratorEditorTest.kt
@@ -5,20 +5,19 @@ import com.fwdekker.randomness.nameMatcher
 import com.intellij.testFramework.fixtures.IdeaTestFixture
 import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
 import com.intellij.ui.TitledSeparator
+import io.kotest.core.spec.style.DescribeSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.swing.edt.FailOnThreadViolationRepaintManager
 import org.assertj.swing.edt.GuiActionRunner
 import org.assertj.swing.fixture.Containers.showInFrame
 import org.assertj.swing.fixture.FrameFixture
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
 import javax.swing.JCheckBox
 
 
 /**
  * GUI tests for [ArrayDecoratorEditor].
  */
-object ArrayDecoratorEditorTest : Spek({
+object ArrayDecoratorEditorTest : DescribeSpec({
     lateinit var ideaFixture: IdeaTestFixture
     lateinit var frame: FrameFixture
 
@@ -26,11 +25,11 @@ object ArrayDecoratorEditorTest : Spek({
     lateinit var editor: ArrayDecoratorEditor
 
 
-    beforeGroup {
+    beforeContainer {
         FailOnThreadViolationRepaintManager.install()
     }
 
-    beforeEachTest {
+    beforeEach {
         ideaFixture = IdeaTestFixtureFactory.getFixtureFactory().createBareFixture()
         ideaFixture.setUp()
 
@@ -39,7 +38,7 @@ object ArrayDecoratorEditorTest : Spek({
         frame = showInFrame(editor.rootComponent)
     }
 
-    afterEachTest {
+    afterEach {
         frame.cleanUp()
         ideaFixture.tearDown()
     }

--- a/src/test/kotlin/com/fwdekker/randomness/array/ArrayDecoratorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/array/ArrayDecoratorTest.kt
@@ -2,21 +2,20 @@ package com.fwdekker.randomness.array
 
 import com.fwdekker.randomness.DataGenerationException
 import com.fwdekker.randomness.DummyScheme
+import io.kotest.core.spec.style.DescribeSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
 
 
 /**
  * Unit tests for [ArrayDecorator].
  */
-object ArrayDecoratorTest : Spek({
+object ArrayDecoratorTest : DescribeSpec({
     lateinit var arrayDecorator: ArrayDecorator
     lateinit var dummyScheme: DummyScheme
 
 
-    beforeEachTest {
+    beforeEach {
         arrayDecorator = ArrayDecorator(enabled = true)
         dummyScheme = DummyScheme(decorators = listOf(arrayDecorator))
     }

--- a/src/test/kotlin/com/fwdekker/randomness/datetime/DateTimeSchemeEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/datetime/DateTimeSchemeEditorTest.kt
@@ -5,20 +5,19 @@ import com.fwdekker.randomness.ui.JDateTimeField
 import com.github.sisyphsu.dateparser.DateParserUtils
 import com.intellij.testFramework.fixtures.IdeaTestFixture
 import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
+import io.kotest.core.spec.style.DescribeSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.swing.edt.FailOnThreadViolationRepaintManager
 import org.assertj.swing.edt.GuiActionRunner
 import org.assertj.swing.fixture.Containers
 import org.assertj.swing.fixture.FrameFixture
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
 import java.time.format.DateTimeFormatter
 
 
 /**
  * GUI tests for [DateTimeSchemeEditor].
  */
-object DateTimeSchemeEditorTest : Spek({
+object DateTimeSchemeEditorTest : DescribeSpec({
     lateinit var ideaFixture: IdeaTestFixture
     lateinit var frame: FrameFixture
     lateinit var scheme: DateTimeScheme
@@ -37,11 +36,11 @@ object DateTimeSchemeEditorTest : Spek({
     }
 
 
-    beforeGroup {
+    beforeContainer {
         FailOnThreadViolationRepaintManager.install()
     }
 
-    beforeEachTest {
+    beforeEach {
         ideaFixture = IdeaTestFixtureFactory.getFixtureFactory().createBareFixture()
         ideaFixture.setUp()
 
@@ -50,7 +49,7 @@ object DateTimeSchemeEditorTest : Spek({
         frame = Containers.showInFrame(editor.rootComponent)
     }
 
-    afterEachTest {
+    afterEach {
         frame.cleanUp()
         ideaFixture.tearDown()
     }

--- a/src/test/kotlin/com/fwdekker/randomness/datetime/DateTimeSchemeTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/datetime/DateTimeSchemeTest.kt
@@ -2,10 +2,9 @@ package com.fwdekker.randomness.datetime
 
 import com.fwdekker.randomness.DataGenerationException
 import com.github.sisyphsu.dateparser.DateParserUtils
+import io.kotest.core.spec.style.DescribeSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
 import java.time.LocalDateTime
 import java.util.regex.Pattern
 
@@ -13,11 +12,11 @@ import java.util.regex.Pattern
 /**
  * Unit tests for [DateTimeScheme].
  */
-object DateTimeSchemeTest : Spek({
+object DateTimeSchemeTest : DescribeSpec({
     lateinit var dateTimeScheme: DateTimeScheme
 
 
-    beforeEachTest {
+    beforeEach {
         dateTimeScheme = DateTimeScheme()
     }
 

--- a/src/test/kotlin/com/fwdekker/randomness/decimal/DecimalSchemeEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/decimal/DecimalSchemeEditorTest.kt
@@ -3,19 +3,18 @@ package com.fwdekker.randomness.decimal
 import com.fwdekker.randomness.array.ArrayDecorator
 import com.intellij.testFramework.fixtures.IdeaTestFixture
 import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
+import io.kotest.core.spec.style.DescribeSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.swing.edt.FailOnThreadViolationRepaintManager
 import org.assertj.swing.edt.GuiActionRunner
 import org.assertj.swing.fixture.Containers.showInFrame
 import org.assertj.swing.fixture.FrameFixture
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
 
 
 /**
  * GUI tests for [DecimalSchemeEditor].
  */
-object DecimalSchemeEditorTest : Spek({
+object DecimalSchemeEditorTest : DescribeSpec({
     lateinit var ideaFixture: IdeaTestFixture
     lateinit var frame: FrameFixture
 
@@ -23,11 +22,11 @@ object DecimalSchemeEditorTest : Spek({
     lateinit var editor: DecimalSchemeEditor
 
 
-    beforeGroup {
+    beforeContainer {
         FailOnThreadViolationRepaintManager.install()
     }
 
-    beforeEachTest {
+    beforeEach {
         ideaFixture = IdeaTestFixtureFactory.getFixtureFactory().createBareFixture()
         ideaFixture.setUp()
 
@@ -36,7 +35,7 @@ object DecimalSchemeEditorTest : Spek({
         frame = showInFrame(editor.rootComponent)
     }
 
-    afterEachTest {
+    afterEach {
         frame.cleanUp()
         ideaFixture.tearDown()
     }

--- a/src/test/kotlin/com/fwdekker/randomness/fixedlength/FixedLengthDecoratorEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/fixedlength/FixedLengthDecoratorEditorTest.kt
@@ -2,19 +2,18 @@ package com.fwdekker.randomness.fixedlength
 
 import com.intellij.testFramework.fixtures.IdeaTestFixture
 import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
+import io.kotest.core.spec.style.DescribeSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.swing.edt.FailOnThreadViolationRepaintManager
 import org.assertj.swing.edt.GuiActionRunner
 import org.assertj.swing.fixture.Containers
 import org.assertj.swing.fixture.FrameFixture
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
 
 
 /**
  * GUI tests for [FixedLengthDecoratorEditor].
  */
-object FixedLengthDecoratorEditorTest : Spek({
+object FixedLengthDecoratorEditorTest : DescribeSpec({
     lateinit var ideaFixture: IdeaTestFixture
     lateinit var frame: FrameFixture
 
@@ -22,11 +21,11 @@ object FixedLengthDecoratorEditorTest : Spek({
     lateinit var editor: FixedLengthDecoratorEditor
 
 
-    beforeGroup {
+    beforeContainer {
         FailOnThreadViolationRepaintManager.install()
     }
 
-    beforeEachTest {
+    beforeEach {
         ideaFixture = IdeaTestFixtureFactory.getFixtureFactory().createBareFixture()
         ideaFixture.setUp()
 
@@ -35,7 +34,7 @@ object FixedLengthDecoratorEditorTest : Spek({
         frame = Containers.showInFrame(editor.rootComponent)
     }
 
-    afterEachTest {
+    afterEach {
         frame.cleanUp()
         ideaFixture.tearDown()
     }

--- a/src/test/kotlin/com/fwdekker/randomness/fixedlength/FixedLengthDecoratorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/fixedlength/FixedLengthDecoratorTest.kt
@@ -3,21 +3,20 @@ package com.fwdekker.randomness.fixedlength
 import com.fwdekker.randomness.DataGenerationException
 import com.fwdekker.randomness.DummyScheme
 import com.fwdekker.randomness.fixedlength.FixedLengthDecorator.Companion.MIN_LENGTH
+import io.kotest.core.spec.style.DescribeSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
 
 
 /**
  * Unit tests for [FixedLengthDecorator].
  */
-object FixedLengthDecoratorTest : Spek({
+object FixedLengthDecoratorTest : DescribeSpec({
     lateinit var fixedLengthDecorator: FixedLengthDecorator
     lateinit var dummyScheme: DummyScheme
 
 
-    beforeEachTest {
+    beforeEach {
         fixedLengthDecorator = FixedLengthDecorator(enabled = true)
         dummyScheme = DummyScheme(decorators = listOf(fixedLengthDecorator))
     }

--- a/src/test/kotlin/com/fwdekker/randomness/integer/IntegerSchemeEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/integer/IntegerSchemeEditorTest.kt
@@ -4,19 +4,18 @@ import com.fwdekker.randomness.CapitalizationMode
 import com.fwdekker.randomness.array.ArrayDecorator
 import com.intellij.testFramework.fixtures.IdeaTestFixture
 import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
+import io.kotest.core.spec.style.DescribeSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.swing.edt.FailOnThreadViolationRepaintManager
 import org.assertj.swing.edt.GuiActionRunner
 import org.assertj.swing.fixture.Containers.showInFrame
 import org.assertj.swing.fixture.FrameFixture
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
 
 
 /**
  * GUI tests for [IntegerSchemeEditor].
  */
-object IntegerSchemeEditorTest : Spek({
+object IntegerSchemeEditorTest : DescribeSpec({
     lateinit var ideaFixture: IdeaTestFixture
     lateinit var frame: FrameFixture
 
@@ -24,11 +23,11 @@ object IntegerSchemeEditorTest : Spek({
     lateinit var editor: IntegerSchemeEditor
 
 
-    beforeGroup {
+    beforeContainer {
         FailOnThreadViolationRepaintManager.install()
     }
 
-    beforeEachTest {
+    beforeEach {
         ideaFixture = IdeaTestFixtureFactory.getFixtureFactory().createBareFixture()
         ideaFixture.setUp()
 
@@ -37,7 +36,7 @@ object IntegerSchemeEditorTest : Spek({
         frame = showInFrame(editor.rootComponent)
     }
 
-    afterEachTest {
+    afterEach {
         frame.cleanUp()
         ideaFixture.tearDown()
     }

--- a/src/test/kotlin/com/fwdekker/randomness/integer/IntegerSchemeTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/integer/IntegerSchemeTest.kt
@@ -2,20 +2,23 @@ package com.fwdekker.randomness.integer
 
 import com.fwdekker.randomness.CapitalizationMode
 import com.fwdekker.randomness.DataGenerationException
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.data.forAll
+import io.kotest.data.headers
+import io.kotest.data.row
+import io.kotest.data.table
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
 
 
 /**
  * Unit tests for [IntegerScheme].
  */
-object IntegerSchemeTest : Spek({
+object IntegerSchemeTest : DescribeSpec({
     lateinit var integerScheme: IntegerScheme
 
 
-    beforeEachTest {
+    beforeEach {
         integerScheme = IntegerScheme()
     }
 
@@ -29,16 +32,19 @@ object IntegerSchemeTest : Spek({
         }
 
         describe("value range") {
-            mapOf(
-                Pair(0L, 0L) to "0",
-                Pair(1L, 1L) to "1",
-                Pair(-5L, -5L) to "-5",
-                Pair(488L, 488L) to "488",
-                Pair(-876L, -876L) to "-876",
-                Pair(Long.MIN_VALUE, Long.MIN_VALUE) to Long.MIN_VALUE.toString(),
-                Pair(Long.MAX_VALUE, Long.MAX_VALUE) to Long.MAX_VALUE.toString()
-            ).forEach { (minValue, maxValue), expectedString ->
-                it("generates $expectedString") {
+            it("generates values within the specified range") {
+                forAll(
+                    table(
+                        headers("min value", "max value", "expected string"),
+                        row(0L, 0L, "0"),
+                        row(1L, 1L, "1"),
+                        row(-5L, -5L, "-5"),
+                        row(488L, 488L, "488"),
+                        row(-876L, -876L, "-876"),
+                        row(Long.MIN_VALUE, Long.MIN_VALUE, Long.MIN_VALUE.toString()),
+                        row(Long.MAX_VALUE, Long.MAX_VALUE, Long.MAX_VALUE.toString()),
+                    )
+                ) { minValue, maxValue, expectedString ->
                     integerScheme.minValue = minValue
                     integerScheme.maxValue = maxValue
 
@@ -58,12 +64,15 @@ object IntegerSchemeTest : Spek({
         }
 
         describe("base") {
-            mapOf(
-                Triple(33_360L, 10, ".") to "33.360",
-                Triple(48_345L, 10, ".") to "48.345",
-                Triple(48_345L, 11, ".") to "33360"
-            ).forEach { (value, base, groupingSeparator), expectedString ->
-                it("generates $expectedString") {
+            it("generates values in the specified base") {
+                forAll(
+                    table(
+                        headers("value", "base", "grouping separator", "expected string"),
+                        row(33_360L, 10, ".", "33.360"),
+                        row(48_345L, 10, ".", "48.345"),
+                        row(48_345L, 11, ".", "33360"),
+                    )
+                ) { value, base, groupingSeparator, expectedString ->
                     integerScheme.minValue = value
                     integerScheme.maxValue = value
                     integerScheme.base = base
@@ -75,12 +84,15 @@ object IntegerSchemeTest : Spek({
         }
 
         describe("separator") {
-            mapOf(
-                Pair(95_713L, "") to "95713",
-                Pair(163_583L, ".") to "163.583",
-                Pair(351_426L, ",") to "351,426"
-            ).forEach { (value, groupingSeparator), expectedString ->
-                it("generates $expectedString") {
+            it("generates strings with the specified separator") {
+                forAll(
+                    table(
+                        headers("value", "grouping separator", "expected string"),
+                        row(95_713L, "", "95713"),
+                        row(163_583L, ".", "163.583"),
+                        row(351_426L, ",", "351,426"),
+                    )
+                ) { value, groupingSeparator, expectedString ->
                     integerScheme.minValue = value
                     integerScheme.maxValue = value
                     integerScheme.groupingSeparator = groupingSeparator
@@ -91,14 +103,15 @@ object IntegerSchemeTest : Spek({
         }
 
         describe("capitalization") {
-            data class Param(val value: Long, val base: Int, val prefix: String, val capitalization: CapitalizationMode)
-
-            mapOf(
-                Param(624L, 10, "", CapitalizationMode.UPPER) to "624",
-                Param(254L, 16, "", CapitalizationMode.UPPER) to "FE",
-                Param(254L, 16, "0x", CapitalizationMode.FIRST_LETTER) to "0xFe"
-            ).forEach { (value, base, prefix, capitalization), expectedString ->
-                it("generates $expectedString") {
+            it("generates strings with the specified capitalization") {
+                forAll(
+                    table(
+                        headers("value", "base", "prefix", "capitalization", "expected string"),
+                        row(624L, 10, "", CapitalizationMode.UPPER, "624"),
+                        row(254L, 16, "", CapitalizationMode.UPPER, "FE"),
+                        row(254L, 16, "0x", CapitalizationMode.FIRST_LETTER, "0xFe"),
+                    )
+                ) { value, base, prefix, capitalization, expectedString ->
                     integerScheme.minValue = value
                     integerScheme.maxValue = value
                     integerScheme.base = base
@@ -111,13 +124,16 @@ object IntegerSchemeTest : Spek({
         }
 
         describe("prefix and suffix") {
-            mapOf(
-                Triple(920L, "", "") to "920",
-                Triple(553L, "before", "after") to "before553after",
-                Triple(948L, "0x", "") to "0x948",
-                Triple(502L, "", "L") to "502L"
-            ).forEach { (value, prefix, suffix), expectedString ->
-                it("generates $expectedString") {
+            it("generates strings with the specified prefix and suffix") {
+                forAll(
+                    table(
+                        headers("value", "prefix", "suffix", "expected string"),
+                        row(920L, "", "", "920"),
+                        row(553L, "before", "after", "before553after"),
+                        row(948L, "0x", "", "0x948"),
+                        row(502L, "", "L", "502L"),
+                    )
+                ) { value, prefix, suffix, expectedString ->
                     integerScheme.minValue = value
                     integerScheme.maxValue = value
                     integerScheme.prefix = prefix

--- a/src/test/kotlin/com/fwdekker/randomness/string/StringSchemeEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/string/StringSchemeEditorTest.kt
@@ -4,19 +4,18 @@ import com.fwdekker.randomness.CapitalizationMode
 import com.fwdekker.randomness.array.ArrayDecorator
 import com.intellij.testFramework.fixtures.IdeaTestFixture
 import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
+import io.kotest.core.spec.style.DescribeSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.swing.edt.FailOnThreadViolationRepaintManager
 import org.assertj.swing.edt.GuiActionRunner
 import org.assertj.swing.fixture.Containers.showInFrame
 import org.assertj.swing.fixture.FrameFixture
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
 
 
 /**
  * GUI tests for [StringSchemeEditor].
  */
-object StringSchemeEditorTest : Spek({
+object StringSchemeEditorTest : DescribeSpec({
     lateinit var ideaFixture: IdeaTestFixture
     lateinit var frame: FrameFixture
 
@@ -24,11 +23,11 @@ object StringSchemeEditorTest : Spek({
     lateinit var editor: StringSchemeEditor
 
 
-    beforeGroup {
+    beforeContainer {
         FailOnThreadViolationRepaintManager.install()
     }
 
-    beforeEachTest {
+    beforeEach {
         ideaFixture = IdeaTestFixtureFactory.getFixtureFactory().createBareFixture()
         ideaFixture.setUp()
 
@@ -37,7 +36,7 @@ object StringSchemeEditorTest : Spek({
         frame = showInFrame(editor.rootComponent)
     }
 
-    afterEachTest {
+    afterEach {
         frame.cleanUp()
         ideaFixture.tearDown()
     }

--- a/src/test/kotlin/com/fwdekker/randomness/string/StringSchemeTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/string/StringSchemeTest.kt
@@ -3,20 +3,19 @@ package com.fwdekker.randomness.string
 import com.fwdekker.randomness.Bundle
 import com.fwdekker.randomness.CapitalizationMode
 import com.fwdekker.randomness.DataGenerationException
+import io.kotest.core.spec.style.DescribeSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
 
 
 /**
  * Unit tests for [StringScheme].
  */
-object StringSchemeTest : Spek({
+object StringSchemeTest : DescribeSpec({
     lateinit var stringScheme: StringScheme
 
 
-    beforeEachTest {
+    beforeEach {
         stringScheme = StringScheme()
     }
 

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateActionLoaderTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateActionLoaderTest.kt
@@ -33,7 +33,7 @@ class TemplateActionLoaderTest : Spek({
             val template = Template(name = "Snow")
             TemplateSettings.default.loadState(TemplateList(listOf(template)))
 
-            TemplateActionLoader.registerActions(actionManager)
+            TemplateActionLoader().registerActions(actionManager)
 
             assertThat(actionManager.getAction(template.actionId)).isNotNull()
         }
@@ -44,9 +44,9 @@ class TemplateActionLoaderTest : Spek({
             val template = Template(name = "Kick")
             TemplateSettings.default.loadState(TemplateList(listOf(template)))
 
-            TemplateActionLoader.registerActions(actionManager)
+            TemplateActionLoader().registerActions(actionManager)
             assertThat(actionManager.getAction(template.actionId)).isNotNull()
-            TemplateActionLoader.unregisterActions(actionManager)
+            TemplateActionLoader().unregisterActions(actionManager)
 
             assertThat(actionManager.getAction(template.actionId)).isNull()
         }
@@ -56,7 +56,7 @@ class TemplateActionLoaderTest : Spek({
         it("registers actions of initial templates") {
             val template = Template(name = "Fine")
 
-            TemplateActionLoader.updateActions(emptySet(), setOf(template))
+            TemplateActionLoader().updateActions(emptySet(), setOf(template))
 
             assertThat(actionManager.getAction(template.actionId)).isNotNull()
         }
@@ -65,8 +65,8 @@ class TemplateActionLoaderTest : Spek({
             val template1 = Template(name = "Ease")
             val template2 = Template(name = "Holy")
 
-            TemplateActionLoader.updateActions(emptySet(), setOf(template1))
-            TemplateActionLoader.updateActions(setOf(template1, template2), setOf(template2))
+            TemplateActionLoader().updateActions(emptySet(), setOf(template1))
+            TemplateActionLoader().updateActions(setOf(template1, template2), setOf(template2))
 
             assertThat(actionManager.getAction(template2.actionId)).isNotNull()
         }
@@ -74,8 +74,8 @@ class TemplateActionLoaderTest : Spek({
         it("unregisters actions of now-removed templates") {
             val template = Template(name = "Fall")
 
-            TemplateActionLoader.updateActions(emptySet(), setOf(template))
-            TemplateActionLoader.updateActions(setOf(template), emptySet())
+            TemplateActionLoader().updateActions(emptySet(), setOf(template))
+            TemplateActionLoader().updateActions(setOf(template), emptySet())
 
             assertThat(actionManager.getAction(template.actionId)).isNull()
         }
@@ -83,9 +83,9 @@ class TemplateActionLoaderTest : Spek({
         it("reregisters actions of updated templates") {
             val template = Template(name = "Pain")
 
-            TemplateActionLoader.updateActions(emptySet(), setOf(template))
+            TemplateActionLoader().updateActions(emptySet(), setOf(template))
             val action = actionManager.getAction(template.actionId)
-            TemplateActionLoader.updateActions(setOf(template), setOf(template))
+            TemplateActionLoader().updateActions(setOf(template), setOf(template))
 
             assertThat(actionManager.getAction(template.actionId)).isNotEqualTo(action)
         }

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateActionLoaderTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateActionLoaderTest.kt
@@ -3,27 +3,26 @@ package com.fwdekker.randomness.template
 import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.testFramework.fixtures.IdeaTestFixture
 import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
+import io.kotest.core.spec.style.DescribeSpec
 import org.assertj.core.api.Assertions.assertThat
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
 
 
 /**
  * Unit tests for [TemplateActionLoader].
  */
-class TemplateActionLoaderTest : Spek({
+class TemplateActionLoaderTest : DescribeSpec({
     lateinit var ideaFixture: IdeaTestFixture
     lateinit var actionManager: ActionManager
 
 
-    beforeEachTest {
+    beforeEach {
         ideaFixture = IdeaTestFixtureFactory.getFixtureFactory().createBareFixture()
         ideaFixture.setUp()
 
         actionManager = ActionManager.getInstance()
     }
 
-    afterEachTest {
+    afterEach {
         ideaFixture.tearDown()
     }
 

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateActionTests.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateActionTests.kt
@@ -7,25 +7,24 @@ import com.fwdekker.randomness.RandomnessIcons
 import com.fwdekker.randomness.TypeIcon
 import com.intellij.testFramework.fixtures.IdeaTestFixture
 import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
+import io.kotest.core.spec.style.DescribeSpec
 import org.assertj.core.api.Assertions.assertThat
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
 import java.awt.Color
 
 
 /**
  * Unit tests for [TemplateGroupAction].
  */
-object TemplateGroupActionTest : Spek({
+object TemplateGroupActionTest : DescribeSpec({
     lateinit var ideaFixture: IdeaTestFixture
 
 
-    beforeEachTest {
+    beforeEach {
         ideaFixture = IdeaTestFixtureFactory.getFixtureFactory().createBareFixture()
         ideaFixture.setUp()
     }
 
-    afterEachTest {
+    afterEach {
         ideaFixture.tearDown()
     }
 
@@ -47,7 +46,7 @@ object TemplateGroupActionTest : Spek({
 /**
  * Unit tests for [TemplateInsertAction].
  */
-object TemplateInsertActionTest : Spek({
+object TemplateInsertActionTest : DescribeSpec({
     describe("init") {
         describe("text and description") {
             it("returns the template's default variant") {
@@ -125,16 +124,16 @@ object TemplateInsertActionTest : Spek({
 /**
  * Unit tests for [TemplateSettingsAction].
  */
-object TemplateSettingsActionTest : Spek({
+object TemplateSettingsActionTest : DescribeSpec({
     lateinit var ideaFixture: IdeaTestFixture
 
 
-    beforeEachTest {
+    beforeEach {
         ideaFixture = IdeaTestFixtureFactory.getFixtureFactory().createBareFixture()
         ideaFixture.setUp()
     }
 
-    afterEachTest {
+    afterEach {
         ideaFixture.tearDown()
     }
 

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateEditorTest.kt
@@ -2,36 +2,35 @@ package com.fwdekker.randomness.template
 
 import com.fwdekker.randomness.array.ArrayDecorator
 import com.fwdekker.randomness.integer.IntegerScheme
+import io.kotest.core.spec.style.DescribeSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.swing.edt.FailOnThreadViolationRepaintManager
 import org.assertj.swing.edt.GuiActionRunner
 import org.assertj.swing.fixture.Containers
 import org.assertj.swing.fixture.FrameFixture
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
 
 
 /**
  * GUI tests for [TemplateEditor].
  */
-object TemplateEditorTest : Spek({
+object TemplateEditorTest : DescribeSpec({
     lateinit var frame: FrameFixture
 
     lateinit var template: Template
     lateinit var editor: TemplateEditor
 
 
-    beforeGroup {
+    beforeContainer {
         FailOnThreadViolationRepaintManager.install()
     }
 
-    beforeEachTest {
+    beforeEach {
         template = Template()
         editor = GuiActionRunner.execute<TemplateEditor> { TemplateEditor(template) }
         frame = Containers.showInFrame(editor.rootComponent)
     }
 
-    afterEachTest {
+    afterEach {
         frame.cleanUp()
     }
 

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateJTreeModelTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateJTreeModelTest.kt
@@ -3,10 +3,9 @@ package com.fwdekker.randomness.template
 import com.fwdekker.randomness.DummyScheme
 import com.fwdekker.randomness.Scheme
 import com.fwdekker.randomness.ui.SimpleTreeModelListener
+import io.kotest.core.spec.style.DescribeSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
 import javax.swing.event.TreeModelEvent
 import javax.swing.event.TreeModelListener
 
@@ -14,11 +13,11 @@ import javax.swing.event.TreeModelListener
 /**
  * Unit tests for [TemplateJTreeModel].
  */
-object TemplateJTreeModelTest : Spek({
+object TemplateJTreeModelTest : DescribeSpec({
     lateinit var model: TemplateJTreeModel
 
 
-    beforeEachTest {
+    beforeEach {
         model = TemplateJTreeModel(
             TemplateList(
                 listOf(
@@ -537,7 +536,7 @@ object TemplateJTreeModelTest : Spek({
         var lastEvent: TreeModelEvent? = null
 
 
-        beforeEachTest {
+        beforeEach {
             nodesChangedInvoked = 0
             nodesInsertedInvoked = 0
             nodesRemovedInvoked = 0
@@ -716,7 +715,7 @@ object TemplateJTreeModelTest : Spek({
 /**
  * Unit tests for [StateNode].
  */
-object StateNodeTest : Spek({
+object StateNodeTest : DescribeSpec({
     describe("canHaveChildren") {
         it("returns true if the state is a template list") {
             assertThat(StateNode(TemplateList(emptyList())).canHaveChildren).isTrue()

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateJTreeTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateJTreeTest.kt
@@ -3,8 +3,9 @@ package com.fwdekker.randomness.template
 import com.fwdekker.randomness.DummyScheme
 import com.fwdekker.randomness.SettingsState
 import com.fwdekker.randomness.clickActionButton
-import com.fwdekker.randomness.getAnActionButton
+import com.fwdekker.randomness.getActionButton
 import com.fwdekker.randomness.string.StringScheme
+import com.intellij.openapi.actionSystem.ActionToolbar
 import com.intellij.testFramework.fixtures.IdeaTestFixture
 import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
 import org.assertj.core.api.Assertions.assertThat
@@ -498,15 +499,21 @@ object TemplateJTreeTest : Spek({
         }
 
 
+        fun updateButtons() = (frame.getActionButton("Add").parent as ActionToolbar).updateActionsImmediately()
+
+
         xdescribe("AddButton") {
             // No non-popup behavior to test
         }
 
         describe("RemoveButton") {
             it("is disabled if nothing is selected") {
-                GuiActionRunner.execute { tree.clearSelection() }
+                GuiActionRunner.execute {
+                    tree.clearSelection()
+                    updateButtons()
+                }
 
-                assertThat(frame.getAnActionButton("Remove").isEnabled).isFalse()
+                assertThat(frame.getActionButton("Remove").isEnabled).isFalse()
             }
 
             it("removes the selected scheme") {
@@ -520,9 +527,12 @@ object TemplateJTreeTest : Spek({
 
         describe("CopyButton") {
             it("is disabled if nothing is selected") {
-                GuiActionRunner.execute { tree.clearSelection() }
+                GuiActionRunner.execute {
+                    tree.clearSelection()
+                    updateButtons()
+                }
 
-                assertThat(frame.getAnActionButton("Copy").isEnabled).isFalse()
+                assertThat(frame.getActionButton("Copy").isEnabled).isFalse()
             }
 
             it("copies the selected scheme") {
@@ -568,21 +578,30 @@ object TemplateJTreeTest : Spek({
 
         describe("UpButton") {
             it("is disabled if nothing is selected") {
-                GuiActionRunner.execute { tree.clearSelection() }
+                GuiActionRunner.execute {
+                    tree.clearSelection()
+                    updateButtons()
+                }
 
-                assertThat(frame.getAnActionButton("Up").isEnabled).isFalse()
+                assertThat(frame.getActionButton("Up").isEnabled).isFalse()
             }
 
             it("is disabled if the selected scheme cannot be moved up") {
-                GuiActionRunner.execute { tree.selectedScheme = list().templates[0] }
+                GuiActionRunner.execute {
+                    tree.selectedScheme = list().templates[0]
+                    updateButtons()
+                }
 
-                assertThat(frame.getAnActionButton("Up").isEnabled).isFalse()
+                assertThat(frame.getActionButton("Up").isEnabled).isFalse()
             }
 
             it("is enabled if the selected scheme can be moved up") {
-                GuiActionRunner.execute { tree.selectedScheme = list().templates[1] }
+                GuiActionRunner.execute {
+                    tree.selectedScheme = list().templates[1]
+                    updateButtons()
+                }
 
-                assertThat(frame.getAnActionButton("Up").isEnabled).isTrue()
+                assertThat(frame.getActionButton("Up").isEnabled).isTrue()
             }
 
             it("moves the selected scheme up") {
@@ -596,21 +615,30 @@ object TemplateJTreeTest : Spek({
 
         describe("DownButton") {
             it("is disabled if nothing is selected") {
-                GuiActionRunner.execute { tree.clearSelection() }
+                GuiActionRunner.execute {
+                    tree.clearSelection()
+                    updateButtons()
+                }
 
-                assertThat(frame.getAnActionButton("Down").isEnabled).isFalse()
+                assertThat(frame.getActionButton("Down").isEnabled).isFalse()
             }
 
             it("is disabled if the selected scheme cannot be moved down") {
-                GuiActionRunner.execute { tree.selectedScheme = list().templates[2] }
+                GuiActionRunner.execute {
+                    tree.selectedScheme = list().templates[2]
+                    updateButtons()
+                }
 
-                assertThat(frame.getAnActionButton("Down").isEnabled).isFalse()
+                assertThat(frame.getActionButton("Down").isEnabled).isFalse()
             }
 
             it("is enabled if the selected scheme can be moved down") {
-                GuiActionRunner.execute { tree.selectedScheme = list().templates[1] }
+                GuiActionRunner.execute {
+                    tree.selectedScheme = list().templates[1]
+                    updateButtons()
+                }
 
-                assertThat(frame.getAnActionButton("Down").isEnabled).isTrue()
+                assertThat(frame.getActionButton("Down").isEnabled).isTrue()
             }
 
             it("moves the selected scheme down") {
@@ -624,15 +652,21 @@ object TemplateJTreeTest : Spek({
 
         describe("ResetButton") {
             it("is disabled if nothing is selected") {
-                GuiActionRunner.execute { tree.clearSelection() }
+                GuiActionRunner.execute {
+                    tree.clearSelection()
+                    updateButtons()
+                }
 
-                assertThat(frame.getAnActionButton("Reset").isEnabled).isFalse()
+                assertThat(frame.getActionButton("Reset").isEnabled).isFalse()
             }
 
             it("is disabled if the selection has not been modified") {
-                GuiActionRunner.execute { tree.selectedScheme = list().templates[0] }
+                GuiActionRunner.execute {
+                    tree.selectedScheme = list().templates[0]
+                    updateButtons()
+                }
 
-                assertThat(frame.getAnActionButton("Reset").isEnabled).isFalse()
+                assertThat(frame.getActionButton("Reset").isEnabled).isFalse()
             }
 
             it("removes the scheme if it was newly added") {

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateJTreeTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateJTreeTest.kt
@@ -8,21 +8,20 @@ import com.fwdekker.randomness.string.StringScheme
 import com.intellij.openapi.actionSystem.ActionToolbar
 import com.intellij.testFramework.fixtures.IdeaTestFixture
 import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
+import io.kotest.core.spec.style.DescribeSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.swing.edt.FailOnThreadViolationRepaintManager
 import org.assertj.swing.edt.GuiActionRunner
 import org.assertj.swing.fixture.Containers
 import org.assertj.swing.fixture.FrameFixture
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
 import javax.swing.JPanel
 
 
 /**
  * GUI tests for [TemplateJTree].
  */
-object TemplateJTreeTest : Spek({
+object TemplateJTreeTest : DescribeSpec({
     lateinit var ideaFixture: IdeaTestFixture
 
     lateinit var originalState: SettingsState
@@ -34,11 +33,11 @@ object TemplateJTreeTest : Spek({
     fun list() = tree.myModel.list
 
 
-    beforeGroup {
+    beforeContainer {
         FailOnThreadViolationRepaintManager.install()
     }
 
-    beforeEachTest {
+    beforeEach {
         ideaFixture = IdeaTestFixtureFactory.getFixtureFactory().createBareFixture()
         ideaFixture.setUp()
 
@@ -58,7 +57,7 @@ object TemplateJTreeTest : Spek({
         tree = GuiActionRunner.execute<TemplateJTree> { TemplateJTree(originalState, currentState) }
     }
 
-    afterEachTest {
+    afterEach {
         ideaFixture.tearDown()
     }
 
@@ -490,11 +489,11 @@ object TemplateJTreeTest : Spek({
         lateinit var frame: FrameFixture
 
 
-        beforeEachTest {
+        beforeEach {
             frame = Containers.showInFrame(GuiActionRunner.execute<JPanel> { tree.asDecoratedPanel() })
         }
 
-        afterEachTest {
+        afterEach {
             frame.cleanUp()
         }
 

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateListEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateListEditorTest.kt
@@ -13,6 +13,7 @@ import com.fwdekker.randomness.word.WordScheme
 import com.intellij.testFramework.fixtures.IdeaTestFixture
 import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
 import com.intellij.ui.JBSplitter
+import io.kotest.core.spec.style.DescribeSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.swing.edt.FailOnThreadViolationRepaintManager
@@ -20,14 +21,12 @@ import org.assertj.swing.edt.GuiActionRunner
 import org.assertj.swing.fixture.AbstractComponentFixture
 import org.assertj.swing.fixture.Containers
 import org.assertj.swing.fixture.FrameFixture
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
 
 
 /**
  * GUI tests for [TemplateListEditor].
  */
-object TemplateListEditorTest : Spek({
+object TemplateListEditorTest : DescribeSpec({
     lateinit var ideaFixture: IdeaTestFixture
     lateinit var frame: FrameFixture
 
@@ -35,14 +34,14 @@ object TemplateListEditorTest : Spek({
     lateinit var editor: TemplateListEditor
 
 
-    beforeGroup {
+    beforeContainer {
         FailOnThreadViolationRepaintManager.install()
 
         TemplateListEditor.createSplitter =
             { vertical, proportionKey, defaultProportion -> JBSplitter(vertical, proportionKey, defaultProportion) }
     }
 
-    beforeEachTest {
+    beforeEach {
         ideaFixture = IdeaTestFixtureFactory.getFixtureFactory().createBareFixture()
         ideaFixture.setUp()
 
@@ -60,7 +59,7 @@ object TemplateListEditorTest : Spek({
         frame = Containers.showInFrame(editor.rootComponent)
     }
 
-    afterEachTest {
+    afterEach {
         frame.cleanUp()
         GuiActionRunner.execute { editor.dispose() }
         ideaFixture.tearDown()

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateListEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateListEditorTest.kt
@@ -38,7 +38,7 @@ object TemplateListEditorTest : Spek({
     beforeGroup {
         FailOnThreadViolationRepaintManager.install()
 
-        TemplateListEditor.CREATE_SPLITTER =
+        TemplateListEditor.createSplitter =
             { vertical, proportionKey, defaultProportion -> JBSplitter(vertical, proportionKey, defaultProportion) }
     }
 

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateListTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateListTest.kt
@@ -5,19 +5,18 @@ import com.fwdekker.randomness.DummyScheme
 import com.fwdekker.randomness.SettingsState
 import com.fwdekker.randomness.string.StringScheme
 import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
+import io.kotest.core.spec.style.DescribeSpec
 import org.assertj.core.api.Assertions.assertThat
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
 
 
 /**
  * Unit tests for [TemplateList].
  */
-object TemplateListTest : Spek({
+object TemplateListTest : DescribeSpec({
     lateinit var templateList: TemplateList
 
 
-    beforeEachTest {
+    beforeEach {
         templateList = TemplateList(emptyList())
     }
 

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateReferenceEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateReferenceEditorTest.kt
@@ -4,20 +4,19 @@ import com.fwdekker.randomness.Box
 import com.fwdekker.randomness.CapitalizationMode
 import com.fwdekker.randomness.DummyScheme
 import com.fwdekker.randomness.array.ArrayDecorator
+import io.kotest.core.spec.style.DescribeSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.swing.edt.FailOnThreadViolationRepaintManager
 import org.assertj.swing.edt.GuiActionRunner
 import org.assertj.swing.fixture.Containers
 import org.assertj.swing.fixture.FrameFixture
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
 import javax.swing.DefaultListModel
 
 
 /**
  * GUI tests for [TemplateReferenceEditor].
  */
-object TemplateReferenceEditorTest : Spek({
+object TemplateReferenceEditorTest : DescribeSpec({
     lateinit var frame: FrameFixture
 
     lateinit var templateList: TemplateList
@@ -25,11 +24,11 @@ object TemplateReferenceEditorTest : Spek({
     lateinit var editor: TemplateReferenceEditor
 
 
-    beforeGroup {
+    beforeContainer {
         FailOnThreadViolationRepaintManager.install()
     }
 
-    beforeEachTest {
+    beforeEach {
         templateList = TemplateList(
             listOf(
                 Template("cup", listOf(DummyScheme())),
@@ -46,7 +45,7 @@ object TemplateReferenceEditorTest : Spek({
         frame = Containers.showInFrame(editor.rootComponent)
     }
 
-    afterEachTest {
+    afterEach {
         frame.cleanUp()
     }
 

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateReferenceTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateReferenceTest.kt
@@ -8,22 +8,21 @@ import com.fwdekker.randomness.DummyScheme
 import com.fwdekker.randomness.OverlayIcon
 import com.fwdekker.randomness.SettingsState
 import com.fwdekker.randomness.integer.IntegerScheme
+import io.kotest.core.spec.style.DescribeSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
 
 
 /**
  * Unit tests for [TemplateReference].
  */
-object TemplateReferenceTest : Spek({
+object TemplateReferenceTest : DescribeSpec({
     lateinit var templateList: TemplateList
     lateinit var reference: TemplateReference
     lateinit var companion: Template
 
 
-    beforeEachTest {
+    beforeEach {
         reference = TemplateReference()
         companion = Template("station", listOf(DummyScheme.from("bus")))
 

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateTest.kt
@@ -5,21 +5,20 @@ import com.fwdekker.randomness.DummyScheme
 import com.fwdekker.randomness.SettingsState
 import com.fwdekker.randomness.integer.IntegerScheme
 import com.fwdekker.randomness.string.StringScheme
+import io.kotest.core.spec.style.DescribeSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
 import kotlin.random.Random
 
 
 /**
  * Unit tests for [Template].
  */
-object TemplateTest : Spek({
+object TemplateTest : DescribeSpec({
     lateinit var template: Template
 
 
-    beforeEachTest {
+    beforeEach {
         template = Template()
     }
 

--- a/src/test/kotlin/com/fwdekker/randomness/ui/ButtonGroupHelperTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/ui/ButtonGroupHelperTest.kt
@@ -1,10 +1,9 @@
 package com.fwdekker.randomness.ui
 
+import io.kotest.core.spec.style.DescribeSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.swing.edt.FailOnThreadViolationRepaintManager
 import org.assertj.swing.edt.GuiActionRunner
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
 import javax.swing.ButtonGroup
 import javax.swing.JButton
 import javax.swing.JLabel
@@ -14,15 +13,15 @@ import javax.swing.JRadioButton
 /**
  * Unit tests for the extension functions in `ButtonGroupKt`.
  */
-object ButtonGroupHelperTest : Spek({
+object ButtonGroupHelperTest : DescribeSpec({
     lateinit var group: ButtonGroup
 
 
-    beforeGroup {
+    beforeContainer {
         FailOnThreadViolationRepaintManager.install()
     }
 
-    beforeEachTest {
+    beforeEach {
         group = ButtonGroup()
     }
 

--- a/src/test/kotlin/com/fwdekker/randomness/ui/JDateTimeFieldTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/ui/JDateTimeFieldTest.kt
@@ -1,12 +1,11 @@
 package com.fwdekker.randomness.ui
 
 import com.github.sisyphsu.dateparser.DateParserUtils
+import io.kotest.core.spec.style.DescribeSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.swing.edt.FailOnThreadViolationRepaintManager
 import org.assertj.swing.edt.GuiActionRunner
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
 import java.text.ParseException
 import java.time.LocalDateTime
 
@@ -14,15 +13,15 @@ import java.time.LocalDateTime
 /**
  * GUI tests for [JDateTimeField].
  */
-object JDateTimeFieldTest : Spek({
+object JDateTimeFieldTest : DescribeSpec({
     lateinit var field: JDateTimeField
 
 
-    beforeGroup {
+    beforeContainer {
         FailOnThreadViolationRepaintManager.install()
     }
 
-    beforeEachTest {
+    beforeEach {
         field = GuiActionRunner.execute<JDateTimeField> { JDateTimeField(LocalDateTime.MIN) }
     }
 

--- a/src/test/kotlin/com/fwdekker/randomness/ui/JNumberSpinnerTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/ui/JNumberSpinnerTest.kt
@@ -1,17 +1,16 @@
 package com.fwdekker.randomness.ui
 
+import io.kotest.core.spec.style.DescribeSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.swing.edt.GuiActionRunner
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
 import javax.swing.JSpinner
 
 
 /**
  * Unit tests for a sample implementation of [JNumberSpinner].
  */
-object JNumberSpinnerTest : Spek({
+object JNumberSpinnerTest : DescribeSpec({
     class JFloatSpinner(
         value: Float = 0.0f,
         minValue: Float = -Float.MAX_VALUE,
@@ -66,7 +65,7 @@ object JNumberSpinnerTest : Spek({
 /**
  * Unit tests for [JDoubleSpinner].
  */
-object JDoubleSpinnerTest : Spek({
+object JDoubleSpinnerTest : DescribeSpec({
     describe("input handling") {
         it("should return a double even if a long is set") {
             val spinner = GuiActionRunner.execute<JDoubleSpinner> { JDoubleSpinner() }
@@ -112,7 +111,7 @@ object JDoubleSpinnerTest : Spek({
 /**
  * Unit tests for [JLongSpinner].
  */
-object JLongSpinnerTest : Spek({
+object JLongSpinnerTest : DescribeSpec({
     describe("input handling") {
         it("truncates when storing a double") {
             val spinner = GuiActionRunner.execute<JLongSpinner> { JLongSpinner() }
@@ -158,7 +157,7 @@ object JLongSpinnerTest : Spek({
 /**
  * Unit tests for [JIntSpinner].
  */
-object JIntSpinnerTest : Spek({
+object JIntSpinnerTest : DescribeSpec({
     describe("input handling") {
         it("truncates when storing a double") {
             val spinner = GuiActionRunner.execute<JIntSpinner> { JIntSpinner() }

--- a/src/test/kotlin/com/fwdekker/randomness/ui/JSpinnerRangeTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/ui/JSpinnerRangeTest.kt
@@ -1,19 +1,18 @@
 package com.fwdekker.randomness.ui
 
+import io.kotest.core.spec.style.DescribeSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.swing.edt.FailOnThreadViolationRepaintManager
 import org.assertj.swing.edt.GuiActionRunner
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
 import javax.swing.JSpinner
 
 
 /**
  * Unit tests for the extension functions in `JSpinnerHelperKt`.
  */
-object JSpinnerRangeTest : Spek({
-    beforeGroup {
+object JSpinnerRangeTest : DescribeSpec({
+    beforeContainer {
         FailOnThreadViolationRepaintManager.install()
     }
 

--- a/src/test/kotlin/com/fwdekker/randomness/ui/LengthDocumentFiltersTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/ui/LengthDocumentFiltersTest.kt
@@ -1,10 +1,9 @@
 package com.fwdekker.randomness.ui
 
+import io.kotest.core.spec.style.DescribeSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.swing.edt.GuiActionRunner
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
 import javax.swing.text.DocumentFilter
 import javax.swing.text.PlainDocument
 
@@ -12,13 +11,13 @@ import javax.swing.text.PlainDocument
 /**
  * Unit tests for [MaxLengthDocumentFilter].
  */
-object MaxLengthDocumentFilterTest : Spek({
+object MaxLengthDocumentFilterTest : DescribeSpec({
     lateinit var document: PlainDocument
     lateinit var filter: DocumentFilter
     val getText = { document.getText(0, document.length) }
 
 
-    beforeEachTest {
+    beforeEach {
         document = PlainDocument()
         filter = MaxLengthDocumentFilter(3)
         document.documentFilter = filter
@@ -175,13 +174,13 @@ object MaxLengthDocumentFilterTest : Spek({
 /**
  * Unit tests for [MinMaxLengthDocumentFilter].
  */
-object MinMaxLengthDocumentFilterTest : Spek({
+object MinMaxLengthDocumentFilterTest : DescribeSpec({
     lateinit var document: PlainDocument
     lateinit var filter: DocumentFilter
     val getText = { document.getText(0, document.length) }
 
 
-    beforeEachTest {
+    beforeEach {
         document = PlainDocument()
         filter = MinMaxLengthDocumentFilter(2, 5)
         document.documentFilter = filter

--- a/src/test/kotlin/com/fwdekker/randomness/ui/ListenerHelperTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/ui/ListenerHelperTest.kt
@@ -7,11 +7,10 @@ import com.intellij.openapi.application.runWriteAction
 import com.intellij.openapi.editor.EditorFactory
 import com.intellij.testFramework.fixtures.IdeaTestFixture
 import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
+import io.kotest.core.spec.style.DescribeSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.swing.edt.GuiActionRunner
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
 import javax.swing.ButtonGroup
 import javax.swing.JCheckBox
 import javax.swing.JRadioButton
@@ -23,14 +22,14 @@ import javax.swing.JTextField
 /**
  * Unit tests for the extension functions in `ListenerHelperKt`.
  */
-object ListenerHelperTest : Spek({
+object ListenerHelperTest : DescribeSpec({
     lateinit var ideaFixture: IdeaTestFixture
 
     var listenerInvoked = false
     lateinit var listener: () -> Unit
 
 
-    beforeEachTest {
+    beforeEach {
         ideaFixture = IdeaTestFixtureFactory.getFixtureFactory().createBareFixture()
         ideaFixture.setUp()
 
@@ -38,7 +37,7 @@ object ListenerHelperTest : Spek({
         listener = { listenerInvoked = true }
     }
 
-    afterEachTest {
+    afterEach {
         ideaFixture.tearDown()
     }
 

--- a/src/test/kotlin/com/fwdekker/randomness/ui/PreviewPanelTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/ui/PreviewPanelTest.kt
@@ -6,19 +6,18 @@ import com.fwdekker.randomness.matcher
 import com.intellij.testFramework.fixtures.IdeaTestFixture
 import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
 import com.intellij.ui.InplaceButton
+import io.kotest.core.spec.style.DescribeSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.swing.edt.FailOnThreadViolationRepaintManager
 import org.assertj.swing.edt.GuiActionRunner
 import org.assertj.swing.fixture.Containers
 import org.assertj.swing.fixture.FrameFixture
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
 
 
 /**
  * GUI tests for [PreviewPanel].
  */
-object PreviewPanelTest : Spek({
+object PreviewPanelTest : DescribeSpec({
     lateinit var ideaFixture: IdeaTestFixture
     lateinit var panel: PreviewPanel
     lateinit var frame: FrameFixture
@@ -27,11 +26,11 @@ object PreviewPanelTest : Spek({
     val placeholder = Bundle("preview.placeholder")
 
 
-    beforeGroup {
+    beforeContainer {
         FailOnThreadViolationRepaintManager.install()
     }
 
-    beforeEachTest {
+    beforeEach {
         ideaFixture = IdeaTestFixtureFactory.getFixtureFactory().createBareFixture()
         ideaFixture.setUp()
 
@@ -41,7 +40,7 @@ object PreviewPanelTest : Spek({
         assertThat(panel.previewText).isEqualTo(placeholder)
     }
 
-    afterEachTest {
+    afterEach {
         frame.cleanUp()
         GuiActionRunner.execute { panel.dispose() }
         ideaFixture.tearDown()

--- a/src/test/kotlin/com/fwdekker/randomness/ui/VariableLabelRadioButtonTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/ui/VariableLabelRadioButtonTest.kt
@@ -1,33 +1,32 @@
 package com.fwdekker.randomness.ui
 
+import io.kotest.core.spec.style.DescribeSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.swing.edt.FailOnThreadViolationRepaintManager
 import org.assertj.swing.edt.GuiActionRunner
 import org.assertj.swing.fixture.Containers
 import org.assertj.swing.fixture.FrameFixture
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
 import javax.swing.ButtonGroup
 
 
 /**
  * GUI tests for [VariableLabelRadioButton].
  */
-object VariableLabelRadioButtonTest : Spek({
+object VariableLabelRadioButtonTest : DescribeSpec({
     lateinit var variableButton: VariableLabelRadioButton
     lateinit var frame: FrameFixture
 
 
-    beforeGroup {
+    beforeContainer {
         FailOnThreadViolationRepaintManager.install()
     }
 
-    beforeEachTest {
+    beforeEach {
         variableButton = GuiActionRunner.execute<VariableLabelRadioButton> { VariableLabelRadioButton() }
         frame = Containers.showInFrame(variableButton)
     }
 
-    afterEachTest {
+    afterEach {
         frame.cleanUp()
     }
 
@@ -72,9 +71,9 @@ object VariableLabelRadioButtonTest : Spek({
         it("focuses the text box when the radio button is selected") {
             assertThat(frame.textBox().target().hasFocus()).isFalse()
 
-            GuiActionRunner.execute { frame.radioButton().target().isSelected = true }
+            frame.radioButton().click()
 
-            assertThat(frame.textBox().target().hasFocus()).isTrue()
+            frame.textBox().requireFocused()
         }
 
         it("selects the radio button when the text box is focused") {

--- a/src/test/kotlin/com/fwdekker/randomness/uuid/UuidSchemeEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/uuid/UuidSchemeEditorTest.kt
@@ -4,19 +4,18 @@ import com.fwdekker.randomness.CapitalizationMode
 import com.fwdekker.randomness.array.ArrayDecorator
 import com.intellij.testFramework.fixtures.IdeaTestFixture
 import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
+import io.kotest.core.spec.style.DescribeSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.swing.edt.FailOnThreadViolationRepaintManager
 import org.assertj.swing.edt.GuiActionRunner
 import org.assertj.swing.fixture.Containers.showInFrame
 import org.assertj.swing.fixture.FrameFixture
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
 
 
 /**
  * GUI tests for [UuidSchemeEditor].
  */
-object UuidSchemeEditorTest : Spek({
+object UuidSchemeEditorTest : DescribeSpec({
     lateinit var ideaFixture: IdeaTestFixture
     lateinit var frame: FrameFixture
 
@@ -24,11 +23,11 @@ object UuidSchemeEditorTest : Spek({
     lateinit var editor: UuidSchemeEditor
 
 
-    beforeGroup {
+    beforeContainer {
         FailOnThreadViolationRepaintManager.install()
     }
 
-    beforeEachTest {
+    beforeEach {
         ideaFixture = IdeaTestFixtureFactory.getFixtureFactory().createBareFixture()
         ideaFixture.setUp()
 
@@ -37,7 +36,7 @@ object UuidSchemeEditorTest : Spek({
         frame = showInFrame(editor.rootComponent)
     }
 
-    afterEachTest {
+    afterEach {
         frame.cleanUp()
         ideaFixture.tearDown()
     }

--- a/src/test/kotlin/com/fwdekker/randomness/uuid/UuidSchemeTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/uuid/UuidSchemeTest.kt
@@ -2,21 +2,20 @@ package com.fwdekker.randomness.uuid
 
 import com.fwdekker.randomness.CapitalizationMode
 import com.fwdekker.randomness.DataGenerationException
+import io.kotest.core.spec.style.DescribeSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
 import kotlin.random.Random
 
 
 /**
  * Unit tests for [UuidScheme].
  */
-object UuidSchemeTest : Spek({
+object UuidSchemeTest : DescribeSpec({
     lateinit var uuidScheme: UuidScheme
 
 
-    beforeEachTest {
+    beforeEach {
         uuidScheme = UuidScheme()
     }
 

--- a/src/test/kotlin/com/fwdekker/randomness/word/DefaultWordListTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/word/DefaultWordListTest.kt
@@ -1,10 +1,9 @@
 package com.fwdekker.randomness.word
 
 import com.fwdekker.randomness.Bundle
+import io.kotest.core.spec.style.DescribeSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
 import java.io.IOException
 import kotlin.system.measureNanoTime
 
@@ -12,7 +11,7 @@ import kotlin.system.measureNanoTime
 /**
  * Unit tests for [DefaultWordList].
  */
-object DefaultWordListTest : Spek({
+object DefaultWordListTest : DescribeSpec({
     describe("words") {
         it("throws an exception if the file does not exist") {
             val list = DefaultWordList("throw", "word-lists/does-not-exist.txt")

--- a/src/test/kotlin/com/fwdekker/randomness/word/WordSchemeEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/word/WordSchemeEditorTest.kt
@@ -7,19 +7,18 @@ import com.intellij.openapi.application.runWriteAction
 import com.intellij.openapi.editor.impl.EditorComponentImpl
 import com.intellij.testFramework.fixtures.IdeaTestFixture
 import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
+import io.kotest.core.spec.style.DescribeSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.swing.edt.FailOnThreadViolationRepaintManager
 import org.assertj.swing.edt.GuiActionRunner
 import org.assertj.swing.fixture.Containers.showInFrame
 import org.assertj.swing.fixture.FrameFixture
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
 
 
 /**
  * GUI tests for [WordSchemeEditor].
  */
-object WordSchemeEditorTest : Spek({
+object WordSchemeEditorTest : DescribeSpec({
     lateinit var ideaFixture: IdeaTestFixture
     lateinit var frame: FrameFixture
 
@@ -28,11 +27,11 @@ object WordSchemeEditorTest : Spek({
     lateinit var wordsEditor: EditorComponentImpl
 
 
-    beforeGroup {
+    beforeContainer {
         FailOnThreadViolationRepaintManager.install()
     }
 
-    beforeEachTest {
+    beforeEach {
         ideaFixture = IdeaTestFixtureFactory.getFixtureFactory().createBareFixture()
         ideaFixture.setUp()
 
@@ -43,7 +42,7 @@ object WordSchemeEditorTest : Spek({
         wordsEditor = frame.robot().finder().find(matcher(EditorComponentImpl::class.java) { it.isValid })
     }
 
-    afterEachTest {
+    afterEach {
         frame.cleanUp()
         GuiActionRunner.execute { editor.dispose() }
         ideaFixture.tearDown()
@@ -161,7 +160,7 @@ object WordSchemeEditorTest : Spek({
         lateinit var firstListAsString: String
 
 
-        beforeEachTest {
+        beforeEach {
             firstList = frame.comboBox("wordListBox").target().getItemAt(1) as DefaultWordList
             firstListAsString = firstList.words.joinToString(separator = "\n", postfix = "\n")
         }

--- a/src/test/kotlin/com/fwdekker/randomness/word/WordSchemeTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/word/WordSchemeTest.kt
@@ -3,20 +3,19 @@ package com.fwdekker.randomness.word
 import com.fwdekker.randomness.Bundle
 import com.fwdekker.randomness.CapitalizationMode
 import com.fwdekker.randomness.DummyScheme
+import io.kotest.core.spec.style.DescribeSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
 
 
 /**
  * Unit tests for [WordScheme].
  */
-object WordSchemeTest : Spek({
+object WordSchemeTest : DescribeSpec({
     lateinit var wordScheme: WordScheme
 
 
-    beforeEachTest {
+    beforeEach {
         wordScheme = WordScheme()
     }
 


### PR DESCRIPTION
A slew of minor and mostly inconsequential updates for the beta version. Ensures the beta version is ready for the coming months :-)

---

* Updates dependencies, plugins, and Gradle
* Fixes style issues detected by latest version of Detekt
* Replaces usage of the Spek library with Kotest
* Removes incompatible IDEA API usages

---

* Improves documentation of warning suppressions
* Documents how to choose compatibility with Java and Kotlin versions in `gradle.properties`
* Updates acknowledgements in `README.md`
* Updates the `.gitignore`
* Finally completely removes `verifier.gradle`

---

* Fixes #448
* Fixes #459 for the beta version as well
* Fixes a bug where modifiers were not detected during insertion
* Fixes a bug where the order of radio buttons in the array settings was incorrect