### PR TITLE
Docs and tests and stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,14 +100,17 @@ See [Plugin Signing](https://plugins.jetbrains.com/docs/intellij/plugin-signing.
 ```bash
 $ gradlew test                    # Run tests (and collect coverage)
 $ gradlew test --tests X          # Run tests in class X (package name optional)
-$ gradlew test -Pkotest.tags="X"  # Run tests with `NamedTag` X (also supports not (!), and (&), or (|))
+$ gradlew test -Pkotest.tags="X"  # Run tests matching tag(s) X (also supports not (!), and (&), or (|))
 $ gradlew koverHtmlReport         # Create HTML coverage report for previous test run
 $ gradlew check                   # Run tests and static analysis
 $ gradlew runPluginVerifier       # Check for compatibility issues
 ```
 
-#### 🏷️ Filtering tests
+#### 🏷️ Tagging and filtering tests
 [Kotest tests can be tagged](https://kotest.io/docs/framework/tags.html) to allow selectively running tests.
+The tags for Randomness are statically defined in
+[`Tags`](https://github.com/FWDekker/intellij-randomness/blob/main/src/test/kotlin/com/fwdekker/randomness/testhelpers/Tags.kt).
+
 Tag an entire test class by adding `tags(...)` to the class definition, or tag an individual test `context` by
 writing `context("foo").config(tags = setOf(...)) {`.
 It is not possible to tag an individual `test` due to limitations in Kotest.

--- a/src/main/kotlin/com/fwdekker/randomness/Icons.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/Icons.kt
@@ -86,17 +86,6 @@ data class TypeIcon(val base: Icon, val text: String, val colors: List<Color>) :
 
 
     /**
-     * Returns an icon that describes both this icon's type and [other]'s type.
-     */
-    fun combineWith(other: TypeIcon) =
-        TypeIcon(
-            Icons.TEMPLATE,
-            if (this.text == other.text) this.text else "",
-            this.colors + other.colors
-        )
-
-
-    /**
      * Paints the colored text icon.
      *
      * @param c a [Component] to get properties useful for painting
@@ -133,6 +122,18 @@ data class TypeIcon(val base: Icon, val text: String, val colors: List<Color>) :
          * The scale of the text inside the icon relative to the icon's size.
          */
         const val FONT_SIZE = 12f / 32f
+
+
+        /**
+         * Returns a single icon that describes all [icons], or `null` if [icons] is empty.
+         */
+        fun combine(icons: Collection<TypeIcon>): TypeIcon? =
+            if (icons.isEmpty()) null
+            else TypeIcon(
+                Icons.TEMPLATE,
+                if (icons.map { it.text }.toSet().size == 1) icons.first().text else "",
+                icons.flatMap { it.colors }
+            )
     }
 }
 

--- a/src/main/kotlin/com/fwdekker/randomness/PopupAction.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/PopupAction.kt
@@ -40,7 +40,7 @@ class PopupAction : AnAction(Icons.RANDOMNESS) {
     override fun update(event: AnActionEvent) {
         event.presentation.icon = Icons.RANDOMNESS
 
-        // Running this in `actionPerformed` always sets it to `true`
+        // Running this in [actionPerformed] always sets it to `true`
         isEditable = event.getData(CommonDataKeys.EDITOR)?.isViewer == false
     }
 
@@ -129,7 +129,7 @@ class PopupAction : AnAction(Icons.RANDOMNESS) {
 
 
 /**
- * An `AbstractAction` that uses [myActionPerformed] as the implementation of its [actionPerformed] method.
+ * An [AbstractAction] that uses [myActionPerformed] as the implementation of its [actionPerformed] method.
  *
  * @property myActionPerformed The code to execute in [actionPerformed].
  */

--- a/src/main/kotlin/com/fwdekker/randomness/XmlHelpers.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/XmlHelpers.kt
@@ -4,36 +4,36 @@ import org.jdom.Element
 
 
 /**
- * Returns a list of all [Element]s contained in this `Element`.
+ * Returns a list of all [Element]s contained in this [Element].
  */
 fun Element.getElements(): List<Element> =
     content().toList().filterIsInstance<Element>()
 
 /**
- * Returns the [Element] contained in this `Element` that has attribute `name="[name]"`, or `null` if no single such
- * `Element` exists.
+ * Returns the [Element] contained in this [Element] that has attribute `name="[name]"`, or `null` if no single such
+ * [Element] exists.
  */
 fun Element.getContentByName(name: String): Element? =
     getContent<Element> { (it as Element).getAttribute("name")?.value == name }.singleOrNull()
 
 /**
- * Returns the value of the `value` attribute of the single [Element] contained in this `Element` that has attribute
- * `name="[name]"`, or `null` if no single such `Element` exists.
+ * Returns the value of the `value` attribute of the single [Element] contained in this [Element] that has attribute
+ * `name="[name]"`, or `null` if no single such [Element] exists.
  */
 fun Element.getAttributeValueByName(name: String): String? =
     getContentByName(name)?.getAttribute("value")?.value
 
 /**
- * Sets the value of the `value` attribute of the single [Element] contained in this `Element` that has attribute
- * `name="[name]"` to [value], or does nothing if no single such `Element` exists.
+ * Sets the value of the `value` attribute of the single [Element] contained in this [Element] that has attribute
+ * `name="[name]"` to [value], or does nothing if no single such [Element] exists.
  */
 fun Element.setAttributeValueByName(name: String, value: String) {
     getContentByName(name)?.setAttribute("value", value)
 }
 
 /**
- * Returns the single [Element] that is contained in this `Element`, or `null` if this `Element` does not contain
- * exactly one `Element`.
+ * Returns the single [Element] that is contained in this [Element], or `null` if this [Element] does not contain
+ * exactly one [Element].
  */
 fun Element.getSingleContent(): Element? =
     content.singleOrNull() as? Element

--- a/src/main/kotlin/com/fwdekker/randomness/datetime/DateTimeSchemeEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/datetime/DateTimeSchemeEditor.kt
@@ -73,7 +73,7 @@ class DateTimeSchemeEditor(scheme: DateTimeScheme = DateTimeScheme()) : SchemeEd
 
 
 /**
- * Binds two `DateTimePicker`s together, analogous to how [com.fwdekker.randomness.ui.bindSpinners] works.
+ * Binds two [JDateTimeField]s together, analogous to how [com.fwdekker.randomness.ui.bindSpinners] works.
  */
 private fun bindDateTimes(minField: JDateTimeField, maxField: JDateTimeField) {
     addChangeListenerTo(minField) {

--- a/src/main/kotlin/com/fwdekker/randomness/template/Template.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/template/Template.kt
@@ -42,7 +42,7 @@ data class Template(
     val arrayDecorator: ArrayDecorator = DEFAULT_ARRAY_DECORATOR,
 ) : Scheme() {
     override val typeIcon
-        get() = schemes.mapNotNull { it.typeIcon }.reduceOrNull { acc, icon -> acc.combineWith(icon) } ?: DEFAULT_ICON
+        get() = TypeIcon.combine(schemes.mapNotNull { it.typeIcon }) ?: DEFAULT_ICON
     override val decorators get() = listOf(arrayDecorator)
 
     /**

--- a/src/main/kotlin/com/fwdekker/randomness/template/TemplateJTree.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/template/TemplateJTree.kt
@@ -257,7 +257,7 @@ class TemplateJTree(
     /**
      * Replaces [oldScheme] with [newScheme] in-place.
      *
-     * If `newScheme` is `null`, then `oldScheme` is removed without being replaced.
+     * If [newScheme] is `null`, then [oldScheme] is removed without being replaced.
      */
     fun replaceScheme(oldScheme: Scheme, newScheme: Scheme?) {
         if (newScheme == null) {
@@ -467,12 +467,12 @@ class TemplateJTree(
             /**
              * Inserts [value] into the tree.
              *
-             * Subclasses may modify the behavior of this method to instead return the `PopupStep` nested under this
+             * Subclasses may modify the behavior of this method to instead return the [PopupStep] nested under this
              * entry.
              *
              * @param value the value to insert
              * @param finalChoice ignored
-             * @return `null`, or the `PopupStep` that is nested under this entry
+             * @return `null`, or the [PopupStep] that is nested under this entry
              */
             override fun onChosen(value: Scheme?, finalChoice: Boolean): PopupStep<*>? {
                 if (value != null)

--- a/src/main/kotlin/com/fwdekker/randomness/template/TemplateJTree.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/template/TemplateJTree.kt
@@ -1,6 +1,7 @@
 package com.fwdekker.randomness.template
 
 import com.fwdekker.randomness.Bundle
+import com.fwdekker.randomness.PopupAction
 import com.fwdekker.randomness.Scheme
 import com.fwdekker.randomness.datetime.DateTimeScheme
 import com.fwdekker.randomness.decimal.DecimalScheme
@@ -386,9 +387,8 @@ class TemplateJTree(
             icon = scheme.icon
 
             if (scheme is Template) {
-                val index = currentTemplateList.templates.indexOf(scheme) + 1
-                if (index <= INDEXED_TEMPLATE_COUNT)
-                    append("${index % INDEXED_TEMPLATE_COUNT} ", SimpleTextAttributes.GRAYED_SMALL_ATTRIBUTES, false)
+                PopupAction.indexToMnemonic(currentTemplateList.templates.indexOf(scheme))
+                    ?.run { append("$this ", SimpleTextAttributes.GRAYED_SMALL_ATTRIBUTES, false) }
             }
 
             append(
@@ -691,10 +691,5 @@ class TemplateJTree(
                 DateTimeScheme(),
                 TemplateReference(),
             )
-
-        /**
-         * Number of [Template]s that should be rendered with the index in front.
-         */
-        const val INDEXED_TEMPLATE_COUNT = 10
     }
 }

--- a/src/main/kotlin/com/fwdekker/randomness/template/TemplateList.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/template/TemplateList.kt
@@ -33,12 +33,13 @@ data class TemplateList(
 
 
     /**
-     * Returns the template in this list with [uuid] as its UUID.
+     * Returns the template in this list that has [uuid] as its UUID, or `null` if there is no such template.
      */
     fun getTemplateByUuid(uuid: String) = templates.singleOrNull { it.uuid == uuid }
 
     /**
-     * Returns the template or scheme in this list with [uuid] as its UUID.
+     * Returns the template or scheme in this list that has [uuid] as its UUID, or `null` if there is no such template
+     * or scheme.
      */
     fun getSchemeByUuid(uuid: String) = templates.flatMap { listOf(it) + it.schemes }.singleOrNull { it.uuid == uuid }
 

--- a/src/main/kotlin/com/fwdekker/randomness/template/TemplateListConfigurable.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/template/TemplateListConfigurable.kt
@@ -24,7 +24,7 @@ class TemplateListConfigurable : Configurable, Disposable {
     /**
      * The user interface for changing the settings, displayed in IntelliJ's settings window.
      */
-    @Suppress("detekt:LateinitUsage") // Initialized in `createComponent`
+    @Suppress("detekt:LateinitUsage") // Initialized in [createComponent]
     lateinit var editor: TemplateListEditor private set
 
     /**

--- a/src/main/kotlin/com/fwdekker/randomness/template/TemplateListEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/template/TemplateListEditor.kt
@@ -81,7 +81,7 @@ class TemplateListEditor(
 
         // Load current state
         reset()
-        templateTree.expandNodes()
+        templateTree.expandAll()
 
         // Select a scheme
         initialSelection

--- a/src/main/kotlin/com/fwdekker/randomness/ui/InterfaceBuilderHelpers.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/ui/InterfaceBuilderHelpers.kt
@@ -128,8 +128,14 @@ fun <E> Cell<ComboBox<E>>.withSimpleRenderer(toString: (E) -> String = { it.toSt
  * A predicate that always returns [output].
  */
 class LiteralPredicate(private val output: Boolean) : ComponentPredicate() {
+    /**
+     * Does nothing, because there's no need to respond to any events to determine the output of [invoke].
+     */
     override fun addListener(listener: (Boolean) -> Unit) = Unit
 
+    /**
+     * Returns [output].
+     */
     override fun invoke() = output
 }
 

--- a/src/main/kotlin/com/fwdekker/randomness/ui/JNumberSpinners.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/ui/JNumberSpinners.kt
@@ -57,8 +57,8 @@ abstract class JNumberSpinner<T>(value: T, minValue: T?, maxValue: T?, stepSize:
 /**
  * A [JNumberSpinner] for doubles.
  *
- * Note that setting `minValue` or `maxValue` to a very large number may cause the parent component's width to be overly
- * large.
+ * Note that setting the minimum or maximum value to a very large number may cause the parent component's width to be
+ * overly large.
  *
  * @param value the default value
  * @param minValue the smallest number that may be represented

--- a/src/main/kotlin/com/fwdekker/randomness/ui/PreviewPanel.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/ui/PreviewPanel.kt
@@ -84,7 +84,7 @@ class PreviewPanel(private val getScheme: () -> Scheme) : Disposable {
     /**
      * Updates the preview with the current settings.
      */
-    @Suppress("SwallowedException") // Alternative is to add coupling to `SettingsComponent`
+    @Suppress("SwallowedException") // Alternative is to add coupling to [SettingsComponent]
     fun updatePreview() {
         try {
             previewText = generateTimely { getScheme().also { it.random = Random(seed) }.generateStrings() }.first()

--- a/src/main/kotlin/com/fwdekker/randomness/word/WordSchemeEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/word/WordSchemeEditor.kt
@@ -147,7 +147,7 @@ fun Document.setWordList(wordList: List<String>) =
 /**
  * Returns a [Disposable] that can dispose the [editor] through the [EditorFactory] that created it.
  */
-@Suppress("ObjectLiteralToLambda") // `Disposable` docs state that lambdas should be avoided
+@Suppress("ObjectLiteralToLambda") // [Disposable] docs state that lambdas should be avoided
 private fun EditorFactory.wrapDisposable(editor: Editor) =
     object : Disposable {
         override fun dispose() = this@wrapDisposable.releaseEditor(editor)

--- a/src/test/kotlin/com/fwdekker/randomness/CapitalizationModeTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/CapitalizationModeTest.kt
@@ -1,7 +1,9 @@
 package com.fwdekker.randomness
 
+import com.fwdekker.randomness.testhelpers.matchBundle
 import io.kotest.assertions.retry
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldBeEqualIgnoringCase
@@ -72,7 +74,7 @@ object CapitalizationModeTest : FunSpec({
 
     context("toLocalizedString") {
         test("returns the associated localized string") {
-            CapitalizationMode.FIRST_LETTER.toLocalizedString() shouldBe Bundle("shared.capitalization.first_letter")
+            CapitalizationMode.FIRST_LETTER.toLocalizedString() should matchBundle("shared.capitalization.first_letter")
         }
     }
 })

--- a/src/test/kotlin/com/fwdekker/randomness/ErrorReporterTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/ErrorReporterTest.kt
@@ -1,10 +1,10 @@
 package com.fwdekker.randomness
 
+import com.fwdekker.randomness.testhelpers.Tags
 import com.fwdekker.randomness.testhelpers.afterNonContainer
 import com.fwdekker.randomness.testhelpers.beforeNonContainer
 import com.intellij.testFramework.fixtures.IdeaTestFixture
 import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
-import io.kotest.core.NamedTag
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldNotContain
@@ -14,7 +14,7 @@ import io.kotest.matchers.string.shouldNotContain
  * Unit tests for [ErrorReporter].
  */
 object ErrorReporterTest : FunSpec({
-    tags(NamedTag("IdeaFixture"))
+    tags(Tags.IDEA_FIXTURE)
 
 
     lateinit var ideaFixture: IdeaTestFixture

--- a/src/test/kotlin/com/fwdekker/randomness/IconsTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/IconsTest.kt
@@ -1,9 +1,9 @@
 package com.fwdekker.randomness
 
+import com.fwdekker.randomness.testhelpers.Tags
 import com.fwdekker.randomness.testhelpers.beforeNonContainer
 import com.fwdekker.randomness.testhelpers.guiGet
 import io.kotest.assertions.throwables.shouldThrow
-import io.kotest.core.NamedTag
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.shouldContainExactly
@@ -65,7 +65,7 @@ object TypeIconTest : FunSpec({
 
 
     context("paintIcon") {
-        tags(NamedTag("Swing"))
+        tags(Tags.SWING)
 
 
         lateinit var image: BufferedImage
@@ -105,7 +105,7 @@ object TypeIconTest : FunSpec({
  */
 object OverlayIconTest : FunSpec({
     context("paintIcon") {
-        tags(NamedTag("Swing"))
+        tags(Tags.SWING)
 
 
         lateinit var image: BufferedImage
@@ -207,7 +207,7 @@ object OverlayedIconTest : FunSpec({
 
 
     context("paintIcon") {
-        tags(NamedTag("Swing"))
+        tags(Tags.SWING)
 
 
         lateinit var image: BufferedImage

--- a/src/test/kotlin/com/fwdekker/randomness/IconsTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/IconsTest.kt
@@ -7,6 +7,7 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.nulls.beNull
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
@@ -29,37 +30,6 @@ object TypeIconTest : FunSpec({
         test("fails if no colors are given") {
             shouldThrow<IllegalArgumentException> { TypeIcon(PlainIcon(), "text", emptyList()) }
                 .message shouldBe "At least one color must be defined."
-        }
-    }
-
-
-    context("combineWith") {
-        test("returns a template TypeIcon") {
-            val icon1 = TypeIcon(PlainIcon(), "text1", listOf(Color.GREEN))
-            val icon2 = TypeIcon(PlainIcon(), "text2", listOf(Color.RED))
-
-            icon1.combineWith(icon2).base shouldBe Icons.TEMPLATE
-        }
-
-        test("retains the text if it is the same for both icons") {
-            val icon1 = TypeIcon(PlainIcon(), "text", listOf(Color.PINK))
-            val icon2 = TypeIcon(PlainIcon(), "text", listOf(Color.CYAN))
-
-            icon1.combineWith(icon2).text shouldBe "text"
-        }
-
-        test("removes the text if it is different for the icons") {
-            val icon1 = TypeIcon(PlainIcon(), "text1", listOf(Color.GRAY))
-            val icon2 = TypeIcon(PlainIcon(), "text2", listOf(Color.ORANGE))
-
-            icon1.combineWith(icon2).text shouldBe ""
-        }
-
-        test("appends the colors of the combined icons") {
-            val icon1 = TypeIcon(PlainIcon(), "text1", listOf(Color.BLUE, Color.WHITE))
-            val icon2 = TypeIcon(PlainIcon(), "text2", listOf(Color.RED, Color.PINK))
-
-            icon1.combineWith(icon2).colors shouldContainExactly listOf(Color.BLUE, Color.WHITE, Color.RED, Color.PINK)
         }
     }
 
@@ -96,6 +66,64 @@ object TypeIconTest : FunSpec({
             }
 
             image.getRGB(0, 0, 32, 32, null, 0, 32).filter { it != 0 } shouldNot beEmpty()
+        }
+    }
+
+
+    context("combine") {
+        test("returns `null` if no icons are given to combine") {
+            TypeIcon.combine(emptyList()) should beNull()
+        }
+
+        test("returns a template icon for a single icon") {
+            val icons = listOf(TypeIcon(PlainIcon(), "text", listOf(Color.LIGHT_GRAY)))
+
+            TypeIcon.combine(icons)!!.base shouldBe Icons.TEMPLATE
+        }
+
+        test("returns a template icon for multiple icons") {
+            val icons =
+                listOf(
+                    TypeIcon(PlainIcon(), "text1", listOf(Color.GREEN)),
+                    TypeIcon(PlainIcon(), "text2", listOf(Color.RED)),
+                    TypeIcon(PlainIcon(), "text3", listOf(Color.MAGENTA)),
+                )
+
+            TypeIcon.combine(icons)!!.base shouldBe Icons.TEMPLATE
+        }
+
+        test("retains the text if it is the same for all icons") {
+            val icons =
+                listOf(
+                    TypeIcon(PlainIcon(), "text", listOf(Color.PINK)),
+                    TypeIcon(PlainIcon(), "text", listOf(Color.CYAN)),
+                    TypeIcon(PlainIcon(), "text", listOf(Color.GREEN)),
+                )
+
+            TypeIcon.combine(icons)!!.text shouldBe "text"
+        }
+
+        test("removes the text if it is not the same for all icons") {
+            val icons =
+                listOf(
+                    TypeIcon(PlainIcon(), "text1", listOf(Color.GRAY)),
+                    TypeIcon(PlainIcon(), "text2", listOf(Color.ORANGE)),
+                    TypeIcon(PlainIcon(), "text2", listOf(Color.BLUE)),
+                )
+
+            TypeIcon.combine(icons)!!.text shouldBe ""
+        }
+
+        test("appends the colors of the combined icons") {
+            val icons =
+                listOf(
+                    TypeIcon(PlainIcon(), "text1", listOf(Color.BLUE, Color.WHITE)),
+                    TypeIcon(PlainIcon(), "text2", listOf(Color.RED)),
+                    TypeIcon(PlainIcon(), "text3", listOf(Color.PINK, Color.BLACK, Color.BLUE)),
+                )
+
+            TypeIcon.combine(icons)!!.colors shouldContainExactly
+                listOf(Color.BLUE, Color.WHITE, Color.RED, Color.PINK, Color.BLACK, Color.BLUE)
         }
     }
 })

--- a/src/test/kotlin/com/fwdekker/randomness/SchemeEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/SchemeEditorTest.kt
@@ -4,6 +4,7 @@ import com.fwdekker.randomness.testhelpers.DummyDecoratorScheme
 import com.fwdekker.randomness.testhelpers.DummyDecoratorSchemeEditor
 import com.fwdekker.randomness.testhelpers.DummyScheme
 import com.fwdekker.randomness.testhelpers.DummySchemeEditor
+import com.fwdekker.randomness.testhelpers.Tags
 import com.fwdekker.randomness.testhelpers.afterNonContainer
 import com.fwdekker.randomness.testhelpers.beforeNonContainer
 import com.fwdekker.randomness.testhelpers.guiGet
@@ -13,7 +14,6 @@ import com.intellij.testFramework.fixtures.IdeaTestFixture
 import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
 import com.intellij.ui.dsl.builder.bindText
 import com.intellij.ui.dsl.builder.panel
-import io.kotest.core.NamedTag
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.ints.shouldBeGreaterThanOrEqual
@@ -33,7 +33,7 @@ import javax.swing.JCheckBox
  * Unit tests for [SchemeEditor].
  */
 object SchemeEditorTest : FunSpec({
-    tags(NamedTag("IdeaFixture"), NamedTag("Swing"))
+    tags(Tags.EDITOR, Tags.IDEA_FIXTURE, Tags.SWING)
 
 
     lateinit var ideaFixture: IdeaTestFixture

--- a/src/test/kotlin/com/fwdekker/randomness/SchemeTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/SchemeTest.kt
@@ -2,8 +2,8 @@ package com.fwdekker.randomness
 
 import com.fwdekker.randomness.testhelpers.DummyDecoratorScheme
 import com.fwdekker.randomness.testhelpers.DummyScheme
+import com.fwdekker.randomness.testhelpers.Tags
 import io.kotest.assertions.throwables.shouldThrow
-import io.kotest.core.NamedTag
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.shouldContainExactly
@@ -18,10 +18,10 @@ import java.awt.Color
  * Unit tests for [Scheme].
  */
 object SchemeTest : FunSpec({
-    tags(NamedTag("Scheme"))
+    tags(Tags.SCHEME)
 
 
-    context("icon") {
+    context("f:icon") {
         test("returns null if the type icon is null") {
             val scheme = DummyScheme()
 
@@ -146,6 +146,9 @@ object SchemeTest : FunSpec({
  * Unit tests for [DecoratorScheme].
  */
 object DecoratorSchemeTest : FunSpec({
+    tags(Tags.SCHEME)
+
+
     context("generateStrings") {
         test("throws an exception if the decorator is invalid") {
             val decorator = DummyDecoratorScheme(enabled = true, valid = false)

--- a/src/test/kotlin/com/fwdekker/randomness/SchemeTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/SchemeTest.kt
@@ -21,7 +21,7 @@ object SchemeTest : FunSpec({
     tags(Tags.SCHEME)
 
 
-    context("f:icon") {
+    context("icon") {
         test("returns null if the type icon is null") {
             val scheme = DummyScheme()
 

--- a/src/test/kotlin/com/fwdekker/randomness/StateTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/StateTest.kt
@@ -1,7 +1,7 @@
 package com.fwdekker.randomness
 
 import com.fwdekker.randomness.testhelpers.DummyState
-import io.kotest.core.NamedTag
+import com.fwdekker.randomness.testhelpers.Tags
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
@@ -13,7 +13,7 @@ import io.kotest.matchers.types.shouldBeSameInstanceAs
  * Unit tests for [State].
  */
 object StateTest : FunSpec({
-    tags(NamedTag("Scheme"))
+    tags(Tags.SCHEME)
 
 
     context("uuid") {

--- a/src/test/kotlin/com/fwdekker/randomness/TimelyTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/TimelyTest.kt
@@ -2,8 +2,10 @@ package com.fwdekker.randomness
 
 import com.fwdekker.randomness.Timely.GENERATOR_TIMEOUT
 import com.fwdekker.randomness.Timely.generateTimely
+import com.fwdekker.randomness.testhelpers.matchBundle
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 
 
@@ -17,7 +19,7 @@ object TimelyTest : FunSpec({
 
     test("throws an exception if the generator does not finish within time") {
         shouldThrow<DataGenerationException> { generateTimely { Thread.sleep(GENERATOR_TIMEOUT + 1000L) } }
-            .message shouldBe Bundle("helpers.error.timed_out")
+            .message should matchBundle("helpers.error.timed_out")
     }
 
     test("throws an exception if the generator throws an exception") {

--- a/src/test/kotlin/com/fwdekker/randomness/XmlHelpersTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/XmlHelpersTest.kt
@@ -3,6 +3,8 @@ package com.fwdekker.randomness
 import com.intellij.openapi.util.JDOMUtil
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.nulls.beNull
+import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 
 
@@ -55,7 +57,7 @@ object XmlHelpersTest : FunSpec({
                 """.trimIndent()
             )
 
-            element.getContentByName("needle")?.name shouldBe null
+            element.getContentByName("needle")?.name should beNull()
         }
 
         test("returns `null` if multiple children have the given name") {
@@ -70,7 +72,7 @@ object XmlHelpersTest : FunSpec({
                 """.trimIndent()
             )
 
-            element.getContentByName("needle")?.name shouldBe null
+            element.getContentByName("needle")?.name should beNull()
         }
     }
 
@@ -100,7 +102,7 @@ object XmlHelpersTest : FunSpec({
                 """.trimIndent()
             )
 
-            element.getAttributeValueByName("needle") shouldBe null
+            element.getAttributeValueByName("needle") should beNull()
         }
 
         test("returns `null` if multiple children have the given name") {
@@ -115,7 +117,7 @@ object XmlHelpersTest : FunSpec({
                 """.trimIndent()
             )
 
-            element.getAttributeValueByName("needle") shouldBe null
+            element.getAttributeValueByName("needle") should beNull()
         }
 
         test("returns `null` if the child does not have a value attribute") {
@@ -129,7 +131,7 @@ object XmlHelpersTest : FunSpec({
                 """.trimIndent()
             )
 
-            element.getAttributeValueByName("needle") shouldBe null
+            element.getAttributeValueByName("needle") should beNull()
         }
     }
 
@@ -161,7 +163,7 @@ object XmlHelpersTest : FunSpec({
                 </tag>
                 """.trimIndent()
             )
-            element.getAttributeValueByName("needle") shouldBe null
+            element.getAttributeValueByName("needle") should beNull()
 
             element.setAttributeValueByName("needle", "new-value")
 
@@ -214,7 +216,7 @@ object XmlHelpersTest : FunSpec({
         test("returns `null` if there are no children") {
             val element = JDOMUtil.load("<tag></tag>")
 
-            element.getSingleContent() shouldBe null
+            element.getSingleContent() should beNull()
         }
 
         test("returns `null` if there are multiple children") {
@@ -227,7 +229,7 @@ object XmlHelpersTest : FunSpec({
                 """.trimIndent()
             )
 
-            element.getSingleContent() shouldBe null
+            element.getSingleContent() should beNull()
         }
     }
 
@@ -291,7 +293,7 @@ object XmlHelpersTest : FunSpec({
                 """.trimIndent()
             )
 
-            element.getContentByPath("wrong", null, "prong", null)?.name shouldBe null
+            element.getContentByPath("wrong", null, "prong", null)?.name should beNull()
         }
     }
 })

--- a/src/test/kotlin/com/fwdekker/randomness/affix/AffixDecoratorEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/affix/AffixDecoratorEditorTest.kt
@@ -2,6 +2,7 @@ package com.fwdekker.randomness.affix
 
 import com.fwdekker.randomness.editorApplyTestFactory
 import com.fwdekker.randomness.editorFieldsTestFactory
+import com.fwdekker.randomness.testhelpers.Tags
 import com.fwdekker.randomness.testhelpers.afterNonContainer
 import com.fwdekker.randomness.testhelpers.beforeNonContainer
 import com.fwdekker.randomness.testhelpers.guiGet
@@ -13,7 +14,6 @@ import com.intellij.testFramework.fixtures.IdeaTestFixture
 import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
 import com.intellij.ui.layout.selected
 import io.kotest.assertions.throwables.shouldNotThrowAny
-import io.kotest.core.NamedTag
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.data.row
 import io.kotest.datatest.withData
@@ -29,7 +29,7 @@ import javax.swing.JCheckBox
  * Unit tests for [AffixDecoratorEditor].
  */
 object AffixDecoratorEditorTest : FunSpec({
-    tags(NamedTag("Editor"), NamedTag("IdeaFixture"), NamedTag("Swing"))
+    tags(Tags.EDITOR, Tags.IDEA_FIXTURE, Tags.SWING)
 
 
     lateinit var ideaFixture: IdeaTestFixture

--- a/src/test/kotlin/com/fwdekker/randomness/affix/AffixDecoratorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/affix/AffixDecoratorTest.kt
@@ -1,8 +1,8 @@
 package com.fwdekker.randomness.affix
 
 import com.fwdekker.randomness.stateDeepCopyTestFactory
+import com.fwdekker.randomness.testhelpers.Tags
 import com.fwdekker.randomness.testhelpers.shouldValidateAsBundle
-import io.kotest.core.NamedTag
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.data.row
 import io.kotest.datatest.withData
@@ -13,7 +13,7 @@ import io.kotest.matchers.shouldBe
  * Unit tests for [AffixDecorator].
  */
 object AffixDecoratorTest : FunSpec({
-    tags(NamedTag("Scheme"))
+    tags(Tags.SCHEME)
 
 
     context("generateStrings") {

--- a/src/test/kotlin/com/fwdekker/randomness/array/ArrayDecoratorEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/array/ArrayDecoratorEditorTest.kt
@@ -2,6 +2,7 @@ package com.fwdekker.randomness.array
 
 import com.fwdekker.randomness.editorApplyTestFactory
 import com.fwdekker.randomness.editorFieldsTestFactory
+import com.fwdekker.randomness.testhelpers.Tags
 import com.fwdekker.randomness.testhelpers.afterNonContainer
 import com.fwdekker.randomness.testhelpers.beforeNonContainer
 import com.fwdekker.randomness.testhelpers.guiGet
@@ -14,7 +15,6 @@ import com.fwdekker.randomness.testhelpers.valueProp
 import com.intellij.testFramework.fixtures.IdeaTestFixture
 import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
 import com.intellij.ui.TitledSeparator
-import io.kotest.core.NamedTag
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.data.row
 import io.kotest.matchers.collections.beEmpty
@@ -29,7 +29,7 @@ import javax.swing.JCheckBox
  * Unit tests for [ArrayDecoratorEditor].
  */
 object ArrayDecoratorEditorTest : FunSpec({
-    tags(NamedTag("Editor"), NamedTag("IdeaFixture"), NamedTag("Swing"))
+    tags(Tags.EDITOR, Tags.IDEA_FIXTURE, Tags.SWING)
 
 
     lateinit var ideaFixture: IdeaTestFixture

--- a/src/test/kotlin/com/fwdekker/randomness/array/ArrayDecoratorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/array/ArrayDecoratorTest.kt
@@ -2,8 +2,8 @@ package com.fwdekker.randomness.array
 
 import com.fwdekker.randomness.affix.AffixDecorator
 import com.fwdekker.randomness.stateDeepCopyTestFactory
+import com.fwdekker.randomness.testhelpers.Tags
 import com.fwdekker.randomness.testhelpers.shouldValidateAsBundle
-import io.kotest.core.NamedTag
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.data.row
 import io.kotest.datatest.withData
@@ -15,7 +15,7 @@ import io.kotest.matchers.shouldBe
  * Unit tests for [ArrayDecorator].
  */
 object ArrayDecoratorTest : FunSpec({
-    tags(NamedTag("Scheme"))
+    tags(Tags.SCHEME)
 
 
     context("generateStrings") {

--- a/src/test/kotlin/com/fwdekker/randomness/datetime/DateTimeSchemeEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/datetime/DateTimeSchemeEditorTest.kt
@@ -2,6 +2,7 @@ package com.fwdekker.randomness.datetime
 
 import com.fwdekker.randomness.editorApplyTestFactory
 import com.fwdekker.randomness.editorFieldsTestFactory
+import com.fwdekker.randomness.testhelpers.Tags
 import com.fwdekker.randomness.testhelpers.afterNonContainer
 import com.fwdekker.randomness.testhelpers.beforeNonContainer
 import com.fwdekker.randomness.testhelpers.dateTimeProp
@@ -12,7 +13,6 @@ import com.fwdekker.randomness.testhelpers.textProp
 import com.fwdekker.randomness.testhelpers.valueProp
 import com.intellij.testFramework.fixtures.IdeaTestFixture
 import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
-import io.kotest.core.NamedTag
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.data.row
 import io.kotest.matchers.shouldBe
@@ -25,7 +25,7 @@ import org.assertj.swing.fixture.FrameFixture
  * Unit tests for [DateTimeSchemeEditor].
  */
 object DateTimeSchemeEditorTest : FunSpec({
-    tags(NamedTag("Editor"), NamedTag("IdeaFixture"), NamedTag("Swing"))
+    tags(Tags.EDITOR, Tags.IDEA_FIXTURE, Tags.SWING)
 
 
     lateinit var ideaFixture: IdeaTestFixture

--- a/src/test/kotlin/com/fwdekker/randomness/datetime/DateTimeSchemeTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/datetime/DateTimeSchemeTest.kt
@@ -2,9 +2,9 @@ package com.fwdekker.randomness.datetime
 
 import com.fwdekker.randomness.integer.IntegerScheme
 import com.fwdekker.randomness.stateDeepCopyTestFactory
+import com.fwdekker.randomness.testhelpers.Tags
 import com.fwdekker.randomness.testhelpers.shouldValidateAsBundle
 import io.kotest.assertions.withClue
-import io.kotest.core.NamedTag
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.data.row
 import io.kotest.datatest.withData
@@ -16,7 +16,7 @@ import io.kotest.matchers.shouldBe
  * Unit tests for [DateTimeScheme].
  */
 object DateTimeSchemeTest : FunSpec({
-    tags(NamedTag("Scheme"))
+    tags(Tags.SCHEME)
 
 
     context("generateStrings") {

--- a/src/test/kotlin/com/fwdekker/randomness/decimal/DecimalSchemeEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/decimal/DecimalSchemeEditorTest.kt
@@ -2,6 +2,7 @@ package com.fwdekker.randomness.decimal
 
 import com.fwdekker.randomness.editorApplyTestFactory
 import com.fwdekker.randomness.editorFieldsTestFactory
+import com.fwdekker.randomness.testhelpers.Tags
 import com.fwdekker.randomness.testhelpers.afterNonContainer
 import com.fwdekker.randomness.testhelpers.beforeNonContainer
 import com.fwdekker.randomness.testhelpers.guiGet
@@ -12,7 +13,6 @@ import com.fwdekker.randomness.testhelpers.textProp
 import com.fwdekker.randomness.testhelpers.valueProp
 import com.intellij.testFramework.fixtures.IdeaTestFixture
 import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
-import io.kotest.core.NamedTag
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.data.row
 import org.assertj.swing.edt.FailOnThreadViolationRepaintManager
@@ -24,7 +24,7 @@ import org.assertj.swing.fixture.FrameFixture
  * Unit tests for [DecimalSchemeEditor].
  */
 object DecimalSchemeEditorTest : FunSpec({
-    tags(NamedTag("Editor"), NamedTag("IdeaFixture"), NamedTag("Swing"))
+    tags(Tags.EDITOR, Tags.IDEA_FIXTURE, Tags.SWING)
 
 
     lateinit var ideaFixture: IdeaTestFixture

--- a/src/test/kotlin/com/fwdekker/randomness/decimal/DecimalSchemeTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/decimal/DecimalSchemeTest.kt
@@ -3,8 +3,8 @@ package com.fwdekker.randomness.decimal
 import com.fwdekker.randomness.affix.AffixDecorator
 import com.fwdekker.randomness.array.ArrayDecorator
 import com.fwdekker.randomness.stateDeepCopyTestFactory
+import com.fwdekker.randomness.testhelpers.Tags
 import com.fwdekker.randomness.testhelpers.shouldValidateAsBundle
-import io.kotest.core.NamedTag
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.data.row
 import io.kotest.datatest.withData
@@ -15,7 +15,7 @@ import io.kotest.matchers.shouldBe
  * Unit tests for [DecimalScheme].
  */
 object DecimalSchemeTest : FunSpec({
-    tags(NamedTag("Scheme"))
+    tags(Tags.SCHEME)
 
 
     context("generateStrings") {

--- a/src/test/kotlin/com/fwdekker/randomness/fixedlength/FixedLengthDecoratorEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/fixedlength/FixedLengthDecoratorEditorTest.kt
@@ -2,6 +2,7 @@ package com.fwdekker.randomness.fixedlength
 
 import com.fwdekker.randomness.editorApplyTestFactory
 import com.fwdekker.randomness.editorFieldsTestFactory
+import com.fwdekker.randomness.testhelpers.Tags
 import com.fwdekker.randomness.testhelpers.afterNonContainer
 import com.fwdekker.randomness.testhelpers.beforeNonContainer
 import com.fwdekker.randomness.testhelpers.guiGet
@@ -12,7 +13,6 @@ import com.fwdekker.randomness.testhelpers.textProp
 import com.fwdekker.randomness.testhelpers.valueProp
 import com.intellij.testFramework.fixtures.IdeaTestFixture
 import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
-import io.kotest.core.NamedTag
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.data.row
 import org.assertj.swing.edt.FailOnThreadViolationRepaintManager
@@ -24,7 +24,7 @@ import org.assertj.swing.fixture.FrameFixture
  * Unit tests for [FixedLengthDecoratorEditor].
  */
 object FixedLengthDecoratorEditorTest : FunSpec({
-    tags(NamedTag("Editor"), NamedTag("IdeaFixture"), NamedTag("Swing"))
+    tags(Tags.EDITOR, Tags.IDEA_FIXTURE, Tags.SWING)
 
 
     lateinit var ideaFixture: IdeaTestFixture

--- a/src/test/kotlin/com/fwdekker/randomness/fixedlength/FixedLengthDecoratorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/fixedlength/FixedLengthDecoratorTest.kt
@@ -1,8 +1,8 @@
 package com.fwdekker.randomness.fixedlength
 
 import com.fwdekker.randomness.stateDeepCopyTestFactory
+import com.fwdekker.randomness.testhelpers.Tags
 import com.fwdekker.randomness.testhelpers.shouldValidateAsBundle
-import io.kotest.core.NamedTag
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.data.row
 import io.kotest.datatest.withData
@@ -13,7 +13,7 @@ import io.kotest.matchers.shouldBe
  * Unit tests for [FixedLengthDecorator].
  */
 object FixedLengthDecoratorTest : FunSpec({
-    tags(NamedTag("Scheme"))
+    tags(Tags.SCHEME)
 
 
     context("generateStrings") {

--- a/src/test/kotlin/com/fwdekker/randomness/integer/IntegerSchemeEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/integer/IntegerSchemeEditorTest.kt
@@ -2,6 +2,7 @@ package com.fwdekker.randomness.integer
 
 import com.fwdekker.randomness.editorApplyTestFactory
 import com.fwdekker.randomness.editorFieldsTestFactory
+import com.fwdekker.randomness.testhelpers.Tags
 import com.fwdekker.randomness.testhelpers.afterNonContainer
 import com.fwdekker.randomness.testhelpers.beforeNonContainer
 import com.fwdekker.randomness.testhelpers.guiGet
@@ -13,7 +14,6 @@ import com.fwdekker.randomness.testhelpers.textProp
 import com.fwdekker.randomness.testhelpers.valueProp
 import com.intellij.testFramework.fixtures.IdeaTestFixture
 import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
-import io.kotest.core.NamedTag
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.data.row
 import io.kotest.datatest.withData
@@ -26,7 +26,7 @@ import org.assertj.swing.fixture.FrameFixture
  * Unit tests for [IntegerSchemeEditor].
  */
 object IntegerSchemeEditorTest : FunSpec({
-    tags(NamedTag("Editor"), NamedTag("IdeaFixture"), NamedTag("Swing"))
+    tags(Tags.EDITOR, Tags.IDEA_FIXTURE, Tags.SWING)
 
 
     lateinit var ideaFixture: IdeaTestFixture

--- a/src/test/kotlin/com/fwdekker/randomness/integer/IntegerSchemeTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/integer/IntegerSchemeTest.kt
@@ -4,9 +4,9 @@ import com.fwdekker.randomness.affix.AffixDecorator
 import com.fwdekker.randomness.array.ArrayDecorator
 import com.fwdekker.randomness.fixedlength.FixedLengthDecorator
 import com.fwdekker.randomness.stateDeepCopyTestFactory
+import com.fwdekker.randomness.testhelpers.Tags
 import com.fwdekker.randomness.testhelpers.shouldValidateAsBundle
 import io.kotest.assertions.withClue
-import io.kotest.core.NamedTag
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.data.row
 import io.kotest.datatest.withData
@@ -18,7 +18,7 @@ import io.kotest.matchers.shouldBe
  * Unit tests for [IntegerScheme].
  */
 object IntegerSchemeTest : FunSpec({
-    tags(NamedTag("Scheme"))
+    tags(Tags.SCHEME)
 
 
     context("generateStrings") {

--- a/src/test/kotlin/com/fwdekker/randomness/string/StringSchemeEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/string/StringSchemeEditorTest.kt
@@ -3,6 +3,7 @@ package com.fwdekker.randomness.string
 import com.fwdekker.randomness.CapitalizationMode
 import com.fwdekker.randomness.editorApplyTestFactory
 import com.fwdekker.randomness.editorFieldsTestFactory
+import com.fwdekker.randomness.testhelpers.Tags
 import com.fwdekker.randomness.testhelpers.afterNonContainer
 import com.fwdekker.randomness.testhelpers.beforeNonContainer
 import com.fwdekker.randomness.testhelpers.guiGet
@@ -13,7 +14,6 @@ import com.fwdekker.randomness.testhelpers.textProp
 import com.fwdekker.randomness.testhelpers.valueProp
 import com.intellij.testFramework.fixtures.IdeaTestFixture
 import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
-import io.kotest.core.NamedTag
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.data.row
 import org.assertj.swing.edt.FailOnThreadViolationRepaintManager
@@ -25,7 +25,7 @@ import org.assertj.swing.fixture.FrameFixture
  * Unit tests for [StringSchemeEditor].
  */
 object StringSchemeEditorTest : FunSpec({
-    tags(NamedTag("Editor"), NamedTag("IdeaFixture"), NamedTag("Swing"))
+    tags(Tags.EDITOR, Tags.IDEA_FIXTURE, Tags.SWING)
 
 
     lateinit var ideaFixture: IdeaTestFixture

--- a/src/test/kotlin/com/fwdekker/randomness/string/StringSchemeTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/string/StringSchemeTest.kt
@@ -3,8 +3,8 @@ package com.fwdekker.randomness.string
 import com.fwdekker.randomness.CapitalizationMode
 import com.fwdekker.randomness.array.ArrayDecorator
 import com.fwdekker.randomness.stateDeepCopyTestFactory
+import com.fwdekker.randomness.testhelpers.Tags
 import com.fwdekker.randomness.testhelpers.shouldValidateAsBundle
-import io.kotest.core.NamedTag
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.data.row
 import io.kotest.datatest.withData
@@ -15,7 +15,7 @@ import io.kotest.matchers.shouldBe
  * Unit tests for [StringScheme].
  */
 object StringSchemeTest : FunSpec({
-    tags(NamedTag("Scheme"))
+    tags(Tags.SCHEME)
 
 
     context("isSimple") {

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateActionLoaderTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateActionLoaderTest.kt
@@ -1,11 +1,11 @@
 package com.fwdekker.randomness.template
 
+import com.fwdekker.randomness.testhelpers.Tags
 import com.fwdekker.randomness.testhelpers.afterNonContainer
 import com.fwdekker.randomness.testhelpers.beforeNonContainer
 import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.testFramework.fixtures.IdeaTestFixture
 import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
-import io.kotest.core.NamedTag
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.shouldHaveAtLeastSize
@@ -18,7 +18,7 @@ import io.kotest.matchers.shouldNot
  * Unit tests for [TemplateActionLoader].
  */
 object TemplateActionLoaderTest : FunSpec({
-    tags(NamedTag("IdeaFixture"))
+    tags(Tags.IDEA_FIXTURE)
 
 
     lateinit var ideaFixture: IdeaTestFixture

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateActionTests.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateActionTests.kt
@@ -1,16 +1,16 @@
 package com.fwdekker.randomness.template
 
-import com.fwdekker.randomness.Bundle
 import com.fwdekker.randomness.Icons
 import com.fwdekker.randomness.OverlayIcon
 import com.fwdekker.randomness.OverlayedIcon
 import com.fwdekker.randomness.TypeIcon
 import com.fwdekker.randomness.testhelpers.DummyScheme
+import com.fwdekker.randomness.testhelpers.Tags
 import com.fwdekker.randomness.testhelpers.afterNonContainer
 import com.fwdekker.randomness.testhelpers.beforeNonContainer
+import com.fwdekker.randomness.testhelpers.matchBundle
 import com.intellij.testFramework.fixtures.IdeaTestFixture
 import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
-import io.kotest.core.NamedTag
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.data.row
 import io.kotest.datatest.withData
@@ -27,7 +27,7 @@ import java.awt.Color
  * Unit tests for [TemplateGroupAction].
  */
 object TemplateGroupActionTest : FunSpec({
-    tags(NamedTag("IdeaFixture"))
+    tags(Tags.IDEA_FIXTURE)
 
 
     lateinit var ideaFixture: IdeaTestFixture
@@ -132,7 +132,7 @@ object TemplateInsertActionTest : FunSpec({
  * Unit tests for [TemplateSettingsAction].
  */
 object TemplateSettingsActionTest : FunSpec({
-    tags(NamedTag("IdeaFixture"))
+    tags(Tags.IDEA_FIXTURE)
 
 
     lateinit var ideaFixture: IdeaTestFixture
@@ -153,7 +153,7 @@ object TemplateSettingsActionTest : FunSpec({
             test("uses a default text if the template is null") {
                 val action = TemplateSettingsAction(template = null)
 
-                action.templatePresentation.text shouldBe Bundle("template.name.settings")
+                action.templatePresentation.text should matchBundle("template.name.settings")
             }
 
             test("uses the template's name if the template is not null") {

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateActionTests.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateActionTests.kt
@@ -185,11 +185,11 @@ object TemplateSettingsActionTest : FunSpec({
             }
 
             test("uses the template's icon if the template is not null") {
-                val icon = TypeIcon(Icons.SCHEME, "war", listOf(Color.GREEN))
+                val icon = TypeIcon(Icons.SCHEME, "wax", listOf(Color.GREEN))
                 val template = Template("subject", mutableListOf(DummyScheme().also { it.typeIcon = icon }))
                 val action = TemplateSettingsAction(template)
 
-                (action.templatePresentation.icon as OverlayedIcon).base shouldBe icon
+                (action.templatePresentation.icon as OverlayedIcon).base shouldBe template.typeIcon
             }
         }
     }

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateEditorTest.kt
@@ -1,12 +1,12 @@
 package com.fwdekker.randomness.template
 
 import com.fwdekker.randomness.editorFieldsTestFactory
+import com.fwdekker.randomness.testhelpers.Tags
 import com.fwdekker.randomness.testhelpers.afterNonContainer
 import com.fwdekker.randomness.testhelpers.beforeNonContainer
 import com.fwdekker.randomness.testhelpers.guiGet
 import com.fwdekker.randomness.testhelpers.prop
 import com.fwdekker.randomness.testhelpers.textProp
-import io.kotest.core.NamedTag
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.data.row
 import io.kotest.matchers.shouldBe
@@ -19,7 +19,7 @@ import org.assertj.swing.fixture.FrameFixture
  * Unit tests for [TemplateEditor].
  */
 object TemplateEditorTest : FunSpec({
-    tags(NamedTag("Editor"), NamedTag("IdeaFixture"), NamedTag("Swing"))
+    tags(Tags.EDITOR, Tags.IDEA_FIXTURE, Tags.SWING)
 
 
     lateinit var frame: FrameFixture

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateJTreeTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateJTreeTest.kt
@@ -4,6 +4,7 @@ import com.fwdekker.randomness.Scheme
 import com.fwdekker.randomness.Settings
 import com.fwdekker.randomness.setAll
 import com.fwdekker.randomness.testhelpers.DummyScheme
+import com.fwdekker.randomness.testhelpers.Tags
 import com.fwdekker.randomness.testhelpers.afterNonContainer
 import com.fwdekker.randomness.testhelpers.beforeNonContainer
 import com.fwdekker.randomness.testhelpers.getActionButton
@@ -15,7 +16,6 @@ import com.intellij.openapi.actionSystem.ActionToolbar
 import com.intellij.testFramework.fixtures.IdeaTestFixture
 import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
 import io.kotest.assertions.throwables.shouldThrow
-import io.kotest.core.NamedTag
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.data.Row3
 import io.kotest.data.row
@@ -39,7 +39,7 @@ import org.assertj.swing.fixture.FrameFixture
  */
 @Suppress("detekt:LargeClass") // Would be weird to split up given that CUT is not split up either
 object TemplateJTreeTest : FunSpec({
-    tags(NamedTag("IdeaFixture"), NamedTag("Swing"))
+    tags(Tags.IDEA_FIXTURE, Tags.SWING)
 
 
     lateinit var ideaFixture: IdeaTestFixture

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateListConfigurableTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateListConfigurableTest.kt
@@ -1,6 +1,7 @@
 package com.fwdekker.randomness.template
 
 import com.fwdekker.randomness.Settings
+import com.fwdekker.randomness.testhelpers.Tags
 import com.fwdekker.randomness.testhelpers.afterNonContainer
 import com.fwdekker.randomness.testhelpers.beforeNonContainer
 import com.fwdekker.randomness.testhelpers.guiGet
@@ -11,7 +12,6 @@ import com.intellij.openapi.options.ConfigurationException
 import com.intellij.testFramework.fixtures.IdeaTestFixture
 import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
 import io.kotest.assertions.throwables.shouldThrow
-import io.kotest.core.NamedTag
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
@@ -25,7 +25,7 @@ import org.assertj.swing.fixture.FrameFixture
  * Unit tests for [TemplateListConfigurable].
  */
 class TemplateListConfigurableTest : FunSpec({
-    tags(NamedTag("IdeaFixture"))
+    tags(Tags.IDEA_FIXTURE)
 
 
     lateinit var ideaFixture: IdeaTestFixture

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateListEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateListEditorTest.kt
@@ -240,15 +240,15 @@ object TemplateListEditorTest : FunSpec({
             guiRun {
                 frame.tree().target().setSelectionRow(1)
                 frame.spinner("minValue").target().value = 7L
-                frame.tree().target().setSelectionRow(3)
             }
-
-            guiRun { editor.reset() }
 
             guiRun {
-                frame.tree().target().setSelectionRow(1)
-                frame.spinner("minValue").target().value shouldBe 0L
+                frame.tree().target().setSelectionRow(3)
+                editor.reset()
             }
+
+            guiRun { frame.tree().target().setSelectionRow(1) }
+            guiGet { frame.spinner("minValue").target().value } shouldBe 0L
         }
     }
 })

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateListEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateListEditorTest.kt
@@ -8,6 +8,7 @@ import com.fwdekker.randomness.integer.IntegerScheme
 import com.fwdekker.randomness.setAll
 import com.fwdekker.randomness.string.StringScheme
 import com.fwdekker.randomness.testhelpers.DummyScheme
+import com.fwdekker.randomness.testhelpers.Tags
 import com.fwdekker.randomness.testhelpers.afterNonContainer
 import com.fwdekker.randomness.testhelpers.beforeNonContainer
 import com.fwdekker.randomness.testhelpers.guiGet
@@ -20,7 +21,6 @@ import com.intellij.openapi.util.Disposer
 import com.intellij.testFramework.fixtures.IdeaTestFixture
 import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
 import io.kotest.assertions.throwables.shouldThrow
-import io.kotest.core.NamedTag
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.data.Row2
 import io.kotest.data.row
@@ -40,7 +40,7 @@ import org.assertj.swing.fixture.FrameFixture
  * Unit tests for [TemplateListEditor].
  */
 object TemplateListEditorTest : FunSpec({
-    tags(NamedTag("Editor"), NamedTag("IdeaFixture"), NamedTag("Swing"))
+    tags(Tags.EDITOR, Tags.IDEA_FIXTURE, Tags.SWING)
 
 
     lateinit var ideaFixture: IdeaTestFixture

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateReferenceEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateReferenceEditorTest.kt
@@ -4,6 +4,7 @@ import com.fwdekker.randomness.CapitalizationMode
 import com.fwdekker.randomness.Settings
 import com.fwdekker.randomness.editorFieldsTestFactory
 import com.fwdekker.randomness.testhelpers.DummyScheme
+import com.fwdekker.randomness.testhelpers.Tags
 import com.fwdekker.randomness.testhelpers.afterNonContainer
 import com.fwdekker.randomness.testhelpers.beforeNonContainer
 import com.fwdekker.randomness.testhelpers.guiGet
@@ -14,10 +15,11 @@ import com.fwdekker.randomness.testhelpers.textProp
 import com.fwdekker.randomness.testhelpers.valueProp
 import com.intellij.testFramework.fixtures.IdeaTestFixture
 import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
-import io.kotest.core.NamedTag
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.data.row
 import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.nulls.beNull
+import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import org.assertj.swing.edt.FailOnThreadViolationRepaintManager
 import org.assertj.swing.fixture.Containers
@@ -28,7 +30,7 @@ import org.assertj.swing.fixture.FrameFixture
  * Unit tests for [TemplateReferenceEditor].
  */
 object TemplateReferenceEditorTest : FunSpec({
-    tags(NamedTag("Editor"), NamedTag("IdeaFixture"), NamedTag("Swing"))
+    tags(Tags.EDITOR, Tags.IDEA_FIXTURE, Tags.SWING)
 
 
     lateinit var ideaFixture: IdeaTestFixture
@@ -76,7 +78,7 @@ object TemplateReferenceEditorTest : FunSpec({
             reference.template = null
             guiRun { editor.reset() }
 
-            guiGet { frame.comboBox("template").itemProp().get() } shouldBe null
+            guiGet { frame.comboBox("template").itemProp().get() } should beNull()
         }
 
         test("does not load the reference's parent as a selectable option") {

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateReferenceTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateReferenceTest.kt
@@ -1,16 +1,16 @@
 package com.fwdekker.randomness.template
 
-import com.fwdekker.randomness.Bundle
 import com.fwdekker.randomness.CapitalizationMode
 import com.fwdekker.randomness.OverlayIcon
 import com.fwdekker.randomness.Settings
 import com.fwdekker.randomness.setAll
 import com.fwdekker.randomness.stateDeepCopyTestFactory
 import com.fwdekker.randomness.testhelpers.DummyScheme
+import com.fwdekker.randomness.testhelpers.Tags
 import com.fwdekker.randomness.testhelpers.beforeNonContainer
+import com.fwdekker.randomness.testhelpers.matchBundle
 import com.fwdekker.randomness.testhelpers.shouldValidateAsBundle
 import io.kotest.assertions.throwables.shouldThrow
-import io.kotest.core.NamedTag
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.data.row
 import io.kotest.datatest.withData
@@ -25,7 +25,7 @@ import io.kotest.matchers.shouldNot
  * Unit tests for [TemplateReference].
  */
 object TemplateReferenceTest : FunSpec({
-    tags(NamedTag("Scheme"))
+    tags(Tags.SCHEME)
 
 
     lateinit var list: TemplateList
@@ -48,7 +48,7 @@ object TemplateReferenceTest : FunSpec({
         test("returns an alternative name if no template is set") {
             reference.template = null
 
-            reference.name shouldBe Bundle("reference.title")
+            reference.name should matchBundle("reference.title")
         }
 
         test("returns the referenced template's name with brackets") {

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateTest.kt
@@ -8,10 +8,10 @@ import com.fwdekker.randomness.integer.IntegerScheme
 import com.fwdekker.randomness.stateDeepCopyTestFactory
 import com.fwdekker.randomness.string.StringScheme
 import com.fwdekker.randomness.testhelpers.DummyScheme
+import com.fwdekker.randomness.testhelpers.Tags
 import com.fwdekker.randomness.testhelpers.shouldValidateAsBundle
 import com.fwdekker.randomness.word.WordScheme
 import io.kotest.assertions.throwables.shouldThrow
-import io.kotest.core.NamedTag
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.data.row
 import io.kotest.datatest.withData
@@ -26,7 +26,7 @@ import kotlin.random.Random
  * Unit tests for [Template].
  */
 object TemplateTest : FunSpec({
-    tags(NamedTag("Scheme"))
+    tags(Tags.SCHEME)
 
 
     context("typeIcon") {

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateTest.kt
@@ -2,6 +2,7 @@ package com.fwdekker.randomness.template
 
 import com.fwdekker.randomness.CapitalizationMode
 import com.fwdekker.randomness.DataGenerationException
+import com.fwdekker.randomness.Icons
 import com.fwdekker.randomness.Settings
 import com.fwdekker.randomness.array.ArrayDecorator
 import com.fwdekker.randomness.integer.IntegerScheme
@@ -30,11 +31,10 @@ object TemplateTest : FunSpec({
 
 
     context("typeIcon") {
-        test("returns the single scheme's icon if that scheme has an icon") {
-            val scheme = IntegerScheme()
-            val template = Template(schemes = mutableListOf(scheme))
+        test("returns the default icon if the template contains no schemes") {
+            val template = Template()
 
-            template.typeIcon shouldBe scheme.typeIcon
+            template.typeIcon shouldBe Template.DEFAULT_ICON
         }
 
         test("returns the default icon if the single scheme has no icon") {
@@ -44,10 +44,13 @@ object TemplateTest : FunSpec({
             template.typeIcon shouldBe Template.DEFAULT_ICON
         }
 
-        test("returns the default icon if no scheme is present") {
-            val template = Template()
+        test("returns a template version of the single scheme's TypeIcon") {
+            val scheme = IntegerScheme()
+            val template = Template(schemes = mutableListOf(scheme))
 
-            template.typeIcon shouldBe Template.DEFAULT_ICON
+            template.typeIcon.base shouldBe Icons.TEMPLATE
+            template.typeIcon.text shouldBe scheme.typeIcon.text
+            template.typeIcon.colors shouldBe scheme.typeIcon.colors
         }
 
         test("returns the scheme's combined icon if multiple are present") {

--- a/src/test/kotlin/com/fwdekker/randomness/testhelpers/DummySchemeTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/testhelpers/DummySchemeTest.kt
@@ -9,6 +9,9 @@ import io.kotest.matchers.shouldNotBe
  * Non-comprehensive tests and sanity checks for [DummyScheme].
  */
 object DummySchemeTest : FunSpec({
+    tags(Tags.SCHEME)
+
+
     test("does not equal another fresh instance") {
         DummyScheme() shouldNotBe DummyScheme()
     }

--- a/src/test/kotlin/com/fwdekker/randomness/testhelpers/Tags.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/testhelpers/Tags.kt
@@ -1,0 +1,31 @@
+package com.fwdekker.randomness.testhelpers
+
+import io.kotest.core.NamedTag
+
+
+/**
+ * Tags for Kotest-based tags for filtering tests.
+ *
+ * See the project's README for more information.
+ */
+object Tags {
+    /**
+     * Tests for [com.fwdekker.randomness.SchemeEditor]s.
+     */
+    val EDITOR = NamedTag("Editor")
+
+    /**
+     * Tests that rely on setting up an IDE fixture.
+     */
+    val IDEA_FIXTURE = NamedTag("IdeaFixture")
+
+    /**
+     * Tests for [com.fwdekker.randomness.Scheme]s.
+     */
+    val SCHEME = NamedTag("Scheme")
+
+    /**
+     * Tests that rely on accessing Swing components.
+     */
+    val SWING = NamedTag("Swing")
+}

--- a/src/test/kotlin/com/fwdekker/randomness/ui/JDateTimeFieldTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/ui/JDateTimeFieldTest.kt
@@ -1,13 +1,14 @@
 package com.fwdekker.randomness.ui
 
-import com.fwdekker.randomness.Bundle
+import com.fwdekker.randomness.testhelpers.Tags
 import com.fwdekker.randomness.testhelpers.beforeNonContainer
 import com.fwdekker.randomness.testhelpers.guiGet
 import com.fwdekker.randomness.testhelpers.guiRun
+import com.fwdekker.randomness.testhelpers.matchBundle
 import com.github.sisyphsu.dateparser.DateParserUtils
 import io.kotest.assertions.throwables.shouldThrow
-import io.kotest.core.NamedTag
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import org.assertj.swing.edt.FailOnThreadViolationRepaintManager
 import java.text.ParseException
@@ -19,7 +20,7 @@ import java.time.Month
  * Unit tests for [JDateTimeField].
  */
 object JDateTimeFieldTest : FunSpec({
-    tags(NamedTag("Swing"))
+    tags(Tags.SWING)
 
 
     lateinit var field: JDateTimeField
@@ -47,7 +48,7 @@ object JDateTimeFieldTest : FunSpec({
         context("set") {
             test("throws an error if a non-date-time is set") {
                 shouldThrow<IllegalArgumentException> { guiRun { field.setValue("invalid") } }
-                    .message shouldBe Bundle("datetime_field.error.invalid_type")
+                    .message should matchBundle("datetime_field.error.invalid_type")
             }
         }
 
@@ -98,7 +99,7 @@ object JDateTimeFieldTest : FunSpec({
                 shouldThrow<ParseException> {
                     field.text = null
                     field.commitEdit()
-                }.message shouldBe Bundle("datetime_field.error.empty_string")
+                }.message should matchBundle("datetime_field.error.empty_string")
             }
         }
 
@@ -107,7 +108,7 @@ object JDateTimeFieldTest : FunSpec({
                 shouldThrow<ParseException> {
                     field.text = ""
                     field.commitEdit()
-                }.message shouldBe Bundle("datetime_field.error.empty_string")
+                }.message should matchBundle("datetime_field.error.empty_string")
             }
         }
 

--- a/src/test/kotlin/com/fwdekker/randomness/ui/JNumberSpinnerTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/ui/JNumberSpinnerTest.kt
@@ -1,9 +1,9 @@
 package com.fwdekker.randomness.ui
 
+import com.fwdekker.randomness.testhelpers.Tags
 import com.fwdekker.randomness.testhelpers.guiGet
 import com.fwdekker.randomness.testhelpers.guiRun
 import io.kotest.assertions.throwables.shouldThrow
-import io.kotest.core.NamedTag
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.nulls.beNull
 import io.kotest.matchers.should
@@ -16,7 +16,7 @@ import javax.swing.JSpinner
  * Unit tests for [JNumberSpinner].
  */
 object JNumberSpinnerTest : FunSpec({
-    tags(NamedTag("Swing"))
+    tags(Tags.SWING)
 
 
     beforeContainer {
@@ -59,7 +59,7 @@ object JNumberSpinnerTest : FunSpec({
  * Unit tests for [bindSpinners].
  */
 object BindSpinnersTest : FunSpec({
-    tags(NamedTag("Swing"))
+    tags(Tags.SWING)
 
 
     beforeContainer {
@@ -104,7 +104,7 @@ object BindSpinnersTest : FunSpec({
  * Unit tests for [JDoubleSpinner].
  */
 object JDoubleSpinnerTest : FunSpec({
-    tags(NamedTag("Swing"))
+    tags(Tags.SWING)
 
 
     beforeContainer {
@@ -157,7 +157,7 @@ object JDoubleSpinnerTest : FunSpec({
  * Unit tests for [JLongSpinner].
  */
 object JLongSpinnerTest : FunSpec({
-    tags(NamedTag("Swing"))
+    tags(Tags.SWING)
 
 
     beforeContainer {
@@ -210,7 +210,7 @@ object JLongSpinnerTest : FunSpec({
  * Unit tests for [JIntSpinner].
  */
 object JIntSpinnerTest : FunSpec({
-    tags(NamedTag("Swing"))
+    tags(Tags.SWING)
 
 
     beforeContainer {

--- a/src/test/kotlin/com/fwdekker/randomness/ui/ListenerHelpersTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/ui/ListenerHelpersTest.kt
@@ -27,7 +27,7 @@ import javax.swing.tree.MutableTreeNode
 
 
 /**
- * Unit tests for extension functions in `ListenerHelpersKt`.
+ * Unit tests for extension functions in [ListenerHelpersKt].
  */
 object ListenerHelpersTest : FunSpec({
     tags(NamedTag("Swing"))
@@ -75,7 +75,7 @@ object ListenerHelpersTest : FunSpec({
                         { PlainDocument().also { it.insertString(0, "text", null) } },
                         { (it as PlainDocument).replace(2, 1, "y", null) },
                     ),
-                // `JBDocument` is excluded because setting up the correct fixtures is very difficult
+                // [JBDocument] is excluded because setting up the correct fixtures is very difficult
                 "JComboBox: Select different item" to
                     row(
                         { ComboBox(arrayOf("item1", "item2")) },

--- a/src/test/kotlin/com/fwdekker/randomness/ui/ListenerHelpersTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/ui/ListenerHelpersTest.kt
@@ -1,12 +1,12 @@
 package com.fwdekker.randomness.ui
 
 import com.fwdekker.randomness.testhelpers.DummySchemeEditor
+import com.fwdekker.randomness.testhelpers.Tags
 import com.fwdekker.randomness.testhelpers.beforeNonContainer
 import com.fwdekker.randomness.testhelpers.guiGet
 import com.fwdekker.randomness.testhelpers.guiRun
 import com.intellij.openapi.ui.ComboBox
 import com.intellij.ui.dsl.builder.panel
-import io.kotest.core.NamedTag
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.data.Row2
 import io.kotest.data.row
@@ -27,10 +27,10 @@ import javax.swing.tree.MutableTreeNode
 
 
 /**
- * Unit tests for extension functions in [ListenerHelpersKt].
+ * Unit tests for extension functions in `ListenerHelpersKt`.
  */
 object ListenerHelpersTest : FunSpec({
-    tags(NamedTag("Swing"))
+    tags(Tags.SWING)
 
 
     var listenerInvoked = false

--- a/src/test/kotlin/com/fwdekker/randomness/ui/PreviewPanelTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/ui/PreviewPanelTest.kt
@@ -2,6 +2,7 @@ package com.fwdekker.randomness.ui
 
 import com.fwdekker.randomness.Bundle
 import com.fwdekker.randomness.testhelpers.DummyScheme
+import com.fwdekker.randomness.testhelpers.Tags
 import com.fwdekker.randomness.testhelpers.afterNonContainer
 import com.fwdekker.randomness.testhelpers.beforeNonContainer
 import com.fwdekker.randomness.testhelpers.find
@@ -12,7 +13,6 @@ import com.intellij.openapi.util.Disposer
 import com.intellij.testFramework.fixtures.IdeaTestFixture
 import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
 import com.intellij.ui.InplaceButton
-import io.kotest.core.NamedTag
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
@@ -25,7 +25,7 @@ import org.assertj.swing.fixture.FrameFixture
  * Unit tests for [PreviewPanel].
  */
 object PreviewPanelTest : FunSpec({
-    tags(NamedTag("IdeaFixture"), NamedTag("Swing"))
+    tags(Tags.IDEA_FIXTURE, Tags.SWING)
 
 
     lateinit var ideaFixture: IdeaTestFixture

--- a/src/test/kotlin/com/fwdekker/randomness/uuid/UuidSchemeEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/uuid/UuidSchemeEditorTest.kt
@@ -2,6 +2,7 @@ package com.fwdekker.randomness.uuid
 
 import com.fwdekker.randomness.editorApplyTestFactory
 import com.fwdekker.randomness.editorFieldsTestFactory
+import com.fwdekker.randomness.testhelpers.Tags
 import com.fwdekker.randomness.testhelpers.afterNonContainer
 import com.fwdekker.randomness.testhelpers.beforeNonContainer
 import com.fwdekker.randomness.testhelpers.guiGet
@@ -12,7 +13,6 @@ import com.fwdekker.randomness.testhelpers.textProp
 import com.fwdekker.randomness.testhelpers.valueProp
 import com.intellij.testFramework.fixtures.IdeaTestFixture
 import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
-import io.kotest.core.NamedTag
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.data.row
 import org.assertj.swing.edt.FailOnThreadViolationRepaintManager
@@ -24,7 +24,7 @@ import org.assertj.swing.fixture.FrameFixture
  * Unit tests for [UuidSchemeEditor].
  */
 object UuidSchemeEditorTest : FunSpec({
-    tags(NamedTag("Editor"), NamedTag("IdeaFixture"), NamedTag("Swing"))
+    tags(Tags.EDITOR, Tags.IDEA_FIXTURE, Tags.SWING)
 
 
     lateinit var ideaFixture: IdeaTestFixture

--- a/src/test/kotlin/com/fwdekker/randomness/uuid/UuidSchemeTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/uuid/UuidSchemeTest.kt
@@ -3,8 +3,8 @@ package com.fwdekker.randomness.uuid
 import com.fwdekker.randomness.affix.AffixDecorator
 import com.fwdekker.randomness.array.ArrayDecorator
 import com.fwdekker.randomness.stateDeepCopyTestFactory
+import com.fwdekker.randomness.testhelpers.Tags
 import com.fwdekker.randomness.testhelpers.shouldValidateAsBundle
-import io.kotest.core.NamedTag
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.data.row
 import io.kotest.datatest.withData
@@ -22,7 +22,7 @@ import io.kotest.matchers.string.shouldNotContain
  * Unit tests for [UuidScheme].
  */
 object UuidSchemeTest : FunSpec({
-    tags(NamedTag("Scheme"))
+    tags(Tags.SCHEME)
 
 
     context("generateStrings") {

--- a/src/test/kotlin/com/fwdekker/randomness/word/DefaultWordListTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/word/DefaultWordListTest.kt
@@ -1,14 +1,13 @@
 package com.fwdekker.randomness.word
 
-import com.fwdekker.randomness.Bundle
 import com.fwdekker.randomness.testhelpers.beforeNonContainer
+import com.fwdekker.randomness.testhelpers.matchBundle
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.longs.shouldBeLessThan
 import io.kotest.matchers.should
-import io.kotest.matchers.shouldBe
 import java.io.IOException
 import kotlin.system.measureNanoTime
 
@@ -26,7 +25,7 @@ object DefaultWordListTest : FunSpec({
         test("throws an exception if the file does not exist") {
             val list = DefaultWordList("name", "word-lists/does-not-exist.txt")
 
-            shouldThrow<IOException> { list.words }.message shouldBe Bundle("word_list.error.file_not_found")
+            shouldThrow<IOException> { list.words }.message should matchBundle("word_list.error.file_not_found")
         }
 
         test("returns an empty list of words if the file is empty") {
@@ -52,7 +51,7 @@ object DefaultWordListTest : FunSpec({
                 val list = DefaultWordList("name", "word-lists/does-not-exist.txt")
 
                 shouldThrow<IOException> { list.words }
-                shouldThrow<IOException> { list.words }.message shouldBe Bundle("word_list.error.file_not_found")
+                    .message should matchBundle("word_list.error.file_not_found")
             }
 
             test("returns words quicker if read again from the same instance") {

--- a/src/test/kotlin/com/fwdekker/randomness/word/WordSchemeEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/word/WordSchemeEditorTest.kt
@@ -3,6 +3,7 @@ package com.fwdekker.randomness.word
 import com.fwdekker.randomness.CapitalizationMode
 import com.fwdekker.randomness.editorApplyTestFactory
 import com.fwdekker.randomness.editorFieldsTestFactory
+import com.fwdekker.randomness.testhelpers.Tags
 import com.fwdekker.randomness.testhelpers.afterNonContainer
 import com.fwdekker.randomness.testhelpers.beforeNonContainer
 import com.fwdekker.randomness.testhelpers.find
@@ -18,7 +19,6 @@ import com.intellij.openapi.editor.impl.EditorComponentImpl
 import com.intellij.openapi.util.Disposer
 import com.intellij.testFramework.fixtures.IdeaTestFixture
 import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
-import io.kotest.core.NamedTag
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.data.row
 import io.kotest.matchers.collections.shouldContainExactly
@@ -32,7 +32,7 @@ import org.assertj.swing.fixture.FrameFixture
  * Unit tests for [WordSchemeEditor].
  */
 object WordSchemeEditorTest : FunSpec({
-    tags(NamedTag("Editor"), NamedTag("IdeaFixture"), NamedTag("Swing"))
+    tags(Tags.EDITOR, Tags.IDEA_FIXTURE, Tags.SWING)
 
 
     lateinit var ideaFixture: IdeaTestFixture

--- a/src/test/kotlin/com/fwdekker/randomness/word/WordSchemeTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/word/WordSchemeTest.kt
@@ -4,8 +4,8 @@ import com.fwdekker.randomness.CapitalizationMode
 import com.fwdekker.randomness.affix.AffixDecorator
 import com.fwdekker.randomness.array.ArrayDecorator
 import com.fwdekker.randomness.stateDeepCopyTestFactory
+import com.fwdekker.randomness.testhelpers.Tags
 import com.fwdekker.randomness.testhelpers.shouldValidateAsBundle
-import io.kotest.core.NamedTag
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.data.row
 import io.kotest.datatest.withData
@@ -16,7 +16,7 @@ import io.kotest.matchers.shouldBe
  * Unit tests for [WordScheme].
  */
 object WordSchemeTest : FunSpec({
-    tags(NamedTag("Scheme"))
+    tags(Tags.SCHEME)
 
 
     context("generateStrings") {


### PR DESCRIPTION
Fixes #479, fixes #480, sort-of fixes #482, fixes #484.

Just a round-up of smaller improvements.

Additionally fixes a bug (that has no corresponding issue) where retaining the expansion state of the `JTree` fails when adding/removing/moving issues. (So basically, retaining the expansion state was completely broken before.) If it hadn't been fixed in this PR, that issue would've been added to #485.