### PR TITLE
Bump dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## 9.9.9-unreleased
+Delete this.
+
+
 ## 3.3.6 -- 2025-02-15
 ### Fixed
 * Fixed exception when submitting bug report without Internet connection. ([#R40](https://github.com/FWDekkerBot/intellij-randomness-issues/issues/40)) ([#560](https://github.com/FWDekker/intellij-randomness/pull/560))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -75,7 +75,10 @@ dependencies {
     dokkaHtmlPlugin("org.jetbrains.dokka", "versioning-plugin", properties("dokkaVersion"))
 
     intellijPlatform {
-        intellijIdeaCommunity(properties("intellijVersion"))
+        intellijIdeaCommunity(
+            properties("intellijVersion"),
+            useInstaller = !properties("intellijVersion").endsWith("EAP-SNAPSHOT"),
+        )
 
         pluginVerifier()
         zipSigner()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,26 +12,26 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.net.URI
 import java.time.Year
 
-fun properties(key: String) = project.findProperty(key).toString()
+fun properties(key: String): String = project.findProperty(key).toString()
 
 
 /// Plugins
 plugins {
     // Compilation
-    id("org.jetbrains.kotlin.jvm") version "1.9.21"  // Set to latest version compatible with `pluginSinceBuild`, see also https://plugins.jetbrains.com/docs/intellij/using-kotlin.html#kotlin-standard-library
-    id("org.jetbrains.intellij.platform") version "2.1.0"
+    id("org.jetbrains.kotlin.jvm") version "1.9.24"  // Set to latest version compatible with `pluginSinceBuild`, see also https://plugins.jetbrains.com/docs/intellij/using-kotlin.html#kotlin-standard-library
+    id("org.jetbrains.intellij.platform") version "2.5.0"
 
     // Tests/coverage
-    id("org.jetbrains.kotlinx.kover") version "0.8.3"
+    id("org.jetbrains.kotlinx.kover") version "0.9.1"
 
     // Static analysis
-    id("io.gitlab.arturbosch.detekt") version "1.23.7"  // See also `gradle.properties`
+    id("io.gitlab.arturbosch.detekt") version "1.23.8"  // See also `gradle.properties`
 
     // Documentation
     id("org.jetbrains.changelog") version "2.2.1"
     id("org.jetbrains.dokka") version "1.9.20"  // See also `buildscript.dependencies` below and `gradle.properties`
 
-    // Runs GitHubScrambler
+    // To run GitHubScrambler
     application
 }
 
@@ -79,7 +79,6 @@ dependencies {
 
         pluginVerifier()
         zipSigner()
-        instrumentationTools()
 
         testFramework(TestFrameworkType.Platform)
     }
@@ -89,13 +88,14 @@ dependencies {
 /// Configuration
 tasks {
     // Compilation
+    java.toolchain.languageVersion.set(JavaLanguageVersion.of(properties("javaVersion")))  // See also https://github.com/gradle/gradle/issues/30499
     withType<JavaCompile> {
         sourceCompatibility = properties("javaVersion")
         targetCompatibility = properties("javaVersion")
     }
     withType<KotlinCompile> {
         kotlinOptions {
-            // Transforms "1.9.20" to "1.9"
+            // Transforms e.g. "1.9.20" to "1.9"
             val kotlinApiVersion = properties("kotlinVersion").split(".").take(2).joinToString(".")
 
             jvmTarget = properties("javaVersion")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,7 @@
 group=com.fwdekker
 # Version number should also be updated in `com.fwdekker.randomness.PersistentSettings.Companion.CURRENT_VERSION`.
-version=3.3.6
+# For in-development versions, write `9.9.9-unreleased`.
+version=9.9.9-unreleased
 
 # Compatibility
 # * `pluginSinceBuild`:
@@ -11,9 +12,9 @@ version=3.3.6
 # * `pluginVerifierIdeVersions`:
 #     For every supported version minor release, include both the IC and the CL release with the highest patch version
 #     See also https://data.services.jetbrains.com/products?fields=name,releases.version,releases.build&code=IC,CL.
-pluginSinceBuild=233.0
-intellijVersion=2023.3
-pluginVerifierIdeVersions=IC-2023.3.8, IC-2024.1.6, IC-2024.2.3, CL-2023.3.6, CL-2024.1.5, CL-2024.2.2
+pluginSinceBuild=242.0
+intellijVersion=2024.2
+pluginVerifierIdeVersions=IC-2024.2.5, IC-2024.3.5, IC-2025.1, CL-2024.2.4, CL-2024.3.5, CL-2025.1
 
 # Targets
 # * Java:
@@ -24,8 +25,8 @@ pluginVerifierIdeVersions=IC-2023.3.8, IC-2024.1.6, IC-2024.2.3, CL-2023.3.6, CL
 #     * Kotlin version should be bundled stdlib version of oldest supported IntelliJ version. See also
 #       https://plugins.jetbrains.com/docs/intellij/using-kotlin.html#kotlin-standard-library.
 #     * Ensure the version of the `org.jetbrains.kotlin.jvm` in `build.gradle.kts` is updated accordingly.
-javaVersion=17
-kotlinVersion=1.9.21
+javaVersion=21
+kotlinVersion=1.9.24
 
 # Dependencies
 # * Detekt should also be updated in `plugins` block.
@@ -33,11 +34,11 @@ kotlinVersion=1.9.21
 # * RgxGen should also be updated in `string.ui.value.pattern_help_url` property in `randomness.properties`.
 assertjSwingVersion=3.17.1
 dateparserVersion=1.0.11
-detektVersion=1.23.7
+detektVersion=1.23.8
 dokkaVersion=1.9.20
 githubCore=2.1.5
-junitVersion=5.11.1
-junitRunnerVersion=1.11.1
+junitVersion=5.12.2
+junitRunnerVersion=1.12.2
 kotestVersion=5.9.1
 rgxgenVersion=2.0
 uuidGeneratorVersion=5.1.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,6 +9,7 @@ version=9.9.9-unreleased
 #     2019.4 (aka 2020.1).
 # * `intellijVersion`:
 #     Use the oldest supported version, because that's what the plugin will be compiled against.
+#     If you want to test the EAP version of, say, IntelliJ 2024.3, use version number `243-EAP-SNAPSHOT`.
 # * `pluginVerifierIdeVersions`:
 #     For every supported version minor release, include both the IC and the CL release with the highest patch version
 #     See also https://data.services.jetbrains.com/products?fields=name,releases.version,releases.build&code=IC,CL.

--- a/gradle.properties
+++ b/gradle.properties
@@ -50,4 +50,3 @@ org.gradle.configuration-cache=true
 # Kotlin
 kotlin.code.style=official
 kotlin.stdlib.default.dependency=false
-kotlin.incremental.useClasspathSnapshot=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip

--- a/src/main/kotlin/com/fwdekker/randomness/ErrorReporter.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/ErrorReporter.kt
@@ -30,7 +30,7 @@ import org.eclipse.egit.github.core.client.PageIterator
 import org.eclipse.egit.github.core.service.IssueService
 import java.awt.Component
 import java.io.File
-import java.net.URL
+import java.net.URI
 import java.util.Base64
 import javax.crypto.Cipher
 import javax.crypto.spec.IvParameterSpec
@@ -245,7 +245,8 @@ private object GitHubScrambler {
      * The URL at which a newer token may be available.
      */
     private val URL =
-        URL("https://raw.githubusercontent.com/FWDekker/intellij-randomness/main/src/main/resources/reporter/token.bin")
+        URI("https://raw.githubusercontent.com/FWDekker/intellij-randomness/main/src/main/resources/reporter/token.bin")
+            .toURL()
 
 
     /**

--- a/src/main/kotlin/com/fwdekker/randomness/string/StringSchemeEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/string/StringSchemeEditor.kt
@@ -13,9 +13,9 @@ import com.intellij.ui.dsl.builder.BottomGap
 import com.intellij.ui.dsl.builder.bindItem
 import com.intellij.ui.dsl.builder.bindSelected
 import com.intellij.ui.dsl.builder.bindText
-import com.intellij.ui.dsl.builder.listCellRenderer
 import com.intellij.ui.dsl.builder.panel
 import com.intellij.ui.dsl.builder.toNullableProperty
+import com.intellij.ui.dsl.listCellRenderer.textListCellRenderer
 import com.intellij.ui.layout.selected
 import javax.swing.JCheckBox
 
@@ -54,7 +54,7 @@ class StringSchemeEditor(scheme: StringScheme = StringScheme()) : SchemeEditor<S
             }.bottomGap(BottomGap.SMALL)
 
             row(Bundle("string.ui.value.capitalization_option")) {
-                comboBox(PRESET_CAPITALIZATION, listCellRenderer { it.toLocalizedString() })
+                comboBox(PRESET_CAPITALIZATION, textListCellRenderer { it?.toLocalizedString() })
                     .withName("capitalization")
                     .bindItem(scheme::capitalization.toNullableProperty())
             }

--- a/src/main/kotlin/com/fwdekker/randomness/template/TemplateActions.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/template/TemplateActions.kt
@@ -11,6 +11,7 @@ import com.fwdekker.randomness.ui.PreviewPanel
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.actionSystem.ActionGroup
 import com.intellij.openapi.actionSystem.ActionUpdateThread
+import com.intellij.openapi.actionSystem.ActionWrapperUtil
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.options.Configurable
@@ -67,7 +68,7 @@ class TemplateGroupAction(private val template: Template) :
             array = event.inputEvent?.isShiftDown ?: false,
             repeat = event.inputEvent?.isAltDown ?: false,
             settings = event.inputEvent?.isControlDown ?: false
-        ).actionPerformed(event)
+        ).let { ActionWrapperUtil.actionPerformed(event, it, this) }
 
     /**
      * Returns variant actions for the main insertion action.

--- a/src/main/kotlin/com/fwdekker/randomness/template/TemplateReferenceEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/template/TemplateReferenceEditor.kt
@@ -12,9 +12,9 @@ import com.intellij.openapi.ui.ComboBox
 import com.intellij.ui.ColoredListCellRenderer
 import com.intellij.ui.dsl.builder.AlignX
 import com.intellij.ui.dsl.builder.bindItem
-import com.intellij.ui.dsl.builder.listCellRenderer
 import com.intellij.ui.dsl.builder.panel
 import com.intellij.ui.dsl.builder.toNullableProperty
+import com.intellij.ui.dsl.listCellRenderer.textListCellRenderer
 import com.intellij.ui.layout.ComboBoxPredicate
 import javax.swing.JList
 
@@ -47,7 +47,7 @@ class TemplateReferenceEditor(scheme: TemplateReference) : SchemeEditor<Template
             }
 
             row(Bundle("reference.ui.value.capitalization_option")) {
-                comboBox(PRESET_CAPITALIZATION, listCellRenderer { it.toLocalizedString() })
+                comboBox(PRESET_CAPITALIZATION, textListCellRenderer { it?.toLocalizedString() })
                     .withName("capitalization")
                     .bindItem(scheme::capitalization.toNullableProperty())
             }

--- a/src/main/kotlin/com/fwdekker/randomness/word/WordSchemeEditor.kt
+++ b/src/main/kotlin/com/fwdekker/randomness/word/WordSchemeEditor.kt
@@ -23,10 +23,10 @@ import com.intellij.openapi.ui.ComboBox
 import com.intellij.openapi.util.Disposer
 import com.intellij.ui.dsl.builder.AlignX
 import com.intellij.ui.dsl.builder.bindItem
-import com.intellij.ui.dsl.builder.listCellRenderer
 import com.intellij.ui.dsl.builder.panel
 import com.intellij.ui.dsl.builder.toMutableProperty
 import com.intellij.ui.dsl.builder.toNullableProperty
+import com.intellij.ui.dsl.listCellRenderer.textListCellRenderer
 import java.awt.event.ItemEvent
 
 
@@ -42,7 +42,7 @@ class WordSchemeEditor(scheme: WordScheme = WordScheme()) : SchemeEditor<WordSch
             lateinit var document: Document
 
             row(Bundle("word.ui.words.insert_option")) {
-                comboBox(listOf(PRESET_ITEM) + DefaultWordList.WORD_LISTS, listCellRenderer { it.name })
+                comboBox(listOf(PRESET_ITEM) + DefaultWordList.WORD_LISTS, textListCellRenderer { it?.name })
                     .withName("presets")
                     .also {
                         it.component.addItemListener { event ->
@@ -85,7 +85,7 @@ class WordSchemeEditor(scheme: WordScheme = WordScheme()) : SchemeEditor<WordSch
 
         group(Bundle("word.ui.format.header")) {
             row(Bundle("word.ui.format.capitalization_option")) {
-                comboBox(PRESET_CAPITALIZATION, listCellRenderer { it.toLocalizedString() })
+                comboBox(PRESET_CAPITALIZATION, textListCellRenderer { it?.toLocalizedString() })
                     .withName("capitalization")
                     .bindItem(scheme::capitalization.toNullableProperty())
             }

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateJTreeTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateJTreeTest.kt
@@ -827,6 +827,7 @@ object TemplateJTreeTest : FunSpec({
                 guiRun {
                     tree.expandRow(0)
                     tree.selectedScheme = currentList.templates[0].schemes[1]
+                    updateButtons()
                 }
 
                 guiRun { frame.getActionButton("Up").click() }
@@ -901,6 +902,9 @@ object TemplateJTreeTest : FunSpec({
 
                 guiRun {
                     tree.selectedScheme = template
+                    updateButtons()
+                }
+                guiRun {
                     frame.getActionButton("Reset").click()
                 }
 
@@ -909,7 +913,10 @@ object TemplateJTreeTest : FunSpec({
 
             test("resets changes to the initially selected scheme") {
                 (currentList.templates[0].schemes[0] as DummyScheme).name = "New Name"
-                guiRun { tree.reload() }
+                guiRun {
+                    tree.reload()
+                    updateButtons()
+                }
                 currentList.templates[0].schemes[0].name shouldBe "New Name"
 
                 guiRun { frame.getActionButton("Reset").click() }
@@ -919,7 +926,10 @@ object TemplateJTreeTest : FunSpec({
 
             test("resets changes to a template") {
                 currentList.templates[0].name = "New Name"
-                guiRun { tree.reload() }
+                guiRun {
+                    tree.reload()
+                    updateButtons()
+                }
                 currentList.templates[0].name shouldBe "New Name"
 
                 guiRun {
@@ -937,8 +947,9 @@ object TemplateJTreeTest : FunSpec({
 
                 guiRun {
                     tree.selectedScheme = currentList.templates[1].schemes[0]
-                    frame.getActionButton("Reset").click()
+                    updateButtons()
                 }
+                guiRun { frame.getActionButton("Reset").click() }
 
                 currentList.templates[1].schemes[0].name shouldBe "Scheme2"
             }
@@ -950,8 +961,9 @@ object TemplateJTreeTest : FunSpec({
 
                 guiRun {
                     tree.selectedScheme = currentList.templates[0]
-                    frame.getActionButton("Reset").click()
+                    updateButtons()
                 }
+                guiRun { frame.getActionButton("Reset").click() }
 
                 currentList.templates[0].schemes.names() shouldContainExactly listOf("Scheme0", "Scheme1")
             }
@@ -963,8 +975,9 @@ object TemplateJTreeTest : FunSpec({
 
                 guiRun {
                     tree.selectedScheme = currentList.templates[2]
-                    frame.getActionButton("Reset").click()
+                    updateButtons()
                 }
+                guiRun { frame.getActionButton("Reset").click() }
 
                 currentList.templates[2].schemes[0].name shouldBe "Scheme3"
             }
@@ -975,7 +988,10 @@ object TemplateJTreeTest : FunSpec({
                 currentList.templates[0].schemes[0].name shouldBe "New Name"
                 guiRun { frame.getActionButton("Reset").click() }
                 (currentList.templates[0].schemes[0] as DummyScheme).name = "New Name"
-                guiRun { tree.reload() }
+                guiRun {
+                    tree.reload()
+                    updateButtons()
+                }
                 currentList.templates[0].schemes[0].name shouldBe "New Name"
 
                 guiRun { frame.getActionButton("Reset").click() }


### PR DESCRIPTION
Bumps a load of dependencies, and fixes associated compatibility issues. (Specifically, fixes #553, fixes #554, fixes #555, and fixes #556.)

Admittedly, the whole `updateButtons()` thing is not maintainable and should be replaced by something better, perhaps (= probably) by integrating with IntelliJ's own UI testing framework.