### PR TITLE
Add framework for settings backwards compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Check the plugin description for more details and animated usage examples.
 * In addition to a list of standard separators, you can now also choose your own separator for all data types, including
   for arrays.
 * You can automatically pad (or truncate) integers to a specific length.
+* Future backwards compatibility, ensuring that your settings can always be imported into future versions.
 
 ### Changed
 * Randomness now uses templates to generate data.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,6 @@
 group=com.fwdekker
 # TODO: Also remove `beta` from `PersistentSettings' annotation`!
+# Version number should also be updated in `com.fwdekker.randomness.PersistentSettings.Companion.CURRENT_VERSION`.
 version=3.0.0-beta.3
 
 # Compatibility

--- a/src/main/kotlin/com/fwdekker/randomness/XmlHelpers.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/XmlHelpers.kt
@@ -1,0 +1,49 @@
+package com.fwdekker.randomness
+
+import org.jdom.Element
+
+
+/**
+ * Returns a list of all [Element]s contained in this `Element`.
+ */
+fun Element.getElements(): List<Element> =
+    content().toList().filterIsInstance<Element>()
+
+/**
+ * Returns the [Element] contained in this `Element` that has attribute `name="[name]"`, or `null` if no single such
+ * `Element` exists.
+ */
+fun Element.getContentByName(name: String): Element? =
+    getContent<Element> { (it as Element).getAttribute("name")?.value == name }.singleOrNull()
+
+/**
+ * Returns the value of the `value` attribute of the single [Element] contained in this `Element` that has attribute
+ * `name="[name]"`, or `null` if no single such `Element` exists.
+ */
+fun Element.getAttributeValueByName(name: String): String? =
+    getContentByName(name)?.getAttribute("value")?.value
+
+/**
+ * Sets the value of the `value` attribute of the single [Element] contained in this `Element` that has attribute
+ * `name="[name]"` to [value], or does nothing if no single such `Element` exists.
+ */
+fun Element.setAttributeValueByName(name: String, value: String) {
+    getContentByName(name)?.setAttribute("value", value)
+}
+
+/**
+ * Returns the single [Element] that is contained in this `Element`, or `null` if this `Element` does not contain
+ * exactly one `Element`.
+ */
+fun Element.getSingleContent(): Element? =
+    content.singleOrNull() as? Element
+
+/**
+ * Traverses a path of [Element]s based on their [names] by monadically calling either [getContentByName] (if the name
+ * is not `null`) or [getSingleContent] (if the name is `null`).
+ */
+fun Element.getContentByPath(vararg names: String?): Element? =
+    names.fold(this as? Element) { acc, name ->
+        if (name == null) acc?.getSingleContent()
+        else acc?.getContentByName(name)
+    }

