### PR TITLE
Clean Dokka output with Gradle task

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -46,7 +46,6 @@ jobs:
         run: |
           rm -rf gh-pages/*
           mv main/build/dokka/html/* gh-pages/
-          rm -rf gh-pages/older/**/.git
 
       - name: Push new documentation
         working-directory: gh-pages/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+
 import io.gitlab.arturbosch.detekt.Detekt
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
@@ -199,3 +200,21 @@ tasks {
         }
     }
 }
+
+// TODO: Remove this workaround for https://github.com/Kotlin/dokka/issues/3398 once it's fixed
+abstract class DokkaHtmlPost : DefaultTask() {
+    private val buildDir = project.layout.buildDirectory
+
+    @TaskAction
+    fun strip() {
+        buildDir.dir("dokka/html/").get().asFile
+            .walk()
+            .filter { it.isDirectory && it.name.startsWith('.') }
+            .forEach { it.deleteRecursively() }
+
+        buildDir.dir("dokka/html/").get().asFileTree
+            .forEach { file -> file.writeText(file.readText().dropLastWhile { it == '\n' } + '\n') }
+    }
+}
+tasks.register<DokkaHtmlPost>("dokkaHtmlPost")
+tasks.dokkaHtml { finalizedBy("dokkaHtmlPost") }


### PR DESCRIPTION
Provides a workaround for Kotlin/dokka#3398 by adding a finalizing task to `dokkaHtml` that (1) removes excessive newlines, and (2) removes `.git` and `.idea` directories which are copied by Dokka.