### PR TITLE
Disable dynamic plugin reloading

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,4 +1,4 @@
-<idea-plugin>
+<idea-plugin require-restart="true">
     <id>com.fwdekker.randomness</id>
     <name>Randomness</name>
     <vendor email="florine@fwdekker.com" url="https://fwdekker.com/">FWDekker</vendor>


### PR DESCRIPTION
Instead of fixing #520, this just disables the dynamic reloading feature.

I spent more than 6 hours trying to find out why dynamic reloading didn't work, found a bunch of supposed memory leaks, and then found extremely insufficient documentation on JetBrains' end on alternative design patterns to avoid those leaks. (Apparently every single `Companion` object was still referenced by the classloader. How am I supposed to avoid _that_?)

It's not worth my time. By explicitly disabling dynamic reloading, at least users won't see their IDE trying and failing to dynamically reload the plugin.