--- a/src/test/kotlin/com/fwdekker/randomness/SettingsTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/SettingsTest.kt
@@ -22,7 +22,12 @@ object SettingsTest : FunSpec({
                 "succeeds for default state" to
                     row(Settings(), null),
                 "fails if template list is invalid" to
-                    row(Settings(TemplateList(mutableListOf(Template("Duplicate"), Template("Duplicate")))), ""),
+                    row(
+                        Settings(
+                            templateList = TemplateList(mutableListOf(Template("Duplicate"), Template("Duplicate"))),
+                        ),
+                        "",
+                    ),
             )
         ) { (scheme, validation) ->
             scheme shouldValidateAsBundle validation
@@ -31,7 +36,7 @@ object SettingsTest : FunSpec({
 
     context("deepCopy") {
         test("deep-copies the template list") {
-            val settings = Settings(TemplateList(mutableListOf(Template("old"))))
+            val settings = Settings(templateList = TemplateList(mutableListOf(Template("old"))))
 
             val copy = settings.deepCopy()
             copy.templates[0].name = "new"
@@ -49,8 +54,8 @@ object SettingsTest : FunSpec({
         }
 
         test("deep-copies the template list") {
-            val settings = Settings(TemplateList(mutableListOf(Template("old"))))
-            val other = Settings(TemplateList(mutableListOf(Template("new"))))
+            val settings = Settings(templateList = TemplateList(mutableListOf(Template("old"))))
+            val other = Settings(templateList = TemplateList(mutableListOf(Template("new"))))
 
             settings.copyFrom(other)
 

--- a/src/test/kotlin/com/fwdekker/randomness/XmlHelpersTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/XmlHelpersTest.kt
@@ -1,0 +1,297 @@
+package com.fwdekker.randomness
+
+import com.intellij.openapi.util.JDOMUtil
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+
+
+/**
+ * Unit tests for extension functions in `XmlHelpersTest`.
+ */
+object XmlHelpersTest : FunSpec({
+    context("getElements") {
+        test("returns all contained elements") {
+            val element = JDOMUtil.load(
+                """
+                <tag>
+                    <content1 />
+                    <content2></content2>
+                    <content3 attribute="value" />
+                    <content4 attribute="value"><tag /></content4>
+                </tag>
+                """.trimIndent()
+            )
+
+            val elements = element.getElements()
+
+            elements.map { it.name } shouldContainExactly listOf("content1", "content2", "content3", "content4")
+        }
+    }
+
+    context("getContentByName") {
+        test("returns the child with the given name") {
+            val element = JDOMUtil.load(
+                """
+                <tag>
+                    <content1 name="wrong" />
+                    <content2 name="needle" />
+                    <content3 attribute="value" />
+                </tag>
+                """.trimIndent()
+            )
+
+            element.getContentByName("needle")?.name shouldBe "content2"
+        }
+
+        test("returns `null` if no children have the given name") {
+            val element = JDOMUtil.load(
+                """
+                <tag>
+                    <content1 name="wrong" />
+                    <content2 name="noodle" />
+                    <content3 attribute="value" />
+                </tag>
+                """.trimIndent()
+            )
+
+            element.getContentByName("needle")?.name shouldBe null
+        }
+
+        test("returns `null` if multiple children have the given name") {
+            val element = JDOMUtil.load(
+                """
+                <tag>
+                    <content1 name="wrong" />
+                    <content2 name="needle" />
+                    <content3 name="needle" />
+                    <content4 attribute="value" />
+                </tag>
+                """.trimIndent()
+            )
+
+            element.getContentByName("needle")?.name shouldBe null
+        }
+    }
+
+    context("getAttributeValueByName") {
+        test("returns value attribute of the child with the given name") {
+            val element = JDOMUtil.load(
+                """
+                <tag>
+                    <content name="wrong" value="undesired" />
+                    <content name="needle" value="value" />
+                    <content attribute="value" />
+                </tag>
+                """.trimIndent()
+            )
+
+            element.getAttributeValueByName("needle") shouldBe "value"
+        }
+
+        test("returns `null` if no children have the given name") {
+            val element = JDOMUtil.load(
+                """
+                <tag>
+                    <content1 name="wrong" value="undesired" />
+                    <content2 name="noodle" value="valet" />
+                    <content3 attribute="value" />
+                </tag>
+                """.trimIndent()
+            )
+
+            element.getAttributeValueByName("needle") shouldBe null
+        }
+
+        test("returns `null` if multiple children have the given name") {
+            val element = JDOMUtil.load(
+                """
+                <tag>
+                    <content1 name="wrong" value="undesired" />
+                    <content2 name="needle" value="valet" />
+                    <content3 name="needle" value="voodoo" />
+                    <content4 attribute="value" />
+                </tag>
+                """.trimIndent()
+            )
+
+            element.getAttributeValueByName("needle") shouldBe null
+        }
+
+        test("returns `null` if the child does not have a value attribute") {
+            val element = JDOMUtil.load(
+                """
+                <tag>
+                    <content name="wrong" value="undesired" />
+                    <content name="needle" />
+                    <content attribute="value" />
+                </tag>
+                """.trimIndent()
+            )
+
+            element.getAttributeValueByName("needle") shouldBe null
+        }
+    }
+
+    context("setAttributeValueByName") {
+        test("changes the child's value to the given value") {
+            val element = JDOMUtil.load(
+                """
+                <tag>
+                    <content name="wrong" value="undesired" />
+                    <content name="needle" value="value" />
+                    <content attribute="value" />
+                </tag>
+                """.trimIndent()
+            )
+            element.getAttributeValueByName("needle") shouldBe "value"
+
+            element.setAttributeValueByName("needle", "new-value")
+
+            element.getAttributeValueByName("needle") shouldBe "new-value"
+        }
+
+        test("adds an attribute if the child does not have a value attribute") {
+            val element = JDOMUtil.load(
+                """
+                <tag>
+                    <content name="wrong" value="undesired" />
+                    <content name="needle" />
+                    <content attribute="value" />
+                </tag>
+                """.trimIndent()
+            )
+            element.getAttributeValueByName("needle") shouldBe null
+
+            element.setAttributeValueByName("needle", "new-value")
+
+            element.getAttributeValueByName("needle") shouldBe "new-value"
+        }
+
+        test("does nothing if no children have the given name") {
+            val element = JDOMUtil.load(
+                """
+                <tag>
+                    <content1 name="wrong" value="undesired" />
+                    <content2 name="noodle" value="valet" />
+                    <content3 attribute="value" />
+                </tag>
+                """.trimIndent()
+            )
+
+            val copy = JDOMUtil.load(JDOMUtil.write(element, ""))
+            element.setAttributeValueByName("needle", "new-value")
+
+            JDOMUtil.write(element, "") shouldBe JDOMUtil.write(copy, "")
+        }
+
+        test("does nothing if multiple children have the given name") {
+            val element = JDOMUtil.load(
+                """
+                <tag>
+                    <content1 name="wrong" value="undesired" />
+                    <content2 name="needle" value="valet" />
+                    <content3 name="needle" value="voodoo" />
+                    <content4 attribute="value" />
+                </tag>
+                """.trimIndent()
+            )
+
+            val copy = JDOMUtil.load(JDOMUtil.write(element, ""))
+            element.setAttributeValueByName("needle", "new-value")
+
+            JDOMUtil.write(element, "") shouldBe JDOMUtil.write(copy, "")
+        }
+    }
+
+    context("getSingleContent") {
+        test("returns the singular child") {
+            val element = JDOMUtil.load("<tag><child /></tag>")
+
+            element.getSingleContent()?.name shouldBe "child"
+        }
+
+        test("returns `null` if there are no children") {
+            val element = JDOMUtil.load("<tag></tag>")
+
+            element.getSingleContent() shouldBe null
+        }
+
+        test("returns `null` if there are multiple children") {
+            val element = JDOMUtil.load(
+                """
+                <tag>
+                    <content1 />
+                    <content2 />
+                </tag>
+                """.trimIndent()
+            )
+
+            element.getSingleContent() shouldBe null
+        }
+    }
+
+    context("getContentByPath") {
+        test("returns the child with the given name") {
+            val element = JDOMUtil.load(
+                """
+                <tag>
+                    <content1 name="wrong" />
+                    <content2 name="needle" />
+                    <content3 attribute="value" />
+                </tag>
+                """.trimIndent()
+            )
+
+            element.getContentByPath("needle")?.name shouldBe "content2"
+        }
+
+        test("returns the singular child if `null` is given") {
+            val element = JDOMUtil.load("<tag><child /></tag>")
+
+            element.getContentByPath(null)?.name shouldBe "child"
+        }
+
+        test("returns the element at the given path") {
+            val element = JDOMUtil.load(
+                """
+                <tag>
+                    <content1 name="wrong" />
+                    <content2 name="needle">
+                        <wrapper>
+                            <contentA name="prong">
+                                <target />
+                            </contentA>
+                            <contentB name="undesired" />
+                        </wrapper>
+                    </content2>
+                    <content3 attribute="value" />
+                </tag>
+                """.trimIndent()
+            )
+
+            element.getContentByPath("needle", null, "prong", null)?.name shouldBe "target"
+        }
+
+        test("returns `null` if no element matches the path") {
+            val element = JDOMUtil.load(
+                """
+                <tag>
+                    <content1 name="wrong" />
+                    <content2 name="needle">
+                        <wrapper>
+                            <contentA name="prong">
+                                <target />
+                            </contentA>
+                            <contentB name="undesired" />
+                        </wrapper>
+                    </content2>
+                    <content3 attribute="value" />
+                </tag>
+                """.trimIndent()
+            )
+
+            element.getContentByPath("wrong", null, "prong", null)?.name shouldBe null
+        }
+    }
+})

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateJTreeTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateJTreeTest.kt
@@ -58,13 +58,13 @@ object TemplateJTreeTest : FunSpec({
 
         originalSettings =
             Settings(
-                TemplateList(
+                templateList = TemplateList(
                     mutableListOf(
                         Template("Template0", mutableListOf(DummyScheme("Scheme0"), DummyScheme("Scheme1"))),
                         Template("Template1", mutableListOf(DummyScheme("Scheme2"))),
-                        Template("Template2", mutableListOf(DummyScheme("Scheme3"), DummyScheme("Scheme4")))
+                        Template("Template2", mutableListOf(DummyScheme("Scheme3"), DummyScheme("Scheme4"))),
                     )
-                )
+                ),
             )
         originalSettings.applyContext(originalSettings)
         currentSettings = originalSettings.deepCopy(retainUuid = true)

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateListEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateListEditorTest.kt
@@ -57,12 +57,12 @@ object TemplateListEditorTest : FunSpec({
         ideaFixture.setUp()
 
         context = Settings(
-            TemplateList(
+            templateList = TemplateList(
                 mutableListOf(
                     Template("Template1", mutableListOf(IntegerScheme(), StringScheme())),
-                    Template("Template2", mutableListOf(DecimalScheme(), WordScheme()))
+                    Template("Template2", mutableListOf(DecimalScheme(), WordScheme())),
                 )
-            )
+            ),
         )
         context.templateList.applyContext(context)
 

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateReferenceEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateReferenceEditorTest.kt
@@ -48,13 +48,13 @@ object TemplateReferenceEditorTest : FunSpec({
         ideaFixture.setUp()
 
         context = Settings(
-            TemplateList(
+            templateList = TemplateList(
                 mutableListOf(
                     Template("Template0", mutableListOf(DummyScheme())),
                     Template("Template1", mutableListOf(TemplateReference())),
                     Template("Template2", mutableListOf(DummyScheme())),
                 )
-            )
+            ),
         )
 
         reference = context.templates[1].schemes[0] as TemplateReference

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateReferenceTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateReferenceTest.kt
@@ -40,7 +40,7 @@ object TemplateReferenceTest : FunSpec({
         referencingTemplate = Template("referencing", mutableListOf(reference))
 
         list = TemplateList(mutableListOf(referencedTemplate, referencingTemplate))
-        list.applyContext(Settings(list))
+        list.applyContext(Settings(templateList = list))
     }
 
 
@@ -178,7 +178,7 @@ object TemplateReferenceTest : FunSpec({
         test("changes the list of templates into which this reference refers") {
             reference.template shouldNot beNull()
 
-            reference.applyContext(Settings(TemplateList(mutableListOf())))
+            reference.applyContext(Settings(templateList = TemplateList(mutableListOf())))
 
             reference.template should beNull()
         }
@@ -198,7 +198,7 @@ object TemplateReferenceTest : FunSpec({
             list.templates += safeTemplate
             referencedTemplate.schemes += TemplateReference(referencingTemplate.uuid)
 
-            list.applyContext(Settings(list))
+            list.applyContext(Settings(templateList = list))
 
             reference.canReference(safeTemplate) shouldBe true
         }
@@ -210,7 +210,7 @@ object TemplateReferenceTest : FunSpec({
         test("returns false if the reference would create a cycle") {
             referencedTemplate.schemes += TemplateReference(referencingTemplate.uuid)
 
-            list.applyContext(Settings(list))
+            list.applyContext(Settings(templateList = list))
 
             reference.canReference(referencedTemplate) shouldBe false
         }
@@ -220,7 +220,7 @@ object TemplateReferenceTest : FunSpec({
             list.templates += otherReferencedTemplate
             referencedTemplate.schemes += TemplateReference(otherReferencedTemplate.uuid)
 
-            list.applyContext(Settings(list))
+            list.applyContext(Settings(templateList = list))
 
             reference.canReference(referencedTemplate) shouldBe false
         }
@@ -232,7 +232,7 @@ object TemplateReferenceTest : FunSpec({
             list.templates += cycleTemplate2
             cycleTemplate1.schemes += TemplateReference(cycleTemplate2.uuid)
 
-            list.applyContext(Settings(list))
+            list.applyContext(Settings(templateList = list))
 
             reference.canReference(referencedTemplate) shouldBe true
         }


### PR DESCRIPTION
Fixes #464.

Stores the plugin's version in the user's settings to allow version detection in the future. Furthermore, though `Settings` remains the usual object with a `templateList` (and perhaps other fields in the future (cf. #469?)), the class `PersistentSettings` now acts as if settings are saved as an `Element` (i.e. as XML). When settings are loaded, `PersistentSettings` has the opportunity to modify the XML before deserialising it into a `Settings`. Therefore, if there are incompatibilities between versions that the default XML deserialiser cannot handle, a small bit of code can be added to make these modifications automatically.