### PR TITLE
[2025.1+] Invoke delegated actions using built-in method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## 9.9.9-unreleased
+### Fixed
+* Change delegate action invocations to use built-in utility method instead.
+
+
 ## 3.3.3 -- 2024-10-16
 ### Changed
 * In template icons, change the order of scheme colors to be clockwise starting from the top, instead of counterclockwise starting on the right.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,7 +69,10 @@ dependencies {
     dokkaHtmlPlugin("org.jetbrains.dokka", "versioning-plugin", properties("dokkaVersion"))
 
     intellijPlatform {
-        intellijIdeaCommunity(properties("intellijVersion"))
+        intellijIdeaCommunity(
+            properties("intellijVersion"),
+            useInstaller = !properties("intellijVersion").endsWith("EAP-SNAPSHOT")
+        )
 
         pluginVerifier()
         zipSigner()

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,6 +8,7 @@ version=3.3.3
 #     2019.4 (aka 2020.1).
 # * `intellijVersion`:
 #     Use the oldest supported version, because that's what the plugin will be compiled against.
+#     If you want to test the EAP version of, say, IntelliJ 2024.3, use version number `243-EAP-SNAPSHOT`.
 # * `pluginVerifierIdeVersions`:
 #     For every supported version minor release, include both the IC and the CL release with the highest patch version
 #     See also https://data.services.jetbrains.com/products?fields=name,releases.version,releases.build&code=IC,CL.

--- a/src/main/kotlin/com/fwdekker/randomness/template/TemplateActions.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/template/TemplateActions.kt
@@ -11,6 +11,7 @@ import com.fwdekker.randomness.ui.PreviewPanel
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.actionSystem.ActionGroup
 import com.intellij.openapi.actionSystem.ActionUpdateThread
+import com.intellij.openapi.actionSystem.ActionWrapperUtil
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.options.Configurable
@@ -63,11 +64,15 @@ class TemplateGroupAction(private val template: Template) :
      * @param event carries contextual information
      */
     override fun actionPerformed(event: AnActionEvent) =
-        getActionByModifier(
-            array = event.inputEvent?.isShiftDown ?: false,
-            repeat = event.inputEvent?.isAltDown ?: false,
-            settings = event.inputEvent?.isControlDown ?: false
-        ).actionPerformed(event)
+        ActionWrapperUtil.actionPerformed(
+            event,
+            this,
+            getActionByModifier(
+                array = event.inputEvent?.isShiftDown ?: false,
+                repeat = event.inputEvent?.isAltDown ?: false,
+                settings = event.inputEvent?.isControlDown ?: false
+            )
+        )
 
     /**
      * Returns variant actions for the main insertion action.


### PR DESCRIPTION
The compatibility checker noticed that I was doing it wrong in 2024.3, and presumably therefore also in older versions.

However, the solution (using `ActionWrapperUtil`) will only be available as of 2024.2. Therefore, this PR can be accepted as of 2025.1, which will be around April 2025.