### PR TITLE
Modern Dokka

### DIFF
--- a/.config/dokka/logo-icon.svg
+++ b/.config/dokka/logo-icon.svg
@@ -1,0 +1,1 @@
+../../src/main/resources/icons/randomness.svg

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,8 +1,19 @@
 # Security policy
+The security of Randomness is important to me.
+If you find a vulnerability in Randomness, please
+[report the vulnerability](https://github.com/FWDekker/mommy/security/advisories/new) as soon as possible.
+
+Please note that Randomness is distinct from IntelliJ and other IDEs developed by JetBrains.
+To report a vulnerability in IntelliJ or another JetBrains product, please
+[check JetBrains' security policy](https://www.jetbrains.com/privacy-security/).
+
 ## Supported versions
-Only the [latest version](https://github.com/FWDekker/intellij-randomness/releases/latest) is ever supported and
-supplied with security patches.
+Only the [latest version of Randomness](https://github.com/FWDekker/intellij-randomness/releases/latest) is ever
+supported and supplied with security patches.
 
 ## Reporting a vulnerability
-To report a security vulnerability, email `security@fwdekker.com` instead of using the issue tracker.
+To report a vulnerability in Randomness, please use
+[GitHub's vulnerability reporting feature](https://github.com/FWDekker/mommy/security/advisories/new).
 You will be contacted as soon as possible.
+You will be thanked publicly for reporting the vulnerability, unless you indicate that you prefer to be thanked
+anonymously.

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,59 @@
+name: CD
+
+on:
+  release:
+    types: [ published ]
+  workflow_dispatch:
+
+jobs:
+  build-pages:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Randomness source code
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          path: main
+      - name: Checkout Randomness pages
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: gh-pages
+          # Required to push updated documentation to repository
+          token: ${{ secrets.personal_access_token }}
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - name: Set up Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          build-root-directory: main/
+          generate-job-summary: false
+
+      - name: Extract version number
+        working-directory: main/
+        run: echo "RANDOMNESS_VERSION=v$(cat gradle.properties | grep '^version=' | sed 's/^.*=//')" >> $GITHUB_ENV
+
+      - name: Generate new documentation
+        working-directory: main/
+        run: ./gradlew dokkaHtml -Pdokka.pagesDir="${{ github.workspace }}/gh-pages/"
+
+      - name: Move new documentation into gh-pages
+        run: |
+          rm -rf gh-pages/*
+          mv main/build/dokka/html/* gh-pages/
+          rm -rf gh-pages/older/**/.git
+
+      - name: Push new documentation
+        working-directory: gh-pages/
+        run: |
+          git config --global user.name "FWDekkerBot"
+          git config --global user.email "bot@fwdekker.com"
+          git add --all
+          git commit -m "Update for ${RANDOMNESS_VERSION}"
+
+          git push origin gh-pages

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 group=com.fwdekker
 # Version number should also be updated in `com.fwdekker.randomness.PersistentSettings.Companion.CURRENT_VERSION`.
-version=3.0.0
+version=3.0.0-next
 
 # Compatibility
 # * `pluginSinceBuild`:
@@ -30,10 +30,12 @@ kotlinApiVersion=1.7
 
 # Dependencies
 # * Detekt should also be updated in `plugins` block.
-# * RgxGen should also be updated in `StringSchemeEditor` link.
+# * Dokka should also be updated in `plugins` block and in `buildscript { dependencies`.
+# * RgxGen should also be updated in `string.ui.value.pattern_help_url` property in `randomness.properties`.
 assertjSwingVersion=3.17.1
 dateparserVersion=1.0.11
 detektVersion=1.23.3
+dokkaVersion=1.9.10
 emojiVersion=5.1.1
 junitVersion=5.10.1
 junitRunnerVersion=1.10.1
@@ -48,5 +50,5 @@ org.gradle.configuration-cache=true
 # Kotlin
 kotlin.code.style=official
 kotlin.stdlib.default.dependency=false
-# TODO: Workaround for https://jb.gg/intellij-platform-kotlin-oom, will not be necessary as of Kotlin 1.9.0
+# TODO: Workaround for https://jb.gg/intellij-platform-kotlin-oom, will not be necessary once user IDEs use Kotlin 1.9.0
 kotlin.incremental.useClasspathSnapshot=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-all.zip

--- a/src/main/kotlin/com/fwdekker/randomness/Settings.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/Settings.kt
@@ -126,6 +126,6 @@ class PersistentSettings : PersistentStateComponent<Element> {
         /**
          * The currently-running version of Randomness.
          */
-        const val CURRENT_VERSION: String = "3.0.0" // Synchronize this with the version in `gradle.properties`
+        const val CURRENT_VERSION: String = "3.0.0-next" // Synchronize this with the version in `gradle.properties`
     }
 }


### PR DESCRIPTION
Modernises the Dokka setup:
* Adds a version dropdown menu to switch between versions.
* Adds a workflow that will update the GitHub pages automatically when a new GitHub release is created.
* Adds an icon and favicon to the documentation.
* Fixes a bug where the version number is displayed multiple times in the header.
* Shows documentation for all functions, not just public functions. (I think I've "fixed" this bug multiple times over the years...)

In the process, I also discovered and reported Kotlin/dokka#3398.

Also, rewrites the security policy. The most relevant change here is that vulnerabilities should preferably [be reported through GitHub's reporting system](https://github.com/FWDekker/intellij-randomness/security/advisories/new) instead of mailing it to a private email address. (Though I will still see emails to the old address.)

Also bumps a few dependencies.