### PR TITLE
Fix exception for string patterns such as `[]{1,3}`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## [9.9.9-unreleased]
+### Fixed
+* Fixed an exception when a `StringScheme` contains a matching pattern containing `[]{1,3}`. ([#R2](https://github.com/FWDekkerBot/intellij-randomness-issues/issues/2))
+
+
 ## 3.3.0 -- 2024-04-16
 ### Added
 * Added support for [character classes](https://www.regular-expressions.info/unicode.html#category) (e.g. `\p{Letter}`) in strings by updating [RgxGen](https://github.com/curious-odd-man/RgxGen) to v2.0. ([#530](https://github.com/FWDekker/intellij-randomness/issues/530))

--- a/src/main/kotlin/com/fwdekker/randomness/string/StringScheme.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/string/StringScheme.kt
@@ -78,8 +78,8 @@ data class StringScheme(
             else ->
                 @Suppress("detekt:TooGenericExceptionCaught") // Consequence of incomplete validation in RgxGen
                 try {
-                    if (this.isNonMatching) RgxGen.parse(pattern).generate()
-                    else RgxGen.parse(pattern).generateNotMatching()
+                    if (this.isNonMatching) RgxGen.parse(pattern).generateNotMatching()
+                    else RgxGen.parse(pattern).generate()
 
                     arrayDecorator.doValidate()
                 } catch (exception: RgxGenParseException) {

--- a/src/test/kotlin/com/fwdekker/randomness/string/StringSchemeTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/string/StringSchemeTest.kt
@@ -96,6 +96,8 @@ object StringSchemeTest : FunSpec({
                     row(StringScheme(pattern = "[]"), "string.error.empty_square"),
                 "fails if pattern has empty square braces" to
                     row(StringScheme(pattern = "a[]b"), "string.error.empty_square"),
+                "fails if pattern has empty square braces 2" to
+                    row(StringScheme(pattern = "[]{1,3}"), ""),
                 "succeeds if empty square braces are escaped" to
                     row(StringScheme(pattern = """\[]"""), null),
                 "fails if pattern has single trailing backslash" to


### PR DESCRIPTION
Fixes FWDekkerBot/intellij-randomness-issues#2.