### PR TITLE
Bump IDE compatibility and prepare release

### DIFF
--- a/.github/RELEASE_CHECKLIST.md
+++ b/.github/RELEASE_CHECKLIST.md
@@ -22,7 +22,8 @@
          1. "Color Reduction" to 64 colours
          2. "Optimize Transparency" with 2% fuzz
          3. "Lossy GIF" with compression level 30
-* Ensure documentation generates without errors, and push the documentation to the `gh-pages` branch.
+* Ensure documentation generates without errors.
+  After the release, run the `cd.yml` workflow to update the `gh-pages` branch.
 
 ## Verification
 * Run tests and static analysis one more time.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-## Unreleased
+## 3.1.0 -- 2023-12-08
 ### Added
 * Added ability to generate non-matching strings.
   ([#447](https://github.com/FWDekker/intellij-randomness/issues/447))
@@ -7,6 +7,9 @@
 ### Changed
 * When inserting arrays at multiple carets, the number of elements per array is now independently chosen for each array.
   ([#450](https://github.com/FWDekker/intellij-randomness/issues/450))
+
+### Deprecated
+* Minimum IDE version has been increased to 2023.1.
 
 
 ## 3.0.0 -- 2023-11-17

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 group=com.fwdekker
 # Version number should also be updated in `com.fwdekker.randomness.PersistentSettings.Companion.CURRENT_VERSION`.
-version=3.0.0-next
+version=3.1.0
 
 # Compatibility
 # * `pluginSinceBuild`:
@@ -11,9 +11,9 @@ version=3.0.0-next
 # * `pluginVerifierIdeVersions`:
 #     For every supported version minor release, include both the IC and the CL release with the highest patch version
 #     See also https://data.services.jetbrains.com/products?fields=name,releases.version,releases.build&code=IC,CL.
-pluginSinceBuild=223.0
-intellijVersion=2022.3
-pluginVerifierIdeVersions=IC-2022.3.3, IC-2023.1.5, IC-2023.2.5, CL-2022.3.3, CL-2023.1.5, CL-2023.2.2
+pluginSinceBuild=231.0
+intellijVersion=2023.1
+pluginVerifierIdeVersions=IC-2023.1.5, IC-2023.2.5, IC-2023.3, CL-2023.1.5, CL-2023.2.2, CL-2023.3
 
 # Targets
 # * Java:
@@ -25,8 +25,8 @@ pluginVerifierIdeVersions=IC-2022.3.3, IC-2023.1.5, IC-2023.2.5, CL-2022.3.3, CL
 #   * Kotlin version should be bundled stdlib version of oldest supported IntelliJ version. See also
 #     https://plugins.jetbrains.com/docs/intellij/using-kotlin.html#kotlin-standard-library.
 javaVersion=17
-kotlinVersion=1.7
-kotlinApiVersion=1.7
+kotlinVersion=1.8
+kotlinApiVersion=1.8
 
 # Dependencies
 # * Detekt should also be updated in `plugins` block.

--- a/src/main/kotlin/com/fwdekker/randomness/Settings.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/Settings.kt
@@ -126,6 +126,6 @@ class PersistentSettings : PersistentStateComponent<Element> {
         /**
          * The currently-running version of Randomness.
          */
-        const val CURRENT_VERSION: String = "3.0.0-next" // Synchronize this with the version in `gradle.properties`
+        const val CURRENT_VERSION: String = "3.1.0" // Synchronize this with the version in `gradle.properties`
     }
 }

--- a/src/main/kotlin/com/fwdekker/randomness/datetime/DateTimeSchemeEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/datetime/DateTimeSchemeEditor.kt
@@ -12,10 +12,10 @@ import com.fwdekker.randomness.ui.bindDateTimeLongValue
 import com.fwdekker.randomness.ui.toLocalDateTime
 import com.fwdekker.randomness.ui.withFixedWidth
 import com.fwdekker.randomness.ui.withName
+import com.intellij.ui.dsl.builder.AlignX
 import com.intellij.ui.dsl.builder.BottomGap
 import com.intellij.ui.dsl.builder.bindText
 import com.intellij.ui.dsl.builder.panel
-import com.intellij.ui.dsl.gridLayout.HorizontalAlign
 
 
 /**
@@ -61,7 +61,7 @@ class DateTimeSchemeEditor(scheme: DateTimeScheme = DateTimeScheme()) : SchemeEd
         row {
             ArrayDecoratorEditor(scheme.arrayDecorator)
                 .also { decoratorEditors += it }
-                .let { cell(it.rootComponent).horizontalAlign(HorizontalAlign.FILL) }
+                .let { cell(it.rootComponent).align(AlignX.FILL) }
         }
     }
 

--- a/src/main/kotlin/com/fwdekker/randomness/decimal/DecimalSchemeEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/decimal/DecimalSchemeEditor.kt
@@ -22,12 +22,12 @@ import com.fwdekker.randomness.ui.withFilter
 import com.fwdekker.randomness.ui.withFixedWidth
 import com.fwdekker.randomness.ui.withName
 import com.intellij.openapi.ui.ComboBox
+import com.intellij.ui.dsl.builder.AlignX
 import com.intellij.ui.dsl.builder.Cell
 import com.intellij.ui.dsl.builder.bindSelected
 import com.intellij.ui.dsl.builder.bindValue
 import com.intellij.ui.dsl.builder.panel
 import com.intellij.ui.dsl.builder.selected
-import com.intellij.ui.dsl.gridLayout.HorizontalAlign
 import javax.swing.JCheckBox
 
 
@@ -113,7 +113,7 @@ class DecimalSchemeEditor(scheme: DecimalScheme = DecimalScheme()) : SchemeEdito
         row {
             ArrayDecoratorEditor(scheme.arrayDecorator)
                 .also { decoratorEditors += it }
-                .let { cell(it.rootComponent).horizontalAlign(HorizontalAlign.FILL) }
+                .let { cell(it.rootComponent).align(AlignX.FILL) }
         }
     }
 

--- a/src/main/kotlin/com/fwdekker/randomness/integer/IntegerSchemeEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/integer/IntegerSchemeEditor.kt
@@ -25,9 +25,9 @@ import com.fwdekker.randomness.ui.withFilter
 import com.fwdekker.randomness.ui.withFixedWidth
 import com.fwdekker.randomness.ui.withName
 import com.intellij.openapi.ui.ComboBox
+import com.intellij.ui.dsl.builder.AlignX
 import com.intellij.ui.dsl.builder.bindSelected
 import com.intellij.ui.dsl.builder.panel
-import com.intellij.ui.dsl.gridLayout.HorizontalAlign
 import com.intellij.ui.layout.and
 import com.intellij.ui.layout.selected
 import javax.swing.JCheckBox
@@ -107,13 +107,13 @@ class IntegerSchemeEditor(scheme: IntegerScheme = IntegerScheme()) : SchemeEdito
         row {
             FixedLengthDecoratorEditor(scheme.fixedLengthDecorator)
                 .also { decoratorEditors += it }
-                .let { cell(it.rootComponent).horizontalAlign(HorizontalAlign.FILL) }
+                .let { cell(it.rootComponent).align(AlignX.FILL) }
         }
 
         row {
             ArrayDecoratorEditor(scheme.arrayDecorator)
                 .also { decoratorEditors += it }
-                .let { cell(it.rootComponent).horizontalAlign(HorizontalAlign.FILL) }
+                .let { cell(it.rootComponent).align(AlignX.FILL) }
         }
     }
 

--- a/src/main/kotlin/com/fwdekker/randomness/string/StringSchemeEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/string/StringSchemeEditor.kt
@@ -11,13 +11,13 @@ import com.fwdekker.randomness.ui.withFixedWidth
 import com.fwdekker.randomness.ui.withName
 import com.fwdekker.randomness.ui.withSimpleRenderer
 import com.intellij.openapi.ui.ComboBox
+import com.intellij.ui.dsl.builder.AlignX
 import com.intellij.ui.dsl.builder.BottomGap
 import com.intellij.ui.dsl.builder.bindItem
 import com.intellij.ui.dsl.builder.bindSelected
 import com.intellij.ui.dsl.builder.bindText
 import com.intellij.ui.dsl.builder.panel
 import com.intellij.ui.dsl.builder.toNullableProperty
-import com.intellij.ui.dsl.gridLayout.HorizontalAlign
 import com.intellij.ui.layout.selected
 import javax.swing.JCheckBox
 
@@ -75,7 +75,7 @@ class StringSchemeEditor(scheme: StringScheme = StringScheme()) : SchemeEditor<S
         row {
             ArrayDecoratorEditor(scheme.arrayDecorator)
                 .also { decoratorEditors += it }
-                .let { cell(it.rootComponent).horizontalAlign(HorizontalAlign.FILL) }
+                .let { cell(it.rootComponent).align(AlignX.FILL) }
         }
     }
 

--- a/src/main/kotlin/com/fwdekker/randomness/template/TemplateJTree.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/template/TemplateJTree.kt
@@ -25,11 +25,12 @@ import com.intellij.ui.LayeredIcon
 import com.intellij.ui.RowsDnDSupport.RefinedDropSupport.Position
 import com.intellij.ui.SimpleTextAttributes
 import com.intellij.ui.ToolbarDecorator
-import com.intellij.ui.TreeSpeedSearch
+import com.intellij.ui.TreeUIHelper
 import com.intellij.ui.treeStructure.Tree
 import com.intellij.util.ui.JBUI
 import javax.swing.JPanel
 import javax.swing.JTree
+import javax.swing.tree.TreePath
 import javax.swing.tree.TreeSelectionModel
 import kotlin.math.min
 
@@ -139,7 +140,8 @@ class TemplateJTree(
 
 
     init {
-        TreeSpeedSearch(this, true) { path -> path.path.filterIsInstance<Scheme>().joinToString { it.name } }
+        val converter = { path: TreePath -> path.path.filterIsInstance<Scheme>().joinToString { it.name } }
+        TreeUIHelper.getInstance().installTreeSpeedSearch(this, converter, true)
 
         emptyText.text = Bundle("template_list.ui.empty")
         isRootVisible = false

--- a/src/main/kotlin/com/fwdekker/randomness/template/TemplateReferenceEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/template/TemplateReferenceEditor.kt
@@ -12,10 +12,10 @@ import com.fwdekker.randomness.ui.withName
 import com.fwdekker.randomness.ui.withSimpleRenderer
 import com.intellij.openapi.ui.ComboBox
 import com.intellij.ui.ColoredListCellRenderer
+import com.intellij.ui.dsl.builder.AlignX
 import com.intellij.ui.dsl.builder.bindItem
 import com.intellij.ui.dsl.builder.panel
 import com.intellij.ui.dsl.builder.toNullableProperty
-import com.intellij.ui.dsl.gridLayout.HorizontalAlign
 import javax.swing.JList
 
 
@@ -57,7 +57,7 @@ class TemplateReferenceEditor(scheme: TemplateReference) : SchemeEditor<Template
         row {
             ArrayDecoratorEditor(scheme.arrayDecorator)
                 .also { decoratorEditors += it }
-                .let { cell(it.rootComponent).horizontalAlign(HorizontalAlign.FILL) }
+                .let { cell(it.rootComponent).align(AlignX.FILL) }
         }
     }
 

--- a/src/main/kotlin/com/fwdekker/randomness/uuid/UuidSchemeEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/uuid/UuidSchemeEditor.kt
@@ -7,11 +7,11 @@ import com.fwdekker.randomness.array.ArrayDecoratorEditor
 import com.fwdekker.randomness.ui.loadMnemonic
 import com.fwdekker.randomness.ui.withName
 import com.fwdekker.randomness.uuid.UuidScheme.Companion.PRESET_AFFIX_DECORATOR_DESCRIPTORS
+import com.intellij.ui.dsl.builder.AlignX
 import com.intellij.ui.dsl.builder.BottomGap
 import com.intellij.ui.dsl.builder.bind
 import com.intellij.ui.dsl.builder.bindSelected
 import com.intellij.ui.dsl.builder.panel
-import com.intellij.ui.dsl.gridLayout.HorizontalAlign
 
 
 /**
@@ -55,7 +55,7 @@ class UuidSchemeEditor(scheme: UuidScheme = UuidScheme()) : SchemeEditor<UuidSch
         row {
             ArrayDecoratorEditor(scheme.arrayDecorator)
                 .also { decoratorEditors += it }
-                .let { cell(it.rootComponent).horizontalAlign(HorizontalAlign.FILL) }
+                .let { cell(it.rootComponent).align(AlignX.FILL) }
         }
     }
 

--- a/src/main/kotlin/com/fwdekker/randomness/word/WordSchemeEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/word/WordSchemeEditor.kt
@@ -23,11 +23,11 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.EditorFactory
 import com.intellij.openapi.ui.ComboBox
 import com.intellij.openapi.util.Disposer
+import com.intellij.ui.dsl.builder.AlignX
 import com.intellij.ui.dsl.builder.bindItem
 import com.intellij.ui.dsl.builder.panel
 import com.intellij.ui.dsl.builder.toMutableProperty
 import com.intellij.ui.dsl.builder.toNullableProperty
-import com.intellij.ui.dsl.gridLayout.HorizontalAlign
 import java.awt.event.ItemEvent
 
 
@@ -75,7 +75,7 @@ class WordSchemeEditor(scheme: WordScheme = WordScheme()) : SchemeEditor<WordSch
                 Disposer.register(this@WordSchemeEditor, factory.wrapDisposable(wordListEditor))
                 cell(wordListEditor.component)
                     .onReset { document.resetUndoHistory() }
-                    .horizontalAlign(HorizontalAlign.FILL)
+                    .align(AlignX.FILL)
                     .withFixedHeight(UIConstants.SIZE_VERY_LARGE)
                     .bind(
                         { document.getWordList() },
@@ -103,7 +103,7 @@ class WordSchemeEditor(scheme: WordScheme = WordScheme()) : SchemeEditor<WordSch
         row {
             ArrayDecoratorEditor(scheme.arrayDecorator)
                 .also { decoratorEditors += it }
-                .let { cell(it.rootComponent).horizontalAlign(HorizontalAlign.FILL) }
+                .let { cell(it.rootComponent).align(AlignX.FILL) }
         }
     }
 

--- a/src/test/kotlin/com/fwdekker/randomness/IconsTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/IconsTest.kt
@@ -41,8 +41,12 @@ object TypeIconTest : FunSpec({
         lateinit var image: BufferedImage
 
 
-        beforeContainer {
+        beforeSpec {
             FailOnThreadViolationRepaintManager.install()
+        }
+
+        afterSpec {
+            FailOnThreadViolationRepaintManager.uninstall()
         }
 
         beforeNonContainer {
@@ -139,8 +143,12 @@ object OverlayIconTest : FunSpec({
         lateinit var image: BufferedImage
 
 
-        beforeContainer {
+        beforeSpec {
             FailOnThreadViolationRepaintManager.install()
+        }
+
+        afterSpec {
+            FailOnThreadViolationRepaintManager.uninstall()
         }
 
         beforeNonContainer {

--- a/src/test/kotlin/com/fwdekker/randomness/SchemeEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/SchemeEditorTest.kt
@@ -41,8 +41,12 @@ object SchemeEditorTest : FunSpec({
     lateinit var editor: DummySchemeEditor
 
 
-    beforeContainer {
+    beforeSpec {
         FailOnThreadViolationRepaintManager.install()
+    }
+
+    afterSpec {
+        FailOnThreadViolationRepaintManager.uninstall()
     }
 
     beforeNonContainer {

--- a/src/test/kotlin/com/fwdekker/randomness/affix/AffixDecoratorEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/affix/AffixDecoratorEditorTest.kt
@@ -39,8 +39,12 @@ object AffixDecoratorEditorTest : FunSpec({
     lateinit var editor: AffixDecoratorEditor
 
 
-    beforeContainer {
+    beforeSpec {
         FailOnThreadViolationRepaintManager.install()
+    }
+
+    afterSpec {
+        FailOnThreadViolationRepaintManager.uninstall()
     }
 
     beforeNonContainer {

--- a/src/test/kotlin/com/fwdekker/randomness/array/ArrayDecoratorEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/array/ArrayDecoratorEditorTest.kt
@@ -39,8 +39,12 @@ object ArrayDecoratorEditorTest : FunSpec({
     lateinit var editor: ArrayDecoratorEditor
 
 
-    beforeContainer {
+    beforeSpec {
         FailOnThreadViolationRepaintManager.install()
+    }
+
+    afterSpec {
+        FailOnThreadViolationRepaintManager.uninstall()
     }
 
     beforeNonContainer {

--- a/src/test/kotlin/com/fwdekker/randomness/datetime/DateTimeSchemeEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/datetime/DateTimeSchemeEditorTest.kt
@@ -34,8 +34,12 @@ object DateTimeSchemeEditorTest : FunSpec({
     lateinit var editor: DateTimeSchemeEditor
 
 
-    beforeContainer {
+    beforeSpec {
         FailOnThreadViolationRepaintManager.install()
+    }
+
+    afterSpec {
+        FailOnThreadViolationRepaintManager.uninstall()
     }
 
     beforeNonContainer {

--- a/src/test/kotlin/com/fwdekker/randomness/decimal/DecimalSchemeEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/decimal/DecimalSchemeEditorTest.kt
@@ -34,8 +34,12 @@ object DecimalSchemeEditorTest : FunSpec({
     lateinit var editor: DecimalSchemeEditor
 
 
-    beforeContainer {
+    beforeSpec {
         FailOnThreadViolationRepaintManager.install()
+    }
+
+    afterSpec {
+        FailOnThreadViolationRepaintManager.uninstall()
     }
 
     beforeNonContainer {

--- a/src/test/kotlin/com/fwdekker/randomness/fixedlength/FixedLengthDecoratorEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/fixedlength/FixedLengthDecoratorEditorTest.kt
@@ -34,8 +34,12 @@ object FixedLengthDecoratorEditorTest : FunSpec({
     lateinit var editor: FixedLengthDecoratorEditor
 
 
-    beforeContainer {
+    beforeSpec {
         FailOnThreadViolationRepaintManager.install()
+    }
+
+    afterSpec {
+        FailOnThreadViolationRepaintManager.uninstall()
     }
 
     beforeNonContainer {

--- a/src/test/kotlin/com/fwdekker/randomness/integer/IntegerSchemeEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/integer/IntegerSchemeEditorTest.kt
@@ -36,8 +36,12 @@ object IntegerSchemeEditorTest : FunSpec({
     lateinit var editor: IntegerSchemeEditor
 
 
-    beforeContainer {
+    beforeSpec {
         FailOnThreadViolationRepaintManager.install()
+    }
+
+    afterSpec {
+        FailOnThreadViolationRepaintManager.uninstall()
     }
 
     beforeNonContainer {

--- a/src/test/kotlin/com/fwdekker/randomness/string/StringSchemeEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/string/StringSchemeEditorTest.kt
@@ -35,8 +35,12 @@ object StringSchemeEditorTest : FunSpec({
     lateinit var editor: StringSchemeEditor
 
 
-    beforeContainer {
+    beforeSpec {
         FailOnThreadViolationRepaintManager.install()
+    }
+
+    afterSpec {
+        FailOnThreadViolationRepaintManager.uninstall()
     }
 
     beforeNonContainer {

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateEditorTest.kt
@@ -28,8 +28,12 @@ object TemplateEditorTest : FunSpec({
     lateinit var editor: TemplateEditor
 
 
-    beforeContainer {
+    beforeSpec {
         FailOnThreadViolationRepaintManager.install()
+    }
+
+    afterSpec {
+        FailOnThreadViolationRepaintManager.uninstall()
     }
 
     beforeNonContainer {

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateJTreeTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateJTreeTest.kt
@@ -52,8 +52,12 @@ object TemplateJTreeTest : FunSpec({
     fun List<Scheme>.names() = this.map { it.name }
 
 
-    beforeContainer {
+    beforeSpec {
         FailOnThreadViolationRepaintManager.install()
+    }
+
+    afterSpec {
+        FailOnThreadViolationRepaintManager.uninstall()
     }
 
     beforeNonContainer {

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateListConfigurableTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateListConfigurableTest.kt
@@ -34,9 +34,14 @@ object TemplateListConfigurableTest : FunSpec({
     lateinit var configurable: TemplateListConfigurable
 
 
-    beforeContainer {
+    beforeSpec {
         FailOnThreadViolationRepaintManager.install()
         TemplateListEditor.useTestSplitter = true
+    }
+
+    afterSpec {
+        TemplateListEditor.useTestSplitter = false
+        FailOnThreadViolationRepaintManager.uninstall()
     }
 
     beforeNonContainer {

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateListEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateListEditorTest.kt
@@ -50,9 +50,14 @@ object TemplateListEditorTest : FunSpec({
     lateinit var editor: TemplateListEditor
 
 
-    beforeContainer {
-        FailOnThreadViolationRepaintManager.install()
+    beforeSpec {
         TemplateListEditor.useTestSplitter = true
+        FailOnThreadViolationRepaintManager.install()
+    }
+
+    afterSpec {
+        FailOnThreadViolationRepaintManager.uninstall()
+        TemplateListEditor.useTestSplitter = false
     }
 
     beforeNonContainer {

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateReferenceEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateReferenceEditorTest.kt
@@ -41,8 +41,12 @@ object TemplateReferenceEditorTest : FunSpec({
     lateinit var editor: TemplateReferenceEditor
 
 
-    beforeContainer {
+    beforeSpec {
         FailOnThreadViolationRepaintManager.install()
+    }
+
+    afterSpec {
+        FailOnThreadViolationRepaintManager.uninstall()
     }
 
     beforeNonContainer {

--- a/src/test/kotlin/com/fwdekker/randomness/ui/JDateTimeFieldTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/ui/JDateTimeFieldTest.kt
@@ -26,8 +26,12 @@ object JDateTimeFieldTest : FunSpec({
     lateinit var field: JDateTimeField
 
 
-    beforeContainer {
+    beforeSpec {
         FailOnThreadViolationRepaintManager.install()
+    }
+
+    afterSpec {
+        FailOnThreadViolationRepaintManager.uninstall()
     }
 
     beforeNonContainer {

--- a/src/test/kotlin/com/fwdekker/randomness/ui/JNumberSpinnerTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/ui/JNumberSpinnerTest.kt
@@ -19,8 +19,12 @@ object JNumberSpinnerTest : FunSpec({
     tags(Tags.SWING)
 
 
-    beforeContainer {
+    beforeSpec {
         FailOnThreadViolationRepaintManager.install()
+    }
+
+    afterSpec {
+        FailOnThreadViolationRepaintManager.uninstall()
     }
 
 
@@ -62,8 +66,12 @@ object BindSpinnersTest : FunSpec({
     tags(Tags.SWING)
 
 
-    beforeContainer {
+    beforeSpec {
         FailOnThreadViolationRepaintManager.install()
+    }
+
+    afterSpec {
+        FailOnThreadViolationRepaintManager.uninstall()
     }
 
 
@@ -107,8 +115,12 @@ object JDoubleSpinnerTest : FunSpec({
     tags(Tags.SWING)
 
 
-    beforeContainer {
+    beforeSpec {
         FailOnThreadViolationRepaintManager.install()
+    }
+
+    afterSpec {
+        FailOnThreadViolationRepaintManager.uninstall()
     }
 
 
@@ -160,8 +172,12 @@ object JLongSpinnerTest : FunSpec({
     tags(Tags.SWING)
 
 
-    beforeContainer {
+    beforeSpec {
         FailOnThreadViolationRepaintManager.install()
+    }
+
+    afterSpec {
+        FailOnThreadViolationRepaintManager.uninstall()
     }
 
 
@@ -213,8 +229,12 @@ object JIntSpinnerTest : FunSpec({
     tags(Tags.SWING)
 
 
-    beforeContainer {
+    beforeSpec {
         FailOnThreadViolationRepaintManager.install()
+    }
+
+    afterSpec {
+        FailOnThreadViolationRepaintManager.uninstall()
     }
 
 

--- a/src/test/kotlin/com/fwdekker/randomness/ui/ListenerHelpersTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/ui/ListenerHelpersTest.kt
@@ -37,8 +37,12 @@ object ListenerHelpersTest : FunSpec({
     val listener = { listenerInvoked = true }
 
 
-    beforeContainer {
+    beforeSpec {
         FailOnThreadViolationRepaintManager.install()
+    }
+
+    afterSpec {
+        FailOnThreadViolationRepaintManager.uninstall()
     }
 
     beforeNonContainer {

--- a/src/test/kotlin/com/fwdekker/randomness/ui/PreviewPanelTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/ui/PreviewPanelTest.kt
@@ -36,8 +36,12 @@ object PreviewPanelTest : FunSpec({
     val placeholder = Bundle("preview.placeholder")
 
 
-    beforeContainer {
+    beforeSpec {
         FailOnThreadViolationRepaintManager.install()
+    }
+
+    afterSpec {
+        FailOnThreadViolationRepaintManager.uninstall()
     }
 
     beforeNonContainer {

--- a/src/test/kotlin/com/fwdekker/randomness/uuid/UuidSchemeEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/uuid/UuidSchemeEditorTest.kt
@@ -34,8 +34,12 @@ object UuidSchemeEditorTest : FunSpec({
     lateinit var editor: UuidSchemeEditor
 
 
-    beforeContainer {
+    beforeSpec {
         FailOnThreadViolationRepaintManager.install()
+    }
+
+    afterSpec {
+        FailOnThreadViolationRepaintManager.uninstall()
     }
 
     beforeNonContainer {

--- a/src/test/kotlin/com/fwdekker/randomness/word/WordSchemeEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/word/WordSchemeEditorTest.kt
@@ -43,8 +43,12 @@ object WordSchemeEditorTest : FunSpec({
     lateinit var wordsEditor: EditorComponentImpl
 
 
-    beforeContainer {
+    beforeSpec {
         FailOnThreadViolationRepaintManager.install()
+    }
+
+    afterSpec {
+        FailOnThreadViolationRepaintManager.uninstall()
     }
 
     beforeNonContainer {


### PR DESCRIPTION
Ready for releasing v3.1.0!

Bumps compatibility to 231 and newer, updates a few deprecated API usages (excluding one that is unfixable due to [IJSDK-1898](https://youtrack.jetbrains.com/issue/IJSDK-1898/Signature-of-IconLoader.filterIcon-is-marked-as-internal)), and fixes a few minor issues in docs and in tests (such as correctly uninstalling the thread-violation manager, and uninstalling only at the end of the very class).