### PR TITLE
Fix and verify property transience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## 3.3.5 -- 2025-TODO-TODO
+TODO
+
+
 ## 3.3.4 -- 2025-01-17
 ### Changed
 * Refreshed (encrypted) bug reporter token. ([#548](https://github.com/FWDekker/intellij-randomness/issues/548))

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 group=com.fwdekker
 # Version number should also be updated in `com.fwdekker.randomness.PersistentSettings.Companion.CURRENT_VERSION`.
-version=3.3.4
+version=3.3.5
 
 # Compatibility
 # * `pluginSinceBuild`:

--- a/src/main/kotlin/com/fwdekker/randomness/CapitalizationMode.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/CapitalizationMode.kt
@@ -1,6 +1,5 @@
 package com.fwdekker.randomness
 
-import java.util.Locale
 import kotlin.random.Random
 
 
@@ -23,12 +22,12 @@ enum class CapitalizationMode(val transform: (String, Random) -> String) {
     /**
      * Makes all characters uppercase.
      */
-    UPPER({ string, _ -> string.uppercase(Locale.getDefault()) }),
+    UPPER({ string, _ -> string.uppercase() }),
 
     /**
      * Makes all characters lowercase.
      */
-    LOWER({ string, _ -> string.lowercase(Locale.getDefault()) }),
+    LOWER({ string, _ -> string.lowercase() }),
 
     /**
      * Makes the first letter of each word uppercase.
@@ -45,20 +44,35 @@ enum class CapitalizationMode(val transform: (String, Random) -> String) {
     /**
      * Returns the localized string name of this mode.
      */
-    fun toLocalizedString() =
-        Bundle("shared.capitalization.${toString().replace(' ', '_').lowercase(Locale.getDefault())}")
+    fun toLocalizedString() = Bundle("shared.capitalization.${toString().replace(' ', '_').lowercase()}")
 }
 
 
 /**
- * Randomly converts this character to uppercase or lowercase using [random] as a source of randomness.
+ * @see CapitalizationMode.RANDOM
  */
 private fun Char.toRandomCase(random: Random) =
-    if (random.nextBoolean()) this.lowercaseChar()
-    else this.uppercaseChar()
+    if (random.nextBoolean()) lowercaseChar()
+    else uppercaseChar()
 
 /**
- * Turns the first character uppercase while all other characters become lowercase.
+ * @see CapitalizationMode.SENTENCE
  */
-private fun String.toSentenceCase() =
-    this.lowercase(Locale.getDefault()).replaceFirstChar { it.uppercaseChar() }
+private fun String.toSentenceCase() = lowercase().replaceFirstChar { it.uppercaseChar() }
+
+/**
+ * Turns the first character lowercase while all other characters remain unchanged.
+ */
+fun String.lowerCaseFirst() = take(1).lowercase() + drop(1)
+
+/**
+ * Turns the first character uppercase while all other characters remain unchanged.
+ */
+fun String.upperCaseFirst() = take(1).uppercase() + drop(1)
+
+/**
+ * Appends [other], ensuring the resulting string is in camel case as long as [this] and [other] are also in camel case.
+ */
+fun String.camelPlus(other: String) =
+    if (this == "") other
+    else this + other.upperCaseFirst()

--- a/src/main/kotlin/com/fwdekker/randomness/ListHelpers.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/ListHelpers.kt
@@ -2,6 +2,12 @@ package com.fwdekker.randomness
 
 
 /**
+ * Returns the [index]th element of [this], wrapping around circularly so that index `-1` is equivalent to
+ * `this.size - 1`.
+ */
+fun <E> List<E>.getMod(index: Int): E = this[(index % size + size) % size]
+
+/**
  * Removes all elements from this collection and adds all elements from [collection].
  */
 fun <E> MutableCollection<E>.setAll(collection: Collection<E>) {

--- a/src/main/kotlin/com/fwdekker/randomness/PopupAction.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/PopupAction.kt
@@ -12,7 +12,6 @@ import com.intellij.openapi.ui.popup.JBPopupFactory
 import com.intellij.ui.popup.list.ListPopupImpl
 import java.awt.event.ActionEvent
 import java.awt.event.KeyEvent
-import java.util.Locale
 import javax.swing.AbstractAction
 import javax.swing.KeyStroke
 
@@ -190,12 +189,12 @@ fun ListPopupImpl.registerModifierActions(captionModifier: (ActionEvent?) -> Str
     (modifiers * optionalModifiers * optionalModifiers).forEach { (a, b, c) ->
         registerAction(
             "${a}${b}${c}Released",
-            KeyStroke.getKeyStroke("$b $c released ${a.uppercase(Locale.getDefault())}"),
+            KeyStroke.getKeyStroke("$b $c released ${a.uppercase()}"),
             SimpleAbstractAction { setCaption(captionModifier(it)) }
         )
         registerAction(
             "${a}${b}${c}Pressed",
-            KeyStroke.getKeyStroke("$a $b $c pressed ${a.uppercase(Locale.getDefault())}"),
+            KeyStroke.getKeyStroke("$a $b $c pressed ${a.uppercase()}"),
             SimpleAbstractAction { setCaption(captionModifier(it)) }
         )
         registerAction(

--- a/src/main/kotlin/com/fwdekker/randomness/Scheme.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/Scheme.kt
@@ -19,13 +19,11 @@ abstract class Scheme : State() {
      * The icon signifying the type of data represented by this scheme, ignoring its [decorators], or `null` if this
      * scheme does not represent any kind of data, as is the case for [DecoratorScheme]s.
      */
-    @get:Transient
     open val typeIcon: TypeIcon? = null
 
     /**
      * The icon signifying this scheme in its entirety, or `null` if it does not have an icon.
      */
-    @get:Transient
     open val icon: OverlayedIcon? get() = typeIcon?.let { OverlayedIcon(it, decorators.mapNotNull(Scheme::icon)) }
 
     /**
@@ -41,7 +39,6 @@ abstract class Scheme : State() {
      * [com.intellij.util.xmlb.annotations.OptionTag]. This way, the deserializer knows that the field is not transient
      * despite not being a mutable field.
      */
-    @get:Transient
     abstract val decorators: List<DecoratorScheme>
 
     /**
@@ -102,11 +99,13 @@ abstract class DecoratorScheme : Scheme() {
      * Whether this decorator is enabled, or whether any invocation of [generateStrings] should be passed directly to
      * the [generator].
      */
+    @get:Transient
     protected open val isEnabled: Boolean = true
 
     /**
      * The generating function whose output should be decorated.
      */
+    @field:Transient
     @get:Transient
     lateinit var generator: (Int) -> List<String>
 

--- a/src/main/kotlin/com/fwdekker/randomness/Settings.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/Settings.kt
@@ -7,9 +7,9 @@ import com.intellij.openapi.components.PersistentStateComponent
 import com.intellij.openapi.components.SettingsCategory
 import com.intellij.openapi.components.Storage
 import com.intellij.openapi.components.service
-import com.intellij.util.xmlb.XmlSerializer
+import com.intellij.util.xmlb.XmlSerializer.deserialize
+import com.intellij.util.xmlb.XmlSerializer.serialize
 import com.intellij.util.xmlb.annotations.OptionTag
-import com.intellij.util.xmlb.annotations.Transient
 import org.jdom.Element
 import java.lang.module.ModuleDescriptor.Version
 import com.intellij.openapi.components.State as JBState
@@ -29,7 +29,6 @@ data class Settings(
     /**
      * @see TemplateList.templates
      */
-    @get:Transient
     val templates: MutableList<Template> get() = templateList.templates
 
 
@@ -89,13 +88,13 @@ internal class PersistentSettings : PersistentStateComponent<Element> {
     /**
      * Returns the [settings] as an [Element].
      */
-    override fun getState(): Element = XmlSerializer.serialize(settings)
+    override fun getState(): Element = serialize(settings)
 
     /**
      * Deserializes [element] into a [Settings] instance, which is then stored in [settings].
      */
     override fun loadState(element: Element) {
-        settings = XmlSerializer.deserialize(upgrade(element), Settings::class.java)
+        settings = deserialize(upgrade(element), Settings::class.java)
     }
 
 

--- a/src/main/kotlin/com/fwdekker/randomness/Settings.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/Settings.kt
@@ -99,19 +99,24 @@ internal class PersistentSettings : PersistentStateComponent<Element> {
 
 
     /**
-     * Silently upgrades the format of the settings contained in [element] to the format of the latest version.
+     * Upgrades the format of the settings contained in [element] to the format of the [targetVersion].
+     *
+     * @see UPGRADES
      */
-    private fun upgrade(element: Element): Element {
+    internal fun upgrade(element: Element, targetVersion: Version = Version.parse(CURRENT_VERSION)): Element {
+        require(targetVersion >= Version.parse("3.0.0")) { "Unsupported upgrade target version $targetVersion." }
+
         val elementVersion = element.getPropertyValue("version")?.let { Version.parse(it) }
+        requireNotNull(elementVersion) { "Missing version number in Randomness settings." }
+        require(elementVersion >= Version.parse("3.0.0")) { "Unsupported Randomness config version $elementVersion." }
 
-        when {
-            elementVersion == null -> Unit
-            elementVersion < Version.parse("3.0.0") -> error("Unsupported Randomness config version $elementVersion.")
-            elementVersion < Version.parse("3.2.0") ->
-                element.getSchemes().filter { it.name == "UuidScheme" }.forEach { it.renameProperty("type", "version") }
-        }
+        if (targetVersion <= elementVersion) return element
 
-        element.setPropertyValue("version", CURRENT_VERSION)
+        UPGRADES
+            .filterKeys { elementVersion < it && targetVersion >= it }
+            .forEach { (_, it) -> it(element) }
+
+        element.setPropertyValue("version", targetVersion.toString())
         return element
     }
 
@@ -123,6 +128,21 @@ internal class PersistentSettings : PersistentStateComponent<Element> {
         /**
          * The currently-running version of Randomness.
          */
-        const val CURRENT_VERSION: String = "3.3.4" // Synchronize this with the version in `gradle.properties`
+        const val CURRENT_VERSION: String = "3.3.5" // Synchronize this with the version in `gradle.properties`
+
+        /**
+         * The upgrade functions to apply to configuration [Element]s in the [upgrade] method.
+         */
+        private val UPGRADES: Map<Version, (Element) -> Unit> =
+            mapOf(
+                Version.parse("3.2.0") to
+                    { e: Element ->
+                        e.getSchemes()
+                            .filter { it.name == "UuidScheme" }
+                            .forEach { it.renameProperty("type", "version") }
+                    },
+                Version.parse("3.3.5") to
+                    { e: Element -> e.getDecorators().forEach { it.removeProperty("generator") } },
+            )
     }
 }

--- a/src/main/kotlin/com/fwdekker/randomness/XmlHelpers.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/XmlHelpers.kt
@@ -67,6 +67,14 @@ fun Element.renameProperty(oldName: String, newName: String) {
     getMultiProperty(oldName).forEach { it.setAttribute("name", newName) }
 }
 
+/**
+ * Removes the property with attribute `name="[name]"`.
+ */
+fun Element.removeProperty(name: String) {
+    getMultiProperty(name).forEach { children.remove(it) }
+}
+
+
 
 /**
  * Assuming this is the [Element] representation of a [Settings] instance, returns the [Element] of the contained
@@ -88,3 +96,25 @@ fun Element.getTemplates(): List<Element> =
  */
 fun Element.getSchemes(): List<Element> =
     getTemplates().mapNotNull { it.getProperty("schemes") }.flatMap { it.children }
+
+/**
+ * Assuming this is the [Element] representation of a [Settings] instance, returns the list of [Element]s of the
+ * contained [com.fwdekker.randomness.DecoratorScheme]s. Searches recursively, so also returns decorators of decorators,
+ * and so on.
+ */
+fun Element.getDecorators(): List<Element> {
+    val decorators = mutableListOf<Element>()
+
+    var schemes = getSchemes()
+    while (schemes.isNotEmpty()) {
+        val containedDecorators = schemes.flatMap { scheme ->
+            scheme.children
+                .filter { child -> child.getAttribute("name")?.value.let { it != null && it.endsWith("Decorator") } }
+                .map { it.children.single() }
+        }
+        schemes = containedDecorators
+        decorators += containedDecorators
+    }
+
+    return decorators
+}

--- a/src/main/kotlin/com/fwdekker/randomness/affix/AffixDecoratorEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/affix/AffixDecoratorEditor.kt
@@ -2,6 +2,7 @@ package com.fwdekker.randomness.affix
 
 import com.fwdekker.randomness.Bundle
 import com.fwdekker.randomness.SchemeEditor
+import com.fwdekker.randomness.camelPlus
 import com.fwdekker.randomness.ui.bindCurrentText
 import com.fwdekker.randomness.ui.disableMnemonic
 import com.fwdekker.randomness.ui.isEditable
@@ -13,7 +14,6 @@ import com.intellij.ui.dsl.builder.panel
 import com.intellij.ui.dsl.builder.selected
 import com.intellij.ui.layout.ComponentPredicate
 import com.intellij.ui.layout.and
-import java.util.Locale
 import javax.swing.JCheckBox
 
 
@@ -39,24 +39,16 @@ class AffixDecoratorEditor(
 
             checkBox(Bundle("affix.ui.option"))
                 .let { if (enableMnemonic) it.loadMnemonic() else it.disableMnemonic() }
-                .withName(camelConcat(namePrefix, "affixEnabled"))
+                .withName(namePrefix.camelPlus("affixEnabled"))
                 .bindSelected(scheme::enabled)
                 .also { enabledCheckBox = it }
 
             comboBox(presets)
                 .enabledIf(enabledIf?.and(enabledCheckBox.selected) ?: enabledCheckBox.selected)
                 .isEditable(true)
-                .withName(camelConcat(namePrefix, "affixDescriptor"))
+                .withName(namePrefix.camelPlus("affixDescriptor"))
                 .bindCurrentText(scheme::descriptor)
             contextHelp(Bundle("affix.ui.comment"))
         }.also { if (enabledIf != null) it.enabledIf(enabledIf) }
     }
 }
-
-
-/**
- * Prefixes [name] with [prefix], ensuring the resulting string is still in camelCase.
- */
-private fun camelConcat(prefix: String, name: String) =
-    if (prefix == "") name
-    else "${prefix}${name[0].uppercase(Locale.getDefault())}${name.drop(1)}"

--- a/src/main/kotlin/com/fwdekker/randomness/integer/IntegerScheme.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/integer/IntegerScheme.kt
@@ -10,7 +10,6 @@ import com.fwdekker.randomness.array.ArrayDecorator
 import com.fwdekker.randomness.fixedlength.FixedLengthDecorator
 import com.intellij.ui.JBColor
 import com.intellij.util.xmlb.annotations.OptionTag
-import com.intellij.util.xmlb.annotations.Transient
 import java.awt.Color
 import java.text.DecimalFormat
 
@@ -39,7 +38,6 @@ data class IntegerScheme(
     @OptionTag val affixDecorator: AffixDecorator = DEFAULT_AFFIX_DECORATOR,
     @OptionTag val arrayDecorator: ArrayDecorator = DEFAULT_ARRAY_DECORATOR,
 ) : Scheme() {
-    @get:Transient
     override val name = Bundle("integer.title")
     override val typeIcon get() = BASE_ICON
     override val decorators get() = listOf(fixedLengthDecorator, affixDecorator, arrayDecorator)

--- a/src/main/kotlin/com/fwdekker/randomness/template/TemplateReference.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/template/TemplateReference.kt
@@ -29,6 +29,7 @@ data class TemplateReference(
     @OptionTag val affixDecorator: AffixDecorator = DEFAULT_AFFIX_DECORATOR,
     @OptionTag val arrayDecorator: ArrayDecorator = DEFAULT_ARRAY_DECORATOR,
 ) : Scheme() {
+    @get:Transient
     override val name get() = template?.name?.let { "[$it]" } ?: Bundle("reference.title")
     override val typeIcon get() = template?.typeIcon ?: DEFAULT_ICON
     override val icon get() = OverlayedIcon(typeIcon, decorators.mapNotNull { it.icon } + OverlayIcon.REFERENCE)
@@ -37,6 +38,7 @@ data class TemplateReference(
     /**
      * The [Template] in the [context]'s [TemplateList] that contains this [TemplateReference].
      */
+    @get:Transient
     val parent: Template
         get() = (+context).templates.single { template -> template.schemes.any { it.uuid == uuid } }
 

--- a/src/main/kotlin/com/fwdekker/randomness/uuid/UuidScheme.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/uuid/UuidScheme.kt
@@ -16,6 +16,7 @@ import com.fwdekker.randomness.affix.AffixDecorator
 import com.fwdekker.randomness.array.ArrayDecorator
 import com.intellij.ui.JBColor
 import com.intellij.util.xmlb.annotations.OptionTag
+import com.intellij.util.xmlb.annotations.Transient
 import java.awt.Color
 import java.util.UUID
 import kotlin.random.Random
@@ -38,6 +39,7 @@ data class UuidScheme(
     @OptionTag val affixDecorator: AffixDecorator = DEFAULT_AFFIX_DECORATOR,
     @OptionTag val arrayDecorator: ArrayDecorator = DEFAULT_ARRAY_DECORATOR,
 ) : Scheme() {
+    @get:Transient
     override val name = Bundle("uuid.title")
     override val typeIcon get() = BASE_ICON
     override val decorators get() = listOf(affixDecorator, arrayDecorator)

--- a/src/main/kotlin/com/fwdekker/randomness/word/WordScheme.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/word/WordScheme.kt
@@ -9,6 +9,7 @@ import com.fwdekker.randomness.affix.AffixDecorator
 import com.fwdekker.randomness.array.ArrayDecorator
 import com.intellij.ui.JBColor
 import com.intellij.util.xmlb.annotations.OptionTag
+import com.intellij.util.xmlb.annotations.Transient
 import java.awt.Color
 
 
@@ -26,6 +27,7 @@ data class WordScheme(
     @OptionTag val affixDecorator: AffixDecorator = DEFAULT_AFFIX_DECORATOR,
     @OptionTag val arrayDecorator: ArrayDecorator = DEFAULT_ARRAY_DECORATOR,
 ) : Scheme() {
+    @get:Transient
     override val name = Bundle("word.title")
     override val typeIcon get() = BASE_ICON
     override val decorators get() = listOf(affixDecorator, arrayDecorator)

--- a/src/test/kotlin/com/fwdekker/randomness/CapitalizationModeTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/CapitalizationModeTest.kt
@@ -3,6 +3,8 @@ package com.fwdekker.randomness
 import com.fwdekker.randomness.testhelpers.matchBundle
 import io.kotest.assertions.retry
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.data.row
+import io.kotest.datatest.withData
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
@@ -76,5 +78,43 @@ object CapitalizationModeTest : FunSpec({
         test("returns the associated localized string") {
             CapitalizationMode.FIRST_LETTER.toLocalizedString() should matchBundle("shared.capitalization.first_letter")
         }
+    }
+})
+
+
+/**
+ * Unit tests for capitalization-related helper functions in `CapitalizationModeKt`.
+ */
+object CapitalizationHelperTest : FunSpec({
+    context("lowerCaseFirst") {
+        withData(
+            mapOf(
+                "outputs an empty string if the input is empty" to row("", ""),
+                "does nothing if the first character is already in lowercase" to row("abcD eFgH", "abcD eFgH"),
+                "changes the first character to lowercase" to row("AbcD EfGh", "abcD EfGh"),
+            )
+        ) { (input, expected) -> input.lowerCaseFirst() shouldBe expected }
+    }
+
+    context("upperCaseFirst") {
+        withData(
+            mapOf(
+                "outputs an empty string if the input is empty" to row("", ""),
+                "does nothing if the first character is already in uppercase" to row("AbcD eFgH", "AbcD eFgH"),
+                "changes the first character to uppercase" to row("abCd eFgH", "AbCd eFgH"),
+            )
+        ) { (input, expected) -> input.upperCaseFirst() shouldBe expected }
+    }
+
+    context("camelPlus") {
+        withData(
+            mapOf(
+                "outputs an empty string if both are empty" to row("", "", ""),
+                "simply appends if the first part is empty" to row("", "fooBar", "fooBar"),
+                "simply appends if the second part is empty" to row("fooBar", "", "fooBar"),
+                "concatenates two words in camel case" to row("foo", "bar", "fooBar"),
+                "concatenates two pairs of words to camel case" to row("fooBar", "bazQux", "fooBarBazQux"),
+            )
+        ) { (first, second, expected) -> first.camelPlus(second) shouldBe expected }
     }
 })

--- a/src/test/kotlin/com/fwdekker/randomness/ListHelpersTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/ListHelpersTest.kt
@@ -1,0 +1,61 @@
+package com.fwdekker.randomness
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.data.row
+import io.kotest.datatest.withData
+import io.kotest.matchers.shouldBe
+
+
+/**
+ * Unit tests for extension functions in `ListHelpersKt`.
+ */
+object ListHelpersTest : FunSpec({
+    context("getMod") {
+        withData(
+            mapOf(
+                "index `0` returns 0th element" to row(42, 0, 0),
+                "index `1` returns 1st element" to row(42, 1, 1),
+                "index `size - 1` returns last element" to row(42, 41, 41),
+                "index `size` returns 0th element" to row(42, 42, 0),
+                "index `size + 1` returns 1st element" to row(42, 43, 1),
+                "index `size * 2` returns 0th element" to row(42, 84, 0),
+                "index `size * 100 + 5` returns 5th element" to row(42, 4205, 5),
+                "index `-1` returns last element" to row(42, -1, 41),
+                "index `-2` returns first-to-last element" to row(42, -2, 40),
+                "index `-3` returns second-to-last element" to row(42, -3, 39),
+                "index `-size` returns 0th element" to row(42, -42, 0),
+                "index `-size * 2` returns 0th element" to row(42, -84, 0),
+                "index `-size * 50 + 9` returns 9th element" to row(42, -4191, 9),
+            )
+        ) { (size, idx, expected) ->
+            val list = List(size) { it }
+            list.getMod(idx) shouldBe expected
+        }
+    }
+
+    context("setAll") {
+        test("adds the given elements to an empty list") {
+            val list = mutableListOf<Int>()
+
+            list.setAll(listOf(0, 1, 2, 3))
+
+            list shouldBe listOf(0, 1, 2, 3)
+        }
+
+        test("removes existing elements before inserting the new elements") {
+            val list = mutableListOf(0, 1, 2)
+
+            list.setAll(listOf(3, 4, 5))
+
+            list shouldBe listOf(3, 4, 5)
+        }
+
+        test("removes existing elements even if they are again to be inserted") {
+            val list = mutableListOf(0, 1, 1, 2)
+
+            list.setAll(listOf(1, 2, 3))
+
+            list shouldBe listOf(1, 2, 3)
+        }
+    }
+})

--- a/src/test/kotlin/com/fwdekker/randomness/PersistentSettingsTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/PersistentSettingsTest.kt
@@ -4,9 +4,13 @@ import com.fwdekker.randomness.testhelpers.beforeNonContainer
 import com.intellij.openapi.util.JDOMUtil
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.nulls.beNull
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNot
+import io.kotest.matchers.string.shouldStartWith
+import java.lang.module.ModuleDescriptor.Version
 import java.net.URL
 
 
@@ -25,25 +29,109 @@ object PersistentSettingsTest : FunSpec({
 
 
     context("version upgrades") {
-        test("fails for versions below v3.0.0") {
-            val xml = JDOMUtil.load("""<component><option name="version" value="2.0.0"/></component>""")
+        context("input validation") {
+            test("fails if the target version is below v3.0.0") {
+                val stored = JDOMUtil.load("""<component><option name="version" value="3.0.0"/></component>""")
 
-            shouldThrow<IllegalStateException> { settings.loadState(xml) }
+                shouldThrow<IllegalArgumentException> { settings.upgrade(stored, Version.parse("2.0.0")) }
+                    .message shouldStartWith "Unsupported upgrade target version"
+            }
+
+            test("fails if the stored version below v3.0.0") {
+                val stored = JDOMUtil.load("""<component><option name="version" value="2.0.0"/></component>""")
+
+                shouldThrow<IllegalArgumentException> { settings.upgrade(stored) }
+                    .message shouldStartWith "Unsupported Randomness config version"
+            }
+
+            test("fails if the stored version is missing") {
+                val stored = JDOMUtil.load("""<component></component>""")
+
+                shouldThrow<IllegalArgumentException> { settings.upgrade(stored) }
+                    .message shouldStartWith "Missing version number"
+            }
         }
 
-        context("v3.1.0 to v3.2.0") {
-            test("replaces `type` with `version` in all `UuidScheme`s") {
-                val xml = JDOMUtil.load(getTestConfig("/settings-upgrades/v3.1.0-v3.2.0.xml"))
-                xml.getSchemes().single().run {
+        context("generic behaviour") {
+            test("bumps the version number if the target version is higher than the stored version") {
+                val stored = JDOMUtil.load("""<component><option name="version" value="9.9.8"/></component>""")
+                stored.getPropertyValue("version") shouldBe "9.9.8"
+
+                val patched = settings.upgrade(stored, Version.parse("9.9.9"))
+                patched.getPropertyValue("version") shouldBe "9.9.9"
+            }
+
+            test("does not bump the version number if the target version is lower than the stored version") {
+                val stored = JDOMUtil.load("""<component><option name="version" value="9.9.8"/></component>""")
+                stored.getPropertyValue("version") shouldBe "9.9.8"
+
+                val patched = settings.upgrade(stored, Version.parse("9.9.7"))
+                patched.getPropertyValue("version") shouldBe "9.9.8"
+            }
+
+            test("applies multiple upgrades in sequence if needed") {
+                val stored = JDOMUtil.load(getTestConfig("/settings-upgrades/v3.1.0-v3.3.5.xml"))
+                stored.getSchemes().single().run {
                     getPropertyValue("type") shouldBe "1"
                     getProperty("version") should beNull()
                 }
+                stored.getDecorators() shouldNot beEmpty()
+                stored.getDecorators().forEach { it.getProperty("generator") shouldNot beNull() }
 
-                settings.loadState(xml)
-
-                settings.state.getSchemes().single().run {
+                val patched = settings.upgrade(stored, Version.parse("3.3.5"))
+                patched.getSchemes().single().run {
                     getProperty("type") should beNull()
                     getPropertyValue("version") shouldBe "1"
+                }
+                patched.getDecorators() shouldNot beEmpty()
+                patched.getDecorators().forEach { it.getProperty("generator") should beNull() }
+            }
+
+            test("upgrades only up to the specified version") {
+                val stored = JDOMUtil.load(getTestConfig("/settings-upgrades/v3.1.0-v3.3.5.xml"))
+                stored.getSchemes().single().run {
+                    getPropertyValue("type") shouldBe "1"
+                    getProperty("version") should beNull()
+                }
+                stored.getDecorators() shouldNot beEmpty()
+                stored.getDecorators().forEach { it.getProperty("generator") shouldNot beNull() }
+
+                val patched = settings.upgrade(stored, Version.parse("3.2.0"))
+                patched.getSchemes().single().run {
+                    getProperty("type") should beNull()
+                    getPropertyValue("version") shouldBe "1"
+                }
+                stored.getDecorators() shouldNot beEmpty()
+                stored.getDecorators().forEach { it.getProperty("generator") shouldNot beNull() }
+            }
+        }
+
+        context("specific upgrades") {
+            context("v3.1.0 to v3.2.0") {
+                test("replaces `type` with `version` in all `UuidScheme`s") {
+                    val stored = JDOMUtil.load(getTestConfig("/settings-upgrades/v3.1.0-v3.2.0.xml"))
+                    stored.getSchemes().single().run {
+                        getPropertyValue("type") shouldBe "1"
+                        getProperty("version") should beNull()
+                    }
+
+                    val patched = settings.upgrade(stored, Version.parse("3.2.0"))
+                    patched.getSchemes().single().run {
+                        getProperty("type") should beNull()
+                        getPropertyValue("version") shouldBe "1"
+                    }
+                }
+            }
+
+            context("v3.3.4 to v3.3.5") {
+                test("removes `generator` fields from all decorators") {
+                    val stored = JDOMUtil.load(getTestConfig("/settings-upgrades/v3.3.4-v3.3.5.xml"))
+                    stored.getDecorators() shouldNot beEmpty()
+                    stored.getDecorators().forEach { it.getProperty("generator") shouldNot beNull() }
+
+                    val patched = settings.upgrade(stored, Version.parse("3.3.5"))
+                    patched.getDecorators() shouldNot beEmpty()
+                    patched.getDecorators().forEach { it.getProperty("generator") should beNull() }
                 }
             }
         }

--- a/src/test/kotlin/com/fwdekker/randomness/PersistentSettingsTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/PersistentSettingsTest.kt
@@ -6,7 +6,7 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.nulls.beNull
 import io.kotest.matchers.should
-import io.kotest.matchers.shouldNot
+import io.kotest.matchers.shouldBe
 import java.net.URL
 
 
@@ -35,7 +35,7 @@ object PersistentSettingsTest : FunSpec({
             test("replaces `type` with `version` in all `UuidScheme`s") {
                 val xml = JDOMUtil.load(getTestConfig("/settings-upgrades/v3.1.0-v3.2.0.xml"))
                 xml.getSchemes().single().run {
-                    getProperty("type") shouldNot beNull()
+                    getPropertyValue("type") shouldBe "1"
                     getProperty("version") should beNull()
                 }
 
@@ -43,7 +43,7 @@ object PersistentSettingsTest : FunSpec({
 
                 settings.state.getSchemes().single().run {
                     getProperty("type") should beNull()
-                    getProperty("version") shouldNot beNull()
+                    getPropertyValue("version") shouldBe "1"
                 }
             }
         }

--- a/src/test/kotlin/com/fwdekker/randomness/StateReflection.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/StateReflection.kt
@@ -1,0 +1,128 @@
+package com.fwdekker.randomness
+
+import com.fwdekker.randomness.integer.IntegerScheme
+import com.intellij.util.xmlb.annotations.OptionTag
+import com.intellij.util.xmlb.annotations.Transient
+import com.intellij.util.xmlb.annotations.XCollection
+import kotlin.reflect.KCallable
+import kotlin.reflect.KMutableProperty
+import kotlin.reflect.KParameter
+import kotlin.reflect.KProperty
+import kotlin.reflect.KProperty1
+import kotlin.reflect.full.allSuperclasses
+import kotlin.reflect.full.hasAnnotation
+import kotlin.reflect.full.memberProperties
+import kotlin.reflect.full.primaryConstructor
+import kotlin.reflect.jvm.javaField
+import kotlin.reflect.jvm.jvmErasure
+
+
+/**
+ * Maps each element to its name, or returns an empty list of `this` is `null`.
+ */
+fun Collection<KCallable<*>>?.callableNames(): Set<String> = (this ?: emptyList()).map { it.name }.toSet()
+
+/**
+ * Maps each element to its name, or returns an empty list of `this` is `null`.
+ */
+fun Collection<KParameter>?.parameterNames(): Set<String> = (this ?: emptyList()).map { it.name!! }.toSet()
+
+
+/**
+ * Returns all of the [State]'s properties ("fields"), i.e. everything preceded by `val` or `var` in this class or any
+ * of its superclasses.
+ *
+ * @param S the type of state containing the returned properties
+ */
+fun <S : State> S.properties(): List<KProperty1<out S, *>> = this::class.memberProperties.toList()
+
+/**
+ * Returns all of [State]'s [parameters] that are defined in the primary constructor.
+ *
+ * @param S the type of state containing the returned parameters
+ */
+fun <S : State> S.parameters(): List<KProperty1<out S, *>> {
+    val params = this::class.primaryConstructor?.parameters.parameterNames()
+    return properties().filter { it.name in params }
+}
+
+/**
+ * Returns `true` if and only if this property is annotated with [A], or if any of the superclasses of the class that
+ * contains `this` property has a property with the same name as `this` property that is annotated with [A].
+ */
+private inline fun <reified A : Annotation> KProperty<*>.hasAnnotationInChain(): Boolean {
+    val ownerClass = parameters
+        .also { require(it.size == 1) { "Type detection requires that property has only one parameter." } }
+        .let { it[0].type.jvmErasure }
+
+    return (ownerClass.allSuperclasses + ownerClass)
+        .map { clz -> clz.memberProperties.filter { it.name == name } }
+        .onEach { require(it.size <= 1) { "(Super)class unexpectedly has multiple properties with same name." } }
+        .flatten()
+        .any {
+            it.hasAnnotation<A>() ||
+                it.getter.hasAnnotation<A>() ||
+                it is KMutableProperty<*> && it.setter.hasAnnotation<A>() ||
+                it.javaField?.getAnnotation(A::class.java) != null
+        }
+}
+
+/**
+ * Returns `true` if and only if this property is annotated as transient in this class itself or in one of its
+ * superclasses.
+ */
+fun KProperty<*>.isTransient(): Boolean = hasAnnotationInChain<Transient>()
+
+/**
+ * Returns `true` if this property will (presumably) be serialized by [com.intellij.util.xmlb.XmlSerializer].
+ */
+fun KProperty<*>.isSerialized(): Boolean =
+    !hasAnnotationInChain<Transient>() &&
+        (this is KMutableProperty<*> || hasAnnotationInChain<OptionTag>() || hasAnnotationInChain<XCollection>())
+
+
+/**
+ * Recursively mutates this element and the properties contained within.
+ *
+ * The logic is broadly as follows:
+ * - Given a primitive, a primitive with a different value is returned.
+ * - Given an enum, the next element is returned.
+ * - Given a list, this function is invoked recursively on each element, and a shallow copy of the list with one element
+ *   appended is returned.
+ * - Given a [State], enumerate over each of its [properties], and invoke this function recursively on each. The
+ *   returned value is written into the [State] instance if and only if the property is mutable.
+ */
+@Suppress("detekt:CyclomaticComplexMethod")
+fun Any?.mutated(): Any {
+    return when (this) {
+        null -> "foo"
+        is Boolean -> not()
+        is Int -> inc()
+        is Long -> inc()
+        is Float -> inc()
+        is Double -> inc()
+        is String -> "foo_$this"
+        is CapitalizationMode -> CapitalizationMode.entries.getMod(ordinal + 1)
+
+        is State ->
+            properties()
+                .filter { it.isSerialized() }
+                .forEach {
+                    val newValue = it.getter.call(this).mutated()
+                    if (it is KMutableProperty<*>)
+                        it.setter.call(this, newValue)
+                }
+                .let { this }
+
+        is List<*> ->
+            if (isEmpty()) error("Cannot mutate empty list.")
+            else when (first()) {
+                is Int -> map { it.mutated() } + 0
+                is String -> map { it.mutated() } + "foo"
+                is Scheme -> map { it.mutated() } + IntegerScheme()
+                else -> error("Cannot mutate lists with elements such as `${first()}`.")
+            }
+
+        else -> error("Cannot mutate value `$this`.")
+    }
+}

--- a/src/test/kotlin/com/fwdekker/randomness/StateReflectionTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/StateReflectionTest.kt
@@ -1,0 +1,397 @@
+package com.fwdekker.randomness
+
+import com.fwdekker.randomness.integer.IntegerScheme
+import com.fwdekker.randomness.string.StringScheme
+import com.fwdekker.randomness.testhelpers.DummyDecoratorScheme
+import com.fwdekker.randomness.testhelpers.DummyScheme
+import com.intellij.util.xmlb.XmlSerializer.serialize
+import com.intellij.util.xmlb.annotations.OptionTag
+import com.intellij.util.xmlb.annotations.Transient
+import com.intellij.util.xmlb.annotations.XCollection
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.data.row
+import io.kotest.datatest.withData
+import io.kotest.matchers.collections.containExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+
+
+/**
+ * Unit tests for extension functions in `StateReflection`.
+ */
+object StateReflectionTest : FunSpec({
+    context("parameters") {
+        withData(
+            mapOf(
+                "returns an empty list if the constructor is empty and there are no fields" to
+                    row(SimpleState(), emptyList()),
+                "returns all constructor parameters" to
+                    row(ParametersOnly(), listOf("foo")),
+                "does not return the fields" to
+                    row(FieldsOnly(), listOf()),
+                "returns all constructor parameters, but not the fields" to
+                    row(ParametersAndFields(), listOf("foo")),
+                "returns the subclass' constructor parameters only" to
+                    row(ParametersAndFieldsSub(), listOf("baz")),
+            )
+        ) { (state, parameters) ->
+            state.parameters().callableNames() shouldContainExactlyInAnyOrder parameters
+        }
+    }
+
+    context("properties") {
+        withData(
+            mapOf(
+                "returns an empty list if the constructor is empty and there are no fields" to
+                    row(SimpleState(), emptyList()),
+                "returns all constructor parameters" to
+                    row(ParametersOnly(), listOf("foo")),
+                "returns all fields" to
+                    row(FieldsOnly(), listOf("foo", "bar")),
+                "returns all constructor parameters and all fields" to
+                    row(ParametersAndFields(), listOf("foo", "bar")),
+                "returns all constructor parameters and all fields from both subclass and superclass" to
+                    row(ParametersAndFieldsSub(), listOf("foo", "bar", "baz", "qux")),
+            )
+        ) { (state, parameters) ->
+            state.properties().callableNames() should containExactlyInAnyOrder(parameters + listOf("context", "uuid"))
+        }
+    }
+
+    context("isTransient") {
+        withData(
+            mapOf(
+                // Constructor parameter
+                "constructor parameter without annotation is not transient" to
+                    row(TransientAnnotations::constructorNotTransient, false),
+                "constructor parameter with `@Transient` is transient" to
+                    row(TransientAnnotations::constructorTransient, true),
+                "constructor parameter with `@field:Transient` is transient" to
+                    row(TransientAnnotations::constructorFieldTransient, true),
+                "constructor parameter with `@get:Transient` is transient" to
+                    row(TransientAnnotations::constructorGetTransient, true),
+                "constructor parameter with `@set:Transient` is transient" to
+                    row(TransientAnnotations::constructorSetTransient, true),
+                // Declared property
+                "declared property without annotation is not transient" to
+                    row(TransientAnnotations::declaredNotTransient, false),
+                "declared property with `@Transient` is transient" to
+                    row(TransientAnnotations::declaredTransient, true),
+                "declared property with `@field:Transient` is transient" to
+                    row(TransientAnnotations::declaredFieldTransient, true),
+                "declared property with `@get:Transient` is transient" to
+                    row(TransientAnnotations::declaredGetTransient, true),
+                "declared property with `@set:Transient` is transient" to
+                    row(TransientAnnotations::declaredSetTransient, true),
+                // Inherited property with annotation
+                "inherited property without annotation is not transient" to
+                    row(TransientAnnotations::superNotTransient, false),
+                "inherited property with `@Transient` is transient" to
+                    row(TransientAnnotations::superTransient, true),
+                "inherited property with `@field:Transient` is transient" to
+                    row(TransientAnnotations::superFieldTransient, true),
+                "inherited property with `@get:Transient` is transient" to
+                    row(TransientAnnotations::superGetTransient, true),
+                "inherited property with `@set:Transient` is transient" to
+                    row(TransientAnnotations::superSetTransient, true),
+                // Inherited property with annotation, override without annotation
+                "inherited property with `@Transient` overridden without annotation is transient" to
+                    row(TransientAnnotations::onlySuperTransient, true),
+                "inherited property with `@field:Transient` overridden without annotation is transient" to
+                    row(TransientAnnotations::onlySuperFieldTransient, true),
+                "inherited property with `@get:Transient` overridden without annotation is transient" to
+                    row(TransientAnnotations::onlySuperGetTransient, true),
+                "inherited property with `@set:Transient` overridden without annotation is transient" to
+                    row(TransientAnnotations::onlySuperSetTransient, true),
+                // Inherited property without annotation, override with annotation
+                "inherited property without annotation overridden with `@Transient` is transient" to
+                    row(TransientAnnotations::onlySubTransient, true),
+                "inherited property without annotation overridden with `@field:Transient` is transient" to
+                    row(TransientAnnotations::onlySubFieldTransient, true),
+                "inherited property without annotation overridden with `@get:Transient` is transient" to
+                    row(TransientAnnotations::onlySubGetTransient, true),
+                "inherited property without annotation overridden with `@set:Transient` is transient" to
+                    row(TransientAnnotations::onlySubSetTransient, true),
+                // Known cases
+                "detects schemes' uuid field as non-transient" to
+                    row(DummyScheme::uuid, false),
+                "detects schemes' context field as transient" to
+                    row(DummyScheme::context, true),
+                "detects decorators' generator field as transient" to
+                    row(DummyDecoratorScheme::generator, true),
+            )
+        ) { (property, isTransient) ->
+            property.isTransient() shouldBe isTransient
+        }
+    }
+
+    context("isSerialized") {
+        val cases = mapOf(
+            // No annotation
+            "immutable primitive is not serialized" to
+                row(TransientSerialized::valInt, false),
+            "immutable `Scheme` is not serialized" to
+                row(TransientSerialized::valScheme, false),
+            "immutable `List` is not serialized" to
+                row(TransientSerialized::valList, false),
+            "immutable `MutableList` is not serialized" to
+                row(TransientSerialized::valMutableList, false),
+            "mutable primitive is serialized" to
+                row(TransientSerialized::varInt, true),
+            "mutable `Scheme` is serialized" to
+                row(TransientSerialized::varScheme, true),
+            "mutable `List` is serialized" to
+                row(TransientSerialized::varList, true),
+            "mutable `MutableList` is serialized" to
+                row(TransientSerialized::varMutableList, true),
+            // @OptionTag
+            "immutable `List` with @OptionTag is serialized" to
+                row(TransientSerialized::valListOptionTag, true),
+            "immutable `MutableList` with @OptionTag is serialized" to
+                row(TransientSerialized::valMutableListOptionTag, true),
+            "mutable primitive with @OptionTag is serialized" to
+                row(TransientSerialized::varIntOptionTag, true),
+            "mutable `Scheme` with @OptionTag is serialized" to
+                row(TransientSerialized::varSchemeOptionTag, true),
+            "mutable `List` with @OptionTag is serialized" to
+                row(TransientSerialized::varListOptionTag, true),
+            "mutable `MutableList` with @OptionTag is serialized" to
+                row(TransientSerialized::varMutableListOptionTag, true),
+            // @XCollection
+            "immutable `List` with @XCollection is serialized" to
+                row(TransientSerialized::valListXCollection, true),
+            "immutable `MutableList` with @XCollection is serialized" to
+                row(TransientSerialized::valMutableListXCollection, true),
+            "mutable `List` with @XCollection is serialized" to
+                row(TransientSerialized::varListXCollection, true),
+            "mutable `MutableList` with @XCollection is serialized" to
+                row(TransientSerialized::varMutableListXCollection, true),
+        )
+
+        context("isSerialized method") {
+            withData(cases) { (property, isSerialized) ->
+                property.isSerialized() shouldBe isSerialized
+            }
+        }
+
+        context("is actually serialized") {
+            withData(cases) { (property, _) ->
+                val xml = serialize(TransientSerialized())
+                val xmlHasProperty = xml.getProperty(property.name) != null
+
+                property.isSerialized() shouldBe xmlHasProperty
+            }
+        }
+    }
+
+    context("mutated") {
+        withData(
+            mapOf(
+                // Primitive(-ish)
+                "null" to row(null, "foo"),
+                "false" to row(false, true),
+                "true" to row(true, false),
+                "integer" to row(79, 80),
+                "long" to row(448L, 449L),
+                "float" to row(181.57f, 182.57f),
+                "double" to row(995.67, 996.67),
+                "string" to row("frank", "foo_frank"),
+                "enum" to row(CapitalizationMode.UPPER, CapitalizationMode.LOWER),
+                // Scheme
+                "scheme with mutable parameters" to
+                    row(SchemeMutable(0, "bar"), SchemeMutable(1, "foo_bar")),
+                "scheme with immutable parameters" to
+                    row(SchemeImmutable(0, "bar"), SchemeImmutable(0, "bar")),
+                "scheme with val immutable list" to
+                    row(SchemeValImmutableList(listOf(0)), SchemeValImmutableList(listOf(0))),
+                "scheme with val mutable list" to
+                    row(SchemeValMutableList(mutableListOf(0)), SchemeValMutableList(mutableListOf(0))),
+                "scheme with var immutable list" to
+                    row(SchemeVarImmutableList(listOf(0)), SchemeVarImmutableList(listOf(1, 0))),
+                "scheme with var mutable list" to
+                    row(SchemeVarMutableList(mutableListOf(0)), SchemeVarMutableList(mutableListOf(1, 0))),
+                "scheme with some transient fields" to
+                    row(SchemeTransient(foo = 0, bar = 0), SchemeTransient(foo = 0, bar = 1)),
+                // List
+                "string list" to row(listOf("a", "b"), listOf("foo_a", "foo_b", "foo")),
+                "scheme list" to row(
+                    listOf(IntegerScheme(), StringScheme()),
+                    listOf(IntegerScheme().mutated(), StringScheme().mutated(), IntegerScheme())
+                ),
+            )
+        ) { (before, after) ->
+            before.mutated() shouldBe after
+        }
+    }
+})
+
+
+/**
+ * A [State] that cannot [deepCopy]. Purely for tests.
+ */
+internal open class SimpleState : State() {
+    override fun deepCopy(retainUuid: Boolean): State = error("Not implemented.")
+}
+
+
+internal class FieldsOnly : SimpleState() {
+    var foo: Int = 0
+    val bar: Int = 0
+}
+
+internal class ParametersOnly(var foo: Int = 0) : SimpleState()
+
+internal class ParametersAndFields(var foo: Int = 0) : SimpleState() {
+    var bar: Int = 0
+}
+
+internal open class ParametersSuper(var foo: Int = 0) : SimpleState() {
+    var bar: Int = 0
+}
+
+internal class ParametersAndFieldsSub(var baz: Int = 0) : ParametersSuper() {
+    var qux: Int = 0
+}
+
+internal open class TransientAnnotationsSuper {
+    var superNotTransient: Int = 0
+
+    @Transient
+    var superTransient: Int = 0
+
+    @field:Transient
+    var superFieldTransient: Int = 0
+
+    @get:Transient
+    var superGetTransient: Int = 0
+
+    @set:Transient
+    var superSetTransient: Int = 0
+
+    @Transient
+    open var onlySuperTransient: Int = 0
+
+    @field:Transient
+    open var onlySuperFieldTransient: Int = 0
+
+    @get:Transient
+    open var onlySuperGetTransient: Int = 0
+
+    @set:Transient
+    open var onlySuperSetTransient: Int = 0
+
+    open var onlySubTransient: Int = 0
+
+    open var onlySubFieldTransient: Int = 0
+
+    open var onlySubGetTransient: Int = 0
+
+    open var onlySubSetTransient: Int = 0
+}
+
+internal class TransientAnnotations(
+    var constructorNotTransient: Int = 0,
+    @Transient var constructorTransient: Int = 0,
+    @field:Transient var constructorFieldTransient: Int = 0,
+    @get:Transient var constructorGetTransient: Int = 0,
+    @set:Transient var constructorSetTransient: Int = 0,
+) : TransientAnnotationsSuper() {
+    var declaredNotTransient: Int = 0
+
+    @Transient
+    var declaredTransient: Int = 0
+
+    @field:Transient
+    var declaredFieldTransient: Int = 0
+
+    @get:Transient
+    var declaredGetTransient: Int = 0
+
+    @set:Transient
+    var declaredSetTransient: Int = 0
+
+    override var onlySuperTransient: Int = 0
+
+    override var onlySuperFieldTransient: Int = 0
+
+    override var onlySuperGetTransient: Int = 0
+
+    override var onlySuperSetTransient: Int = 0
+
+    @Transient
+    override var onlySubTransient: Int = 0
+
+    @field:Transient
+    override var onlySubFieldTransient: Int = 0
+
+    @get:Transient
+    override var onlySubGetTransient: Int = 0
+
+    @set:Transient
+    override var onlySubSetTransient: Int = 0
+}
+
+internal class TransientSerialized : SimpleState() {
+    val valInt: Int = 0
+
+    val valScheme: Scheme = IntegerScheme()
+
+    val valList: List<String> = listOf("foo", "bar")
+
+    val valMutableList: MutableList<String> = mutableListOf("foo", "bar")
+
+    var varInt: Int = 0
+
+    var varScheme: Scheme = IntegerScheme()
+
+    var varList: List<String> = listOf("foo", "bar")
+
+    var varMutableList: MutableList<String> = mutableListOf("foo", "bar")
+
+
+    @get:OptionTag
+    val valListOptionTag: List<String> = listOf("foo", "bar")
+
+    @get:OptionTag
+    val valMutableListOptionTag: MutableList<String> = mutableListOf("foo", "bar")
+
+    @get:OptionTag
+    var varIntOptionTag: Int = 0
+
+    @get:OptionTag
+    var varSchemeOptionTag: Scheme = IntegerScheme()
+
+    @get:OptionTag
+    var varListOptionTag: List<String> = listOf("foo", "bar")
+
+    @get:OptionTag
+    var varMutableListOptionTag: MutableList<String> = mutableListOf("foo", "bar")
+
+
+    @get:XCollection
+    val valListXCollection: List<String> = listOf("foo", "bar")
+
+    @get:XCollection
+    val valMutableListXCollection: MutableList<String> = mutableListOf("foo", "bar")
+
+    @get:XCollection
+    var varListXCollection: List<String> = listOf("foo", "bar")
+
+    @get:XCollection
+    var varMutableListXCollection: MutableList<String> = mutableListOf("foo", "bar")
+}
+
+internal data class SchemeMutable(var foo: Int = 0, var bar: String = "bar") : SimpleState()
+
+internal data class SchemeImmutable(val foo: Int = 0, val bar: String = "bar") : SimpleState()
+
+internal data class SchemeValImmutableList(val list: List<Int> = listOf(0)) : SimpleState()
+
+internal data class SchemeValMutableList(val list: MutableList<Int> = mutableListOf(0)) : SimpleState()
+
+internal data class SchemeVarImmutableList(var list: List<Int> = listOf(0)) : SimpleState()
+
+internal data class SchemeVarMutableList(var list: MutableList<Int> = mutableListOf(0)) : SimpleState()
+
+internal data class SchemeTransient(@Transient var foo: Int = 0, var bar: Int = 0) : SimpleState()

--- a/src/test/kotlin/com/fwdekker/randomness/StateTestFactory.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/StateTestFactory.kt
@@ -1,16 +1,12 @@
 package com.fwdekker.randomness
 
-import com.fwdekker.randomness.integer.IntegerScheme
-import com.fwdekker.randomness.template.Template
 import com.fwdekker.randomness.testhelpers.beforeNonContainer
-import io.kotest.core.spec.style.FunSpec
+import com.intellij.util.xmlb.XmlSerializer.deserialize
+import com.intellij.util.xmlb.XmlSerializer.serialize
 import io.kotest.core.spec.style.funSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
-import kotlin.reflect.KMutableProperty
-import kotlin.reflect.KProperty
-import kotlin.reflect.full.memberProperties
-import kotlin.reflect.full.primaryConstructor
 
 
 /**
@@ -54,143 +50,34 @@ fun <S : State> stateDeepCopyTestFactory(createState: () -> S) =
  */
 fun <S : Scheme> schemeSerializationTestFactory(createScheme: () -> S) =
     funSpec {
+        fun <T> reserialize(any: Any, clz: Class<T>): T =
+            deserialize(serialize(deserialize(serialize(any), clz)), clz)
+
+
         context("(de)serialization") {
-            fun validate(scheme: Scheme) {
-                val original = PersistentSettings()
-                original.settings.templateList.templates.apply {
-                    clear()
-                    add(scheme.asTemplate())
-                }
-
-                val copy = PersistentSettings().apply { loadState(original.state) }
-                copy.settings shouldBe original.settings
+            test("mutation is not a no-op") {
+                createScheme().mutated() shouldNotBe createScheme()
             }
-
 
             test("retains default values") {
-                validate(createScheme())
+                val scheme = createScheme()
+                reserialize(createScheme(), scheme::class.java) shouldBe scheme
             }
 
-            test("retains changed values, including those in decorators") {
-                validate(createScheme().mutate())
+            test("retains modified values") {
+                val scheme = createScheme().mutated()
+                reserialize(scheme, scheme::class.java) shouldBe scheme
+            }
+
+            test("serializes exactly the properties for which `isSerialized` holds") {
+                val scheme = createScheme()
+                val xml = serialize(scheme)
+
+                val beanProps = scheme.properties().filter { it.isSerialized() }.map { it.name }
+                    .map { it.removePrefix("is").lowerCaseFirst() }
+                val xmlProps = xml.children.mapNotNull { it.getAttribute("name")?.value }
+
+                xmlProps shouldContainExactlyInAnyOrder beanProps
             }
         }
     }
-
-
-/**
- * Mutates every single field of `this` [Scheme] in some way.
- */
-@Suppress(
-    "UNCHECKED_CAST",
-    "detekt:CognitiveComplexMethod",
-    "detekt:CyclomaticComplexMethod",
-    "detekt:NestedBlockDepth",
-)
-fun <S : Scheme> S.mutate(): S {
-    val msg = { prop: KProperty<*> -> "Property '${prop.name}' has unknown type '${prop.returnType}'." }
-    val params = this::class.primaryConstructor!!.parameters.map { it.name!! }.toSet()
-
-    this::class.memberProperties.filter { it.name in params }
-        .forEach { prop ->
-            val oldValue = prop.getter.call(this)
-
-            if (prop is KMutableProperty<*>) {
-                // Overwrite mutable properties
-                prop.setter.call(
-                    this,
-                    when (oldValue) {
-                        is Boolean -> !oldValue
-                        is Int -> oldValue.inc()
-                        is Long -> oldValue.inc()
-                        is Float -> oldValue.inc()
-                        is Double -> oldValue.inc()
-                        is String -> "foo$oldValue"
-                        is String? -> "foo"
-                        is CapitalizationMode -> CapitalizationMode.entries.let { it[(oldValue.ordinal + 1) % it.size] }
-                        is List<*> ->
-                            if (oldValue[0] is String) oldValue.map { it as String + "bar" } + "bar"
-                            else error(msg(prop))
-
-                        else -> error(msg(prop))
-                    }
-                )
-            } else {
-                // Mutate immutable properties in-place
-                when (oldValue) {
-                    is Scheme -> oldValue.mutate()
-                    is MutableList<*> ->
-                        if (oldValue[0] is Scheme)
-                            (oldValue as MutableList<Scheme>)
-                                .onEach { it.mutate() }
-                                .add(IntegerScheme())
-                        else error(msg(prop))
-
-                    else -> error(msg(prop))
-                }
-            }
-        }
-
-    return this
-}
-
-/**
- * Returns a [Template] containing `this` [Scheme]; if `this` is a [DecoratorScheme], `this` is put inside another
- * [Scheme].
- */
-fun <S : Scheme> S.asTemplate(): Template =
-    if (this is Template) this
-    else Template(
-        "My Template",
-        mutableListOf(
-            if (this is DecoratorScheme) {
-                val name = this::class.simpleName!!.replaceFirstChar { it.lowercaseChar() }
-                val const = IntegerScheme::class.primaryConstructor!!
-                const.callBy(mapOf(const.parameters.single { it.name == name } to this))
-            } else {
-                this
-            }
-        )
-    )
-
-
-/**
- * Tests that [mutate] actually changes fields.
- */
-object MutateTest : FunSpec({
-    context("mutate") {
-        test("mutates every field of IntegerScheme and its decorators") {
-            val before = IntegerScheme()
-            val after = IntegerScheme().mutate()
-
-            after shouldNotBe before
-
-            after.minValue shouldNotBe before.minValue
-            after.maxValue shouldNotBe before.maxValue
-            after.base shouldNotBe before.base
-            after.isUppercase shouldNotBe before.isUppercase
-            after.groupingSeparatorEnabled shouldNotBe before.groupingSeparatorEnabled
-            after.groupingSeparator shouldNotBe before.groupingSeparator
-
-            after.fixedLengthDecorator shouldNotBe before.fixedLengthDecorator
-            after.fixedLengthDecorator.enabled shouldNotBe before.fixedLengthDecorator.enabled
-            after.fixedLengthDecorator.length shouldNotBe before.fixedLengthDecorator.length
-            after.fixedLengthDecorator.filler shouldNotBe before.fixedLengthDecorator.filler
-
-            after.affixDecorator shouldNotBe before.affixDecorator
-            after.affixDecorator.enabled shouldNotBe before.affixDecorator.enabled
-            after.affixDecorator.descriptor shouldNotBe before.affixDecorator.descriptor
-
-            after.arrayDecorator shouldNotBe before.arrayDecorator
-            after.arrayDecorator.enabled shouldNotBe before.arrayDecorator.enabled
-            after.arrayDecorator.minCount shouldNotBe before.arrayDecorator.minCount
-            after.arrayDecorator.maxCount shouldNotBe before.arrayDecorator.maxCount
-            after.arrayDecorator.separatorEnabled shouldNotBe before.arrayDecorator.separatorEnabled
-            after.arrayDecorator.separator shouldNotBe before.arrayDecorator.separator
-
-            after.arrayDecorator.affixDecorator shouldNotBe before.arrayDecorator.affixDecorator
-            after.arrayDecorator.affixDecorator.enabled shouldNotBe before.arrayDecorator.affixDecorator.enabled
-            after.arrayDecorator.affixDecorator.descriptor shouldNotBe before.arrayDecorator.affixDecorator.descriptor
-        }
-    }
-})

--- a/src/test/resources/settings-upgrades/v3.1.0-v3.3.5.xml
+++ b/src/test/resources/settings-upgrades/v3.1.0-v3.3.5.xml
@@ -1,0 +1,47 @@
+<!-- This is a fictional config mixing v3.1.0 with v3.3.4, used only for some specific tests. -->
+<component name="Randomness">
+  <option name="uuid" value="1f4f2248-6934-4221-be27-103f03c9ccad"/>
+  <option name="version" value="3.1.0"/>
+  <option name="templateList">
+    <TemplateList>
+      <option name="uuid" value="31a9c2ee-9c42-44f4-b6fb-48dda2ba95de"/>
+      <option name="templates">
+        <list>
+          <Template>
+            <option name="name" value="UUID"/>
+            <option name="schemes">
+              <UuidScheme>
+                <option name="addDashes" value="true"/>
+                <option name="type" value="1"/>
+                <option name="uppercase" value="false"/>
+                <option name="uuid" value="240aaa25-eeb4-4564-8286-7c0c2420c874"/>
+                <option name="arrayDecorator">
+                  <ArrayDecorator>
+                    <option name="enabled" value="true" />
+                    <option name="maxCount" value="3" />
+                    <option name="minCount" value="3" />
+                    <option name="separator" value=", " />
+                    <option name="separatorEnabled" value="true" />
+                    <option name="uuid" value="c91dbee3-bf1c-4637-b1bc-7fcaeb521e0a" />
+                    <option name="affixDecorator">
+                      <AffixDecorator>
+                        <option name="descriptor" value="[@]" />
+                        <option name="enabled" value="true" />
+                        <option name="uuid" value="faf33697-551b-44c4-ad30-40896821cab7" />
+                        <option name="generator">
+                          <Function1 />
+                        </option>
+                      </AffixDecorator>
+                    </option>
+                    <option name="generator" />
+                  </ArrayDecorator>
+                </option>
+              </UuidScheme>
+            </option>
+            <option name="uuid" value="92fd8e20-618e-479f-93f0-ce04f6470caa"/>
+          </Template>
+        </list>
+      </option>
+    </TemplateList>
+  </option>
+</component>

--- a/src/test/resources/settings-upgrades/v3.3.4-v3.3.5.xml
+++ b/src/test/resources/settings-upgrades/v3.3.4-v3.3.5.xml
@@ -1,0 +1,66 @@
+<component name="Randomness">
+  <option name="uuid" value="eceb06e2-c4ef-481d-855b-4320efca8111" />
+  <option name="version" value="3.3.4" />
+  <option name="templateList">
+    <TemplateList>
+      <option name="uuid" value="2fd28530-b4cb-4ba4-af5e-e795b3db3da6" />
+      <option name="templates">
+        <list>
+          <Template>
+            <option name="name" value="Integer" />
+            <option name="schemes">
+              <IntegerScheme>
+                <option name="base" value="10" />
+                <option name="groupingSeparator" value="," />
+                <option name="groupingSeparatorEnabled" value="false" />
+                <option name="maxValue" value="1000" />
+                <option name="minValue" value="0" />
+                <option name="uppercase" value="false" />
+                <option name="uuid" value="f4b7bde8-f099-489e-b1d7-4a0224627cf5" />
+                <option name="fixedLengthDecorator">
+                  <FixedLengthDecorator>
+                    <option name="enabled" value="true" />
+                    <option name="filler" value="0" />
+                    <option name="length" value="3" />
+                    <option name="uuid" value="75d7e411-32ca-4aec-8620-d4101c071914" />
+                    <option name="generator" />
+                  </FixedLengthDecorator>
+                </option>
+                <option name="affixDecorator">
+                  <AffixDecorator>
+                    <option name="descriptor" value="0x@" />
+                    <option name="enabled" value="false" />
+                    <option name="uuid" value="c398f17c-194f-41ad-9206-10cb40abb8e6" />
+                    <option name="generator" />
+                  </AffixDecorator>
+                </option>
+                <option name="arrayDecorator">
+                  <ArrayDecorator>
+                    <option name="enabled" value="true" />
+                    <option name="maxCount" value="3" />
+                    <option name="minCount" value="3" />
+                    <option name="separator" value=", " />
+                    <option name="separatorEnabled" value="true" />
+                    <option name="uuid" value="c91dbee3-bf1c-4637-b1bc-7fcaeb521e0a" />
+                    <option name="affixDecorator">
+                      <AffixDecorator>
+                        <option name="descriptor" value="[@]" />
+                        <option name="enabled" value="true" />
+                        <option name="uuid" value="faf33697-551b-44c4-ad30-40896821cab7" />
+                        <option name="generator">
+                          <Function1 />
+                        </option>
+                      </AffixDecorator>
+                    </option>
+                    <option name="generator" />
+                  </ArrayDecorator>
+                </option>
+              </IntegerScheme>
+            </option>
+            <option name="uuid" value="722092d7-5e01-4627-a8c8-df152d1ff9bd" />
+          </Template>
+        </list>
+      </option>
+    </TemplateList>
+  </option>
+</component>


### PR DESCRIPTION
Fixes issue [#R37](https://github.com/FWDekkerBot/intellij-randomness-issues/issues/37).

The issue was that the `generator` field was incorrectly not seen as transient, and therefore serialized to users' config files. However, a lambda cannot be (de)serialized! Therefore, when loading the config, an exception occurred.

Understanding how the serializer determines what to serialize was very tough. It's so tough, and so unclear (imo) that I decided to [open an issue with JetBrains](https://youtrack.jetbrains.com/issue/IJPL-175868/Unclear-Transient-behaviour-with-inheritance) requesting that they either make it work as I expect it to, or better document how it works currently.

Until then, I have added a large number of tests that help verifying that serialization is successful. Previously, #551 introduced the "magical" `mutate` function to automatically mutate a `State` and see if this affects serialization. I have extended this idea with `StateReflection`, which is a general library for inspecting `State` classes generically (i.e. without knowing which state class it is) so that I can write automatically generated tests for serialization. Of course, those automated tests can also fail, so I also added a few manual tests that cover the most egregious cases.

Finally, this PR also
* fixes a few rather outdated calls to `lowercase` giving the no-longer-required `Locale` parameter, and
* moves various capitalisation helper functions to `CapitalizationMode` and better tests them.