### PR TITLE
Fix bug reporter bug, prepare for v3.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## 3.3.6 -- 2025-02-15
+### Fixed
+* Fixed exception when submitting bug report without Internet connection. ([#R40](https://github.com/FWDekkerBot/intellij-randomness-issues/issues/40)) ([#560](https://github.com/FWDekker/intellij-randomness/pull/560))
+
+
 ## 3.3.5 -- 2025-01-27
 ### Fixed
 * Fixed corrupted settings resulting in error messages after enabling "Array", "Fixed Length", or "Surround With" in any template or scheme. With this update, corrupted settings are patched back into a working state automatically. To prevent similar bugs in the future, unit tests have been added that automatically detect bugs resulting in corrupt settings. ([#R37](https://github.com/FWDekkerBot/intellij-randomness-issues/issues/37)) ([#558](https://github.com/FWDekker/intellij-randomness/pull/558))

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 group=com.fwdekker
 # Version number should also be updated in `com.fwdekker.randomness.PersistentSettings.Companion.CURRENT_VERSION`.
-version=3.3.5
+version=3.3.6
 
 # Compatibility
 # * `pluginSinceBuild`:

--- a/src/main/kotlin/com/fwdekker/randomness/ErrorReporter.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/ErrorReporter.kt
@@ -47,7 +47,7 @@ internal class ErrorReporter : ErrorReportSubmitter() {
     /**
      * Interacts with GitHub.
      */
-    private val github by lazy { GitHubReporter() }
+    private val github = GitHubReporter()
 
 
     /**
@@ -141,7 +141,9 @@ private class GitHubReporter {
     /**
      * Service for interacting with the issues API on GitHub.
      */
-    private val issueService = IssueService(GitHubClient().also { it.setOAuth2Token(GitHubScrambler.getToken()) })
+    private val issueService by lazy {
+        IssueService(GitHubClient().also { it.setOAuth2Token(GitHubScrambler.getToken()) })
+    }
 
 
     /**

--- a/src/main/kotlin/com/fwdekker/randomness/Settings.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/Settings.kt
@@ -128,7 +128,7 @@ internal class PersistentSettings : PersistentStateComponent<Element> {
         /**
          * The currently-running version of Randomness.
          */
-        const val CURRENT_VERSION: String = "3.3.5" // Synchronize this with the version in `gradle.properties`
+        const val CURRENT_VERSION: String = "3.3.6" // Synchronize this with the version in `gradle.properties`
 
         /**
          * The upgrade functions to apply to configuration [Element]s in the [upgrade] method.

--- a/src/main/resources/randomness.properties
+++ b/src/main/resources/randomness.properties
@@ -104,7 +104,7 @@ reporter.notify.view_in_browser=View report in browser
 reporter.privacy_notice=Pressing the Report button will create an anonymous, publicly-visible report on GitHub. The report will contain the error description you wrote, the attachment(s) shown above, and the version number of Randomness, your IDE, your operating system, and your Java installation. Please check <a href="https://github.com/site/privacy">GitHub's privacy policy</a>.
 reporter.report=Report
 reporter.report.duplicate=</a>a comment to <a href="%1$s">issue #%2$d</a>. Thank you for your feedback!
-reporter.report.error=This may happen if you are using an old version of Randomness. Otherwise, please try again later. If this keeps happening, consider <a href="https://github.com/FWDekker/intellij-randomness/issues/new/choose">reporting this issue manually</a>.
+reporter.report.error=This may happen if you do not have an Internet connection, or if you are using an old version of Randomness. If this is not the case, please try again later. If this keeps happening, consider <a href="https://github.com/FWDekker/intellij-randomness/issues/new/choose">reporting this issue manually</a>.
 reporter.report.new=</a><a href="%1$s">issue #%2$d</a>. Thank you for your feedback!
 reporter.task.title=Submitting issue report
 shared.action.add=Add


### PR DESCRIPTION
Fixes FWDekkerBot/intellij-randomness-issues#40.

Simply makes sure that the initialisation of the network-related code happens inside the `GithubReporter`'s `try`-`catch` block.