### PR TITLE
Rewrite CI scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,32 +13,74 @@ on:
       - '.github/img/**'
 
 jobs:
-  build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ ubuntu-latest, windows-latest ]
+  test-linux:
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Java
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17'
-          cache: 'gradle'
-      - name: Run checks (Ubuntu)
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          chmod +x ./gradlew
-          sudo apt install -y xvfb
-          xvfb-run --auto-servernum ./gradlew --no-daemon check
-          ./gradlew --stop
-      - name: Run checks (Windows)
-        if: matrix.os == 'windows-latest'
-        run: |
-          ./gradlew --no-daemon check
-          ./gradlew --stop
-      - uses: codecov/codecov-action@v3
-        if: success() && matrix.os == 'ubuntu-latest'
+      - name: Set up Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          generate-job-summary: false
+      - name: Run tests
+        run: xvfb-run --auto-servernum ./gradlew check
+      - name: Store coverage report
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage
+          path: build/reports/kover/report.xml
+
+  test-macos:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - name: Set up Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          generate-job-summary: false
+      - name: Run tests
+        run: ./gradlew check
+
+  test-windows:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - name: Set up Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          generate-job-summary: false
+      - name: Run tests
+        run: ./gradlew check
+
+  upload-coverage:
+    needs: [ test-linux, test-macos, test-windows ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Load coverage report
+        uses: actions/download-artifact@v3
+        with:
+          name: coverage
+      - name: Upload coverage report
+        uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: true
-          files: build/reports/kover/report.xml
+          files: report.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## Unreleased
+(empty)
+
+
 ## 3.0.0 -- 2023-11-17
 This release brings a major overhaul of how data is generated, allowing you to create your own data types such as IP
 addresses or entire JSON objects.


### PR DESCRIPTION
Fixes #502.

Adds tests on macOS, upgrades various actions, uses new actions where appropriate, and uploads coverage only once all tests have passed.