### PR TITLE
Kotest improvements

### DIFF
--- a/src/test/kotlin/com/fwdekker/randomness/CapitalizationModeTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/CapitalizationModeTest.kt
@@ -1,11 +1,10 @@
 package com.fwdekker.randomness
 
-import com.fwdekker.randomness.testhelpers.matchBundle
+import com.fwdekker.randomness.testhelpers.shouldMatchBundle
 import io.kotest.assertions.retry
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.data.row
 import io.kotest.datatest.withData
-import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldBeEqualIgnoringCase
@@ -76,7 +75,7 @@ object CapitalizationModeTest : FunSpec({
 
     context("toLocalizedString") {
         test("returns the associated localized string") {
-            CapitalizationMode.FIRST_LETTER.toLocalizedString() should matchBundle("shared.capitalization.first_letter")
+            CapitalizationMode.FIRST_LETTER.toLocalizedString() shouldMatchBundle "shared.capitalization.first_letter"
         }
     }
 })

--- a/src/test/kotlin/com/fwdekker/randomness/IconsTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/IconsTest.kt
@@ -4,12 +4,12 @@ package com.fwdekker.randomness
 
 import com.fwdekker.randomness.testhelpers.Tags
 import com.fwdekker.randomness.testhelpers.afterNonContainer
-import com.fwdekker.randomness.testhelpers.beSameIconAs
 import com.fwdekker.randomness.testhelpers.beforeNonContainer
 import com.fwdekker.randomness.testhelpers.colorIcon
 import com.fwdekker.randomness.testhelpers.getEastColor
 import com.fwdekker.randomness.testhelpers.getWestColor
 import com.fwdekker.randomness.testhelpers.render
+import com.fwdekker.randomness.testhelpers.shouldBeSameIconAs
 import com.fwdekker.randomness.testhelpers.typeIcon
 import com.intellij.testFramework.fixtures.IdeaTestFixture
 import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
@@ -19,11 +19,9 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.common.ExperimentalKotest
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.beEmpty
-import io.kotest.matchers.collections.contain
-import io.kotest.matchers.collections.haveSize
 import io.kotest.matchers.collections.shouldContainExactly
-import io.kotest.matchers.nulls.beNull
-import io.kotest.matchers.should
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
 import io.kotest.matchers.types.shouldBeSameInstanceAs
@@ -93,7 +91,7 @@ object TypeIconTest : FunSpec({
 
     context("combine") {
         test("returns `null` if no icons are given to combine") {
-            TypeIcon.combine(emptyList()) should beNull()
+            TypeIcon.combine(emptyList()) shouldBe null
         }
 
         test("returns a template icon for a single icon") {
@@ -181,23 +179,23 @@ object OverlayedIconTest : FunSpec({
     context("plusOverlay") {
         test("does not alter the original icon") {
             val icon = OverlayedIcon(typeIcon(), listOf(OverlayIcon.ARRAY))
-            icon.overlays should haveSize(1)
+            icon.overlays shouldHaveSize 1
 
             val alteredIcon = icon.plusOverlay(OverlayIcon.SETTINGS)
 
-            icon.overlays should haveSize(1)
-            alteredIcon.overlays should haveSize(2)
+            icon.overlays shouldHaveSize 1
+            alteredIcon.overlays shouldHaveSize 2
         }
 
         test("returns a copy with the given overlay added") {
             val overlay = OverlayIcon.REPEAT
             val icon = OverlayedIcon(typeIcon(), listOf(OverlayIcon.ARRAY))
-            icon.overlays should haveSize(1)
-            icon.overlays shouldNot contain(overlay)
+            icon.overlays shouldHaveSize 1
+            icon.overlays shouldNotContain overlay
 
             val alteredIcon = icon.plusOverlay(overlay)
 
-            alteredIcon.overlays should haveSize(2)
+            alteredIcon.overlays shouldHaveSize 2
             alteredIcon.overlays.last() shouldBe overlay
         }
     }
@@ -230,7 +228,7 @@ object OverlayedIconTest : FunSpec({
 
             val overlayed = OverlayedIcon(base)
 
-            base should beSameIconAs(overlayed)
+            base shouldBeSameIconAs overlayed
         }
 
         test("returns an icon that paints the base even if overlays are specified") {

--- a/src/test/kotlin/com/fwdekker/randomness/InsertActionTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/InsertActionTest.kt
@@ -4,8 +4,8 @@ import com.fwdekker.randomness.testhelpers.DummyInsertAction
 import com.fwdekker.randomness.testhelpers.Tags
 import com.fwdekker.randomness.testhelpers.afterNonContainer
 import com.fwdekker.randomness.testhelpers.beforeNonContainer
-import com.fwdekker.randomness.testhelpers.edtTest
-import com.fwdekker.randomness.testhelpers.guiRun
+import com.fwdekker.randomness.testhelpers.ideaEdtTest
+import com.fwdekker.randomness.testhelpers.ideaRunEdt
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.actionSystem.Presentation
@@ -40,7 +40,7 @@ object InsertActionTest : FunSpec({
         myFixture.testDataPath = javaClass.classLoader.getResource("integration-project/")!!.path
         myFixture.setUp()
 
-        guiRun {
+        ideaRunEdt {
             val file = myFixture.copyFileToProject("emptyFile.txt")
             myFixture.openFileInEditor(file)
 
@@ -89,13 +89,13 @@ object InsertActionTest : FunSpec({
 
 
     context("actionPerformed") {
-        edtTest("inserts text into an empty document") {
+        ideaEdtTest("inserts text into an empty document") {
             myFixture.testAction(insertAction)
 
             document.text shouldBe "0"
         }
 
-        edtTest("inserts text in front of existing text") {
+        ideaEdtTest("inserts text in front of existing text") {
             runWriteCommandAction(myFixture.project) { document.setText("contents") }
 
             setCaret(0)
@@ -104,7 +104,7 @@ object InsertActionTest : FunSpec({
             document.text shouldBe "0contents"
         }
 
-        edtTest("inserts text behind existing text") {
+        ideaEdtTest("inserts text behind existing text") {
             runWriteCommandAction(myFixture.project) { document.setText("contents") }
 
             setCaret(8)
@@ -113,7 +113,7 @@ object InsertActionTest : FunSpec({
             document.text shouldBe "contents0"
         }
 
-        edtTest("inserts text in the middle of existing text") {
+        ideaEdtTest("inserts text in the middle of existing text") {
             runWriteCommandAction(myFixture.project) { document.setText("contents") }
 
             setCaret(3)
@@ -122,7 +122,7 @@ object InsertActionTest : FunSpec({
             document.text shouldBe "con0tents"
         }
 
-        edtTest("replaces the entire document if selected") {
+        ideaEdtTest("replaces the entire document if selected") {
             runWriteCommandAction(myFixture.project) { document.setText("contents") }
 
             setSelection(0, 8)
@@ -131,7 +131,7 @@ object InsertActionTest : FunSpec({
             document.text shouldBe "0"
         }
 
-        edtTest("replaces a partial selection of text") {
+        ideaEdtTest("replaces a partial selection of text") {
             runWriteCommandAction(myFixture.project) { document.setText("contents") }
 
             setSelection(2, 4)
@@ -140,7 +140,7 @@ object InsertActionTest : FunSpec({
             document.text shouldBe "co0ents"
         }
 
-        edtTest("inserts text at multiple carets") {
+        ideaEdtTest("inserts text at multiple carets") {
             runWriteCommandAction(myFixture.project) { document.setText("line1\nline2\nline3") }
 
             setCaret(2)
@@ -151,7 +151,7 @@ object InsertActionTest : FunSpec({
             document.text shouldBe "li0ne1\nl1ine2\nline23"
         }
 
-        edtTest("replaces text at multiple carets") {
+        ideaEdtTest("replaces text at multiple carets") {
             runWriteCommandAction(myFixture.project) { document.setText("line1\nline2\nline3") }
 
             setSelection(2, 7)
@@ -161,7 +161,7 @@ object InsertActionTest : FunSpec({
             document.text shouldBe "li0ine1e3"
         }
 
-        edtTest("simultaneously inserts at carets and replaces at selections") {
+        ideaEdtTest("simultaneously inserts at carets and replaces at selections") {
             runWriteCommandAction(myFixture.project) { document.setText("line1\nline2\nline3") }
 
             setCaret(2)
@@ -173,7 +173,7 @@ object InsertActionTest : FunSpec({
             document.text shouldBe "li0ne1li2ne2\n3e3"
         }
 
-        edtTest("inserts the same value at multiple carets") {
+        ideaEdtTest("inserts the same value at multiple carets") {
             runWriteCommandAction(myFixture.project) { document.setText("line1\nline2\nline3") }
 
             setCaret(5)
@@ -187,19 +187,19 @@ object InsertActionTest : FunSpec({
         }
 
 
-        edtTest("inserts nothing if the scheme is invalid") {
+        ideaEdtTest("inserts nothing if the scheme is invalid") {
             myFixture.testAction(DummyInsertAction { throw DataGenerationException("Invalid input!") })
 
             document.text shouldBe ""
         }
 
-        edtTest("inserts nothing if the scheme is invalid with an empty message") {
+        ideaEdtTest("inserts nothing if the scheme is invalid with an empty message") {
             myFixture.testAction(DummyInsertAction { throw DataGenerationException() })
 
             document.text shouldBe ""
         }
 
-        edtTest("inserts nothing if the project is null") {
+        ideaEdtTest("inserts nothing if the project is null") {
             val event = AnActionEvent.createFromDataContext("", null) {
                 if (it == CommonDataKeys.PROJECT.name) myFixture.project
                 else null
@@ -210,7 +210,7 @@ object InsertActionTest : FunSpec({
             document.text shouldBe ""
         }
 
-        edtTest("inserts nothing if the editor is null") {
+        ideaEdtTest("inserts nothing if the editor is null") {
             val event = AnActionEvent.createFromDataContext("", null) {
                 if (it == CommonDataKeys.EDITOR.name) myFixture.editor
                 else null
@@ -223,7 +223,7 @@ object InsertActionTest : FunSpec({
     }
 
     context("presentation") {
-        edtTest("disables the presentation if the editor is null") {
+        ideaEdtTest("disables the presentation if the editor is null") {
             val presentation = Presentation()
 
             insertAction.update(AnActionEvent.createFromDataContext("", presentation) { null })
@@ -231,7 +231,7 @@ object InsertActionTest : FunSpec({
             presentation.isEnabled shouldBe false
         }
 
-        edtTest("enables the presentation if the editor is not null") {
+        ideaEdtTest("enables the presentation if the editor is not null") {
             val presentation = Presentation()
 
             insertAction.update(AnActionEvent.createFromDataContext("", presentation) { myFixture.editor })
@@ -239,7 +239,7 @@ object InsertActionTest : FunSpec({
             presentation.isEnabled shouldBe true
         }
 
-        edtTest("disables the presentation if the editor is read-only") {
+        ideaEdtTest("disables the presentation if the editor is read-only") {
             val presentation = Presentation()
 
             myFixture.editor.document.setReadOnly(true)

--- a/src/test/kotlin/com/fwdekker/randomness/PersistentSettingsTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/PersistentSettingsTest.kt
@@ -8,10 +8,9 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.data.row
 import io.kotest.datatest.withData
 import io.kotest.matchers.collections.beEmpty
-import io.kotest.matchers.nulls.beNull
-import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
+import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldStartWith
 import java.io.FileNotFoundException
 import java.lang.module.ModuleDescriptor.Version
@@ -78,36 +77,36 @@ object PersistentSettingsTest : FunSpec({
                 val stored = JDOMUtil.load(getTestConfig("/settings-upgrades/v3.1.0-v3.3.5.xml"))
                 stored.getSchemes().single().run {
                     getPropertyValue("type") shouldBe "1"
-                    getProperty("version") should beNull()
+                    getProperty("version") shouldBe null
                 }
                 stored.getDecorators() shouldNot beEmpty()
-                stored.getDecorators().forEach { it.getProperty("generator") shouldNot beNull() }
+                stored.getDecorators().forEach { it.getProperty("generator") shouldNotBe null }
 
                 val patched = settings.upgrade(stored, Version.parse("3.3.5"))
                 patched.getSchemes().single().run {
-                    getProperty("type") should beNull()
+                    getProperty("type") shouldBe null
                     getPropertyValue("version") shouldBe "1"
                 }
                 patched.getDecorators() shouldNot beEmpty()
-                patched.getDecorators().forEach { it.getProperty("generator") should beNull() }
+                patched.getDecorators().forEach { it.getProperty("generator") shouldBe null }
             }
 
             test("upgrades only up to the specified version") {
                 val stored = JDOMUtil.load(getTestConfig("/settings-upgrades/v3.1.0-v3.3.5.xml"))
                 stored.getSchemes().single().run {
                     getPropertyValue("type") shouldBe "1"
-                    getProperty("version") should beNull()
+                    getProperty("version") shouldBe null
                 }
                 stored.getDecorators() shouldNot beEmpty()
-                stored.getDecorators().forEach { it.getProperty("generator") shouldNot beNull() }
+                stored.getDecorators().forEach { it.getProperty("generator") shouldNotBe null }
 
                 val patched = settings.upgrade(stored, Version.parse("3.2.0"))
                 patched.getSchemes().single().run {
-                    getProperty("type") should beNull()
+                    getProperty("type") shouldBe null
                     getPropertyValue("version") shouldBe "1"
                 }
                 stored.getDecorators() shouldNot beEmpty()
-                stored.getDecorators().forEach { it.getProperty("generator") shouldNot beNull() }
+                stored.getDecorators().forEach { it.getProperty("generator") shouldNotBe null }
             }
         }
 

--- a/src/test/kotlin/com/fwdekker/randomness/SchemeEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/SchemeEditorTest.kt
@@ -16,7 +16,6 @@ import com.intellij.ui.dsl.builder.panel
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.ints.shouldBeGreaterThanOrEqual
-import io.kotest.matchers.nulls.beNull
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.beInstanceOf
@@ -105,7 +104,7 @@ object SchemeEditorTest : FunSpec({
                 }
             }
 
-            editor.preferredFocusedComponent should beNull()
+            editor.preferredFocusedComponent shouldBe null
         }
     }
 

--- a/src/test/kotlin/com/fwdekker/randomness/SchemeEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/SchemeEditorTest.kt
@@ -6,8 +6,7 @@ import com.fwdekker.randomness.testhelpers.DummyScheme
 import com.fwdekker.randomness.testhelpers.DummySchemeEditor
 import com.fwdekker.randomness.testhelpers.Tags
 import com.fwdekker.randomness.testhelpers.afterNonContainer
-import com.fwdekker.randomness.testhelpers.guiGet
-import com.fwdekker.randomness.testhelpers.guiRun
+import com.fwdekker.randomness.testhelpers.ideaRunEdt
 import com.fwdekker.randomness.testhelpers.useBareIdeaFixture
 import com.fwdekker.randomness.testhelpers.useEdtViolationDetection
 import com.fwdekker.randomness.ui.withName
@@ -46,7 +45,7 @@ object SchemeEditorTest : FunSpec({
 
 
     suspend fun registerTestEditor(createEditor: () -> DummySchemeEditor) {
-        editor = guiGet(createEditor)
+        editor = ideaRunEdt(createEditor)
         frame = Containers.showInFrame(editor.rootComponent)
     }
 
@@ -118,9 +117,9 @@ object SchemeEditorTest : FunSpec({
             }
             frame.textBox().requireText("old")
 
-            guiRun { frame.textBox().target().text = "new" }
+            ideaRunEdt { frame.textBox().target().text = "new" }
             frame.textBox().requireText("new")
-            guiRun { editor.reset() }
+            ideaRunEdt { editor.reset() }
 
             frame.textBox().requireText("old")
         }
@@ -142,9 +141,9 @@ object SchemeEditorTest : FunSpec({
             }
             frame.textBox().requireText("old")
 
-            guiRun { frame.textBox().target().text = "new" }
+            ideaRunEdt { frame.textBox().target().text = "new" }
             frame.textBox().requireText("new")
-            guiRun { editor.reset() }
+            ideaRunEdt { editor.reset() }
 
             frame.textBox().requireText("old")
         }
@@ -155,7 +154,7 @@ object SchemeEditorTest : FunSpec({
             val scheme = DummyScheme(prefix = "old")
             registerTestEditor { DummySchemeEditor(scheme) { panel { row { textField().bindText(scheme::prefix) } } } }
 
-            guiRun { frame.textBox().target().text = "new" }
+            ideaRunEdt { frame.textBox().target().text = "new" }
             editor.apply()
 
             scheme.prefix shouldBe "new"
@@ -176,7 +175,7 @@ object SchemeEditorTest : FunSpec({
                 }
             }
 
-            guiRun { frame.textBox().target().text = "new" }
+            ideaRunEdt { frame.textBox().target().text = "new" }
             editor.apply()
 
             scheme.decorators[0] shouldBeSameInstanceAs decorator
@@ -191,7 +190,7 @@ object SchemeEditorTest : FunSpec({
 
             var updateCount = 0
             editor.addChangeListener { updateCount++ }
-            guiRun { frame.textBox().target().text = "new" }
+            ideaRunEdt { frame.textBox().target().text = "new" }
 
             updateCount shouldBe 1
         }
@@ -203,7 +202,7 @@ object SchemeEditorTest : FunSpec({
 
             var updateCount = 0
             editor.addChangeListener { updateCount++ }
-            guiRun { frame.textBox().target().text = "new" }
+            ideaRunEdt { frame.textBox().target().text = "new" }
 
             updateCount shouldBeGreaterThanOrEqual 1
         }
@@ -226,7 +225,7 @@ object SchemeEditorTest : FunSpec({
 
             var updateCount = 0
             editor.addChangeListener { updateCount++ }
-            guiRun { frame.textBox().target().text = "new" }
+            ideaRunEdt { frame.textBox().target().text = "new" }
 
             updateCount shouldBeGreaterThanOrEqual 2
         }

--- a/src/test/kotlin/com/fwdekker/randomness/SchemeTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/SchemeTest.kt
@@ -7,7 +7,6 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.shouldContainExactly
-import io.kotest.matchers.nulls.beNull
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeSameInstanceAs
@@ -26,7 +25,7 @@ object SchemeTest : FunSpec({
 
             scheme.typeIcon = null
 
-            scheme.icon should beNull()
+            scheme.icon shouldBe null
         }
 
         test("uses the type icon as a basis for the icon") {

--- a/src/test/kotlin/com/fwdekker/randomness/StateTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/StateTest.kt
@@ -3,11 +3,10 @@ package com.fwdekker.randomness
 import com.fwdekker.randomness.testhelpers.DummyState
 import com.fwdekker.randomness.testhelpers.Tags
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.matchers.collections.haveSize
-import io.kotest.matchers.should
+import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
-import io.kotest.matchers.types.beTheSameInstanceAs
+import io.kotest.matchers.types.shouldBeSameInstanceAs
 
 
 /**
@@ -30,7 +29,7 @@ object StateTest : FunSpec({
 
             original.applyContext(context)
 
-            +original.context should beTheSameInstanceAs(context)
+            +original.context shouldBeSameInstanceAs context
         }
     }
 
@@ -59,7 +58,7 @@ object StateTest : FunSpec({
 
             val copy = original.deepCopy()
 
-            +copy.context should beTheSameInstanceAs(context)
+            +copy.context shouldBeSameInstanceAs context
         }
 
         test("deep-copies fields") {
@@ -68,8 +67,8 @@ object StateTest : FunSpec({
 
             copy.list.add(0)
 
-            original.list should haveSize(0)
-            copy.list should haveSize(1)
+            original.list shouldHaveSize 0
+            copy.list shouldHaveSize 1
         }
     }
 })

--- a/src/test/kotlin/com/fwdekker/randomness/TimelyTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/TimelyTest.kt
@@ -2,10 +2,9 @@ package com.fwdekker.randomness
 
 import com.fwdekker.randomness.Timely.GENERATOR_TIMEOUT
 import com.fwdekker.randomness.Timely.generateTimely
-import com.fwdekker.randomness.testhelpers.matchBundle
+import com.fwdekker.randomness.testhelpers.shouldMatchBundle
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 
 
@@ -19,7 +18,7 @@ object TimelyTest : FunSpec({
 
     test("throws an exception if the generator does not finish within time") {
         shouldThrow<DataGenerationException> { generateTimely { Thread.sleep(GENERATOR_TIMEOUT + 1000L) } }
-            .message should matchBundle("misc.timed_out")
+            .message shouldMatchBundle "misc.timed_out"
     }
 
     test("throws an exception if the generator throws an exception") {

--- a/src/test/kotlin/com/fwdekker/randomness/XmlHelpersTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/XmlHelpersTest.kt
@@ -14,7 +14,6 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
-import io.kotest.matchers.nulls.beNull
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
@@ -77,7 +76,7 @@ object XmlHelpersTest : FunSpec({
                 """.trimIndent()
             )
 
-            element.getProperty("needle")?.name should beNull()
+            element.getProperty("needle")?.name shouldBe null
         }
 
         test("returns `null` if multiple children have the given name") {
@@ -92,7 +91,7 @@ object XmlHelpersTest : FunSpec({
                 """.trimIndent()
             )
 
-            element.getProperty("needle")?.name should beNull()
+            element.getProperty("needle")?.name shouldBe null
         }
     }
 
@@ -201,7 +200,7 @@ object XmlHelpersTest : FunSpec({
                 """.trimIndent()
             )
 
-            element.getPropertyByPath("wrong", null, "prong", null)?.name should beNull()
+            element.getPropertyByPath("wrong", null, "prong", null)?.name shouldBe null
         }
     }
 
@@ -231,7 +230,7 @@ object XmlHelpersTest : FunSpec({
                 """.trimIndent()
             )
 
-            element.getPropertyValue("needle") should beNull()
+            element.getPropertyValue("needle") shouldBe null
         }
 
         test("returns `null` if the property exists multiple times") {
@@ -246,7 +245,7 @@ object XmlHelpersTest : FunSpec({
                 """.trimIndent()
             )
 
-            element.getPropertyValue("needle") should beNull()
+            element.getPropertyValue("needle") shouldBe null
         }
 
         test("returns `null` if the property has no value") {
@@ -260,7 +259,7 @@ object XmlHelpersTest : FunSpec({
                 """.trimIndent()
             )
 
-            element.getPropertyValue("needle") should beNull()
+            element.getPropertyValue("needle") shouldBe null
         }
     }
 

--- a/src/test/kotlin/com/fwdekker/randomness/affix/AffixDecoratorEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/affix/AffixDecoratorEditorTest.kt
@@ -5,10 +5,9 @@ import com.fwdekker.randomness.testhelpers.afterNonContainer
 import com.fwdekker.randomness.testhelpers.beforeNonContainer
 import com.fwdekker.randomness.testhelpers.editorApplyTests
 import com.fwdekker.randomness.testhelpers.editorFieldsTests
-import com.fwdekker.randomness.testhelpers.guiGet
-import com.fwdekker.randomness.testhelpers.guiRun
 import com.fwdekker.randomness.testhelpers.prop
 import com.fwdekker.randomness.testhelpers.requireEnabledIs
+import com.fwdekker.randomness.testhelpers.runEdt
 import com.fwdekker.randomness.testhelpers.textProp
 import com.fwdekker.randomness.testhelpers.useEdtViolationDetection
 import com.intellij.ui.layout.selected
@@ -40,7 +39,7 @@ object AffixDecoratorEditorTest : FunSpec({
 
     beforeNonContainer {
         scheme = AffixDecorator(enabled = true)
-        editor = guiGet { AffixDecoratorEditor(scheme, presets = listOf("a", "b", "c")) }
+        editor = runEdt { AffixDecoratorEditor(scheme, presets = listOf("a", "b", "c")) }
         frame = Containers.showInFrame(editor.rootComponent)
     }
 
@@ -57,7 +56,7 @@ object AffixDecoratorEditorTest : FunSpec({
 
             test("disables mnemonics if false") {
                 frame.cleanUp()
-                editor = guiGet { AffixDecoratorEditor(scheme, presets = listOf("."), enableMnemonic = false) }
+                editor = runEdt { AffixDecoratorEditor(scheme, presets = listOf("."), enableMnemonic = false) }
                 frame = Containers.showInFrame(editor.rootComponent)
 
                 frame.checkBox("affixEnabled").target().mnemonic shouldBe 0
@@ -72,7 +71,7 @@ object AffixDecoratorEditorTest : FunSpec({
 
             test("prefixes component names by the given prefix and retains camel case") {
                 frame.cleanUp()
-                editor = guiGet { AffixDecoratorEditor(scheme, presets = listOf("."), namePrefix = "prefix") }
+                editor = runEdt { AffixDecoratorEditor(scheme, presets = listOf("."), namePrefix = "prefix") }
                 frame = Containers.showInFrame(editor.rootComponent)
 
                 shouldNotThrowAny { frame.checkBox("prefixAffixEnabled") }
@@ -88,7 +87,7 @@ object AffixDecoratorEditorTest : FunSpec({
 
 
             beforeNonContainer {
-                toggle = guiGet { JCheckBox().also { it.isSelected = false } }
+                toggle = runEdt { JCheckBox().also { it.isSelected = false } }
             }
 
 
@@ -105,10 +104,10 @@ object AffixDecoratorEditorTest : FunSpec({
                 val predicate = predicateState?.let { toggle.selected }
 
                 frame.cleanUp()
-                editor = guiGet { AffixDecoratorEditor(scheme, presets = listOf("."), enabledIf = predicate) }
+                editor = runEdt { AffixDecoratorEditor(scheme, presets = listOf("."), enabledIf = predicate) }
                 frame = Containers.showInFrame(editor.rootComponent)
 
-                guiRun {
+                runEdt {
                     if (predicateState != null) toggle.isSelected = predicateState
                     frame.checkBox().target().isSelected = checkboxState
                 }

--- a/src/test/kotlin/com/fwdekker/randomness/array/ArrayDecoratorEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/array/ArrayDecoratorEditorTest.kt
@@ -5,11 +5,10 @@ import com.fwdekker.randomness.testhelpers.afterNonContainer
 import com.fwdekker.randomness.testhelpers.beforeNonContainer
 import com.fwdekker.randomness.testhelpers.editorApplyTests
 import com.fwdekker.randomness.testhelpers.editorFieldsTests
-import com.fwdekker.randomness.testhelpers.guiGet
-import com.fwdekker.randomness.testhelpers.guiRun
 import com.fwdekker.randomness.testhelpers.isSelectedProp
 import com.fwdekker.randomness.testhelpers.matcher
 import com.fwdekker.randomness.testhelpers.prop
+import com.fwdekker.randomness.testhelpers.runEdt
 import com.fwdekker.randomness.testhelpers.textProp
 import com.fwdekker.randomness.testhelpers.useEdtViolationDetection
 import com.fwdekker.randomness.testhelpers.valueProp
@@ -39,7 +38,7 @@ object ArrayDecoratorEditorTest : FunSpec({
 
     beforeNonContainer {
         scheme = ArrayDecorator(enabled = true)
-        editor = guiGet { ArrayDecoratorEditor(scheme) }
+        editor = runEdt { ArrayDecoratorEditor(scheme) }
         frame = showInFrame(editor.rootComponent)
     }
 
@@ -56,7 +55,7 @@ object ArrayDecoratorEditorTest : FunSpec({
 
             test("hides the titled separator if the editor is embedded") {
                 frame.cleanUp()
-                editor = guiGet { ArrayDecoratorEditor(scheme, embedded = true) }
+                editor = runEdt { ArrayDecoratorEditor(scheme, embedded = true) }
                 frame = showInFrame(editor.rootComponent)
 
                 frame.robot().finder().findAll(matcher(TitledSeparator::class.java)) should beEmpty()
@@ -68,14 +67,14 @@ object ArrayDecoratorEditorTest : FunSpec({
     context("input handling") {
         context("arrayEnabled") {
             test("disables inputs if deselected") {
-                guiRun { frame.checkBox("arrayEnabled").target().isSelected = false }
+                runEdt { frame.checkBox("arrayEnabled").target().isSelected = false }
 
                 frame.spinner("arrayMinCount").requireDisabled()
             }
 
             test("enables inputs if (re)selected") {
-                guiRun { frame.checkBox("arrayEnabled").target().isSelected = false }
-                guiRun { frame.checkBox("arrayEnabled").target().isSelected = true }
+                runEdt { frame.checkBox("arrayEnabled").target().isSelected = false }
+                runEdt { frame.checkBox("arrayEnabled").target().isSelected = true }
 
                 frame.spinner("arrayMinCount").requireEnabled()
             }
@@ -83,7 +82,7 @@ object ArrayDecoratorEditorTest : FunSpec({
             test("remains disabled and is disconnected from inputs if the editor is embedded") {
                 frame.cleanUp()
                 scheme.enabled = false
-                editor = guiGet { ArrayDecoratorEditor(scheme, embedded = true) }
+                editor = runEdt { ArrayDecoratorEditor(scheme, embedded = true) }
                 frame = showInFrame(editor.rootComponent)
 
                 // This special matcher does not require the component to be visible
@@ -94,19 +93,19 @@ object ArrayDecoratorEditorTest : FunSpec({
 
         context("*Count") {
             test("truncates decimals in the minimum count") {
-                guiRun { frame.spinner("arrayMinCount").target().value = 983.24f }
+                runEdt { frame.spinner("arrayMinCount").target().value = 983.24f }
 
                 frame.spinner("arrayMinCount").requireValue(983)
             }
 
             test("truncates decimals in the maximum count") {
-                guiRun { frame.spinner("arrayMaxCount").target().value = 881.78f }
+                runEdt { frame.spinner("arrayMaxCount").target().value = 881.78f }
 
                 frame.spinner("arrayMaxCount").requireValue(881)
             }
 
             test("binds the minimum and maximum counts") {
-                guiRun { frame.spinner("arrayMinCount").target().value = 188 }
+                runEdt { frame.spinner("arrayMinCount").target().value = 188 }
 
                 frame.spinner("arrayMinCount").requireValue(188)
                 frame.spinner("arrayMaxCount").requireValue(188)
@@ -117,19 +116,19 @@ object ArrayDecoratorEditorTest : FunSpec({
             context("embedded") {
                 beforeNonContainer {
                     frame.cleanUp()
-                    editor = guiGet { ArrayDecoratorEditor(scheme, embedded = true) }
+                    editor = runEdt { ArrayDecoratorEditor(scheme, embedded = true) }
                     frame = showInFrame(editor.rootComponent)
                 }
 
 
                 test("disables separator if checkbox is disabled") {
-                    guiRun { frame.checkBox("arraySeparatorEnabled").target().isSelected = false }
+                    runEdt { frame.checkBox("arraySeparatorEnabled").target().isSelected = false }
 
                     frame.comboBox("arraySeparator").requireDisabled()
                 }
 
                 test("enables separator if checkbox is enabled") {
-                    guiRun { frame.checkBox("arraySeparatorEnabled").target().isSelected = true }
+                    runEdt { frame.checkBox("arraySeparatorEnabled").target().isSelected = true }
 
                     frame.comboBox("arraySeparator").requireEnabled()
                 }
@@ -137,28 +136,28 @@ object ArrayDecoratorEditorTest : FunSpec({
 
             context("not embedded") {
                 test("disables separator if panel is disabled and checkbox is disabled") {
-                    guiRun { frame.checkBox("arraySeparatorEnabled").target().isSelected = false }
+                    runEdt { frame.checkBox("arraySeparatorEnabled").target().isSelected = false }
 
                     frame.comboBox("arraySeparator").requireDisabled()
                 }
 
                 test("disables separator if panel is disabled and checkbox is enabled") {
-                    guiRun { frame.checkBox("arrayEnabled").target().isSelected = false }
-                    guiRun { frame.checkBox("arraySeparatorEnabled").target().isSelected = true }
+                    runEdt { frame.checkBox("arrayEnabled").target().isSelected = false }
+                    runEdt { frame.checkBox("arraySeparatorEnabled").target().isSelected = true }
 
                     frame.comboBox("arraySeparator").requireDisabled()
                 }
 
                 test("disables separator if panel is enabled and checkbox is disabled") {
-                    guiRun { frame.checkBox("arrayEnabled").target().isSelected = true }
-                    guiRun { frame.checkBox("arraySeparatorEnabled").target().isSelected = false }
+                    runEdt { frame.checkBox("arrayEnabled").target().isSelected = true }
+                    runEdt { frame.checkBox("arraySeparatorEnabled").target().isSelected = false }
 
                     frame.comboBox("arraySeparator").requireDisabled()
                 }
 
                 test("enables separator if panel is enabled and checkbox is enabled") {
-                    guiRun { frame.checkBox("arrayEnabled").target().isSelected = true }
-                    guiRun { frame.checkBox("arraySeparatorEnabled").target().isSelected = true }
+                    runEdt { frame.checkBox("arrayEnabled").target().isSelected = true }
+                    runEdt { frame.checkBox("arraySeparatorEnabled").target().isSelected = true }
 
                     frame.comboBox("arraySeparator").requireEnabled()
                 }

--- a/src/test/kotlin/com/fwdekker/randomness/datetime/DateTimeSchemeEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/datetime/DateTimeSchemeEditorTest.kt
@@ -6,9 +6,8 @@ import com.fwdekker.randomness.testhelpers.afterNonContainer
 import com.fwdekker.randomness.testhelpers.beforeNonContainer
 import com.fwdekker.randomness.testhelpers.editorApplyTests
 import com.fwdekker.randomness.testhelpers.editorFieldsTests
-import com.fwdekker.randomness.testhelpers.guiGet
-import com.fwdekker.randomness.testhelpers.guiRun
 import com.fwdekker.randomness.testhelpers.prop
+import com.fwdekker.randomness.testhelpers.runEdt
 import com.fwdekker.randomness.testhelpers.textProp
 import com.fwdekker.randomness.testhelpers.timestampProp
 import com.fwdekker.randomness.testhelpers.useEdtViolationDetection
@@ -36,7 +35,7 @@ object DateTimeSchemeEditorTest : FunSpec({
 
     beforeNonContainer {
         scheme = DateTimeScheme()
-        editor = guiGet { DateTimeSchemeEditor(scheme) }
+        editor = runEdt { DateTimeSchemeEditor(scheme) }
         frame = Containers.showInFrame(editor.rootComponent)
     }
 
@@ -47,12 +46,12 @@ object DateTimeSchemeEditorTest : FunSpec({
 
     context("input handling") {
         test("binds the minimum and maximum times") {
-            guiRun { frame.textBox("minDateTime").timestampProp().set(Timestamp("1131")) }
+            runEdt { frame.textBox("minDateTime").timestampProp().set(Timestamp("1131")) }
 
-            guiRun { frame.textBox("maxDateTime").timestampProp().set(Timestamp("0463")) }
+            runEdt { frame.textBox("maxDateTime").timestampProp().set(Timestamp("0463")) }
 
-            guiGet { frame.textBox("minDateTime").timestampProp().get() } shouldBe Timestamp("0463")
-            guiGet { frame.textBox("maxDateTime").timestampProp().get() } shouldBe Timestamp("0463")
+            runEdt { frame.textBox("minDateTime").timestampProp().get() } shouldBe Timestamp("0463")
+            runEdt { frame.textBox("maxDateTime").timestampProp().get() } shouldBe Timestamp("0463")
         }
     }
 

--- a/src/test/kotlin/com/fwdekker/randomness/decimal/DecimalSchemeEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/decimal/DecimalSchemeEditorTest.kt
@@ -5,10 +5,9 @@ import com.fwdekker.randomness.testhelpers.afterNonContainer
 import com.fwdekker.randomness.testhelpers.beforeNonContainer
 import com.fwdekker.randomness.testhelpers.editorApplyTests
 import com.fwdekker.randomness.testhelpers.editorFieldsTests
-import com.fwdekker.randomness.testhelpers.guiGet
-import com.fwdekker.randomness.testhelpers.guiRun
 import com.fwdekker.randomness.testhelpers.isSelectedProp
 import com.fwdekker.randomness.testhelpers.prop
+import com.fwdekker.randomness.testhelpers.runEdt
 import com.fwdekker.randomness.testhelpers.textProp
 import com.fwdekker.randomness.testhelpers.useEdtViolationDetection
 import com.fwdekker.randomness.testhelpers.valueProp
@@ -35,7 +34,7 @@ object DecimalSchemeEditorTest : FunSpec({
 
     beforeNonContainer {
         scheme = DecimalScheme()
-        editor = guiGet { DecimalSchemeEditor(scheme) }
+        editor = runEdt { DecimalSchemeEditor(scheme) }
         frame = showInFrame(editor.rootComponent)
     }
 
@@ -48,7 +47,7 @@ object DecimalSchemeEditorTest : FunSpec({
     context("input handling") {
         context("*Value") {
             test("binds the minimum and maximum values") {
-                guiRun { frame.spinner("minValue").target().value = 3670.0 }
+                runEdt { frame.spinner("minValue").target().value = 3670.0 }
 
                 frame.spinner("minValue").requireValue(3670.0)
                 frame.spinner("maxValue").requireValue(3670.0)
@@ -57,7 +56,7 @@ object DecimalSchemeEditorTest : FunSpec({
 
         context("decimalCount") {
             test("truncates decimals in the decimal count") {
-                guiRun { frame.spinner("decimalCount").target().value = 693.57f }
+                runEdt { frame.spinner("decimalCount").target().value = 693.57f }
 
                 frame.spinner("decimalCount").requireValue(693)
             }
@@ -66,18 +65,18 @@ object DecimalSchemeEditorTest : FunSpec({
         context("groupingSeparator") {
             context("enforces the length filter") {
                 beforeNonContainer {
-                    guiRun { frame.checkBox("groupingSeparatorEnabled").target().isSelected = true }
+                    runEdt { frame.checkBox("groupingSeparatorEnabled").target().isSelected = true }
                 }
 
 
                 test("enforces a minimum length of 1") {
-                    guiRun { frame.comboBox("groupingSeparator").target().editor.item = "" }
+                    runEdt { frame.comboBox("groupingSeparator").target().editor.item = "" }
 
                     frame.comboBox("groupingSeparator").requireSelection(",")
                 }
 
                 test("enforces a maximum length of 1") {
-                    guiRun { frame.comboBox("groupingSeparator").target().editor.item = "long" }
+                    runEdt { frame.comboBox("groupingSeparator").target().editor.item = "long" }
 
                     frame.comboBox("groupingSeparator").requireSelection(",")
                 }
@@ -85,13 +84,13 @@ object DecimalSchemeEditorTest : FunSpec({
 
             context("enabled state") {
                 test("enables the input if the checkbox is selected") {
-                    guiRun { frame.checkBox("groupingSeparatorEnabled").target().isSelected = true }
+                    runEdt { frame.checkBox("groupingSeparatorEnabled").target().isSelected = true }
 
                     frame.comboBox("groupingSeparator").requireEnabled()
                 }
 
                 test("disables the input if the checkbox is not selected") {
-                    guiRun { frame.checkBox("groupingSeparatorEnabled").target().isSelected = false }
+                    runEdt { frame.checkBox("groupingSeparatorEnabled").target().isSelected = false }
 
                     frame.comboBox("groupingSeparator").requireDisabled()
                 }

--- a/src/test/kotlin/com/fwdekker/randomness/fixedlength/FixedLengthDecoratorEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/fixedlength/FixedLengthDecoratorEditorTest.kt
@@ -5,10 +5,9 @@ import com.fwdekker.randomness.testhelpers.afterNonContainer
 import com.fwdekker.randomness.testhelpers.beforeNonContainer
 import com.fwdekker.randomness.testhelpers.editorApplyTests
 import com.fwdekker.randomness.testhelpers.editorFieldsTests
-import com.fwdekker.randomness.testhelpers.guiGet
-import com.fwdekker.randomness.testhelpers.guiRun
 import com.fwdekker.randomness.testhelpers.isSelectedProp
 import com.fwdekker.randomness.testhelpers.prop
+import com.fwdekker.randomness.testhelpers.runEdt
 import com.fwdekker.randomness.testhelpers.textProp
 import com.fwdekker.randomness.testhelpers.useEdtViolationDetection
 import com.fwdekker.randomness.testhelpers.valueProp
@@ -35,7 +34,7 @@ object FixedLengthDecoratorEditorTest : FunSpec({
 
     beforeNonContainer {
         scheme = FixedLengthDecorator(enabled = true)
-        editor = guiGet { FixedLengthDecoratorEditor(scheme) }
+        editor = runEdt { FixedLengthDecoratorEditor(scheme) }
         frame = Containers.showInFrame(editor.rootComponent)
     }
 
@@ -47,15 +46,15 @@ object FixedLengthDecoratorEditorTest : FunSpec({
     context("input handling") {
         context("fixedLengthEnabled") {
             test("disables inputs if deselected") {
-                guiRun { frame.checkBox("fixedLengthEnabled").target().isSelected = false }
+                runEdt { frame.checkBox("fixedLengthEnabled").target().isSelected = false }
 
                 frame.spinner("fixedLengthLength").requireDisabled()
                 frame.textBox("fixedLengthFiller").requireDisabled()
             }
 
             test("enables inputs if (re)selected") {
-                guiRun { frame.checkBox("fixedLengthEnabled").target().isSelected = false }
-                guiRun { frame.checkBox("fixedLengthEnabled").target().isSelected = true }
+                runEdt { frame.checkBox("fixedLengthEnabled").target().isSelected = false }
+                runEdt { frame.checkBox("fixedLengthEnabled").target().isSelected = true }
 
                 frame.spinner("fixedLengthLength").requireEnabled()
                 frame.textBox("fixedLengthFiller").requireEnabled()
@@ -64,7 +63,7 @@ object FixedLengthDecoratorEditorTest : FunSpec({
 
         context("filler") {
             test("enforces the filler's length filter") {
-                guiRun { frame.textBox("fixedLengthFiller").target().text = "zAt" }
+                runEdt { frame.textBox("fixedLengthFiller").target().text = "zAt" }
 
                 frame.textBox("fixedLengthFiller").requireText("t")
             }

--- a/src/test/kotlin/com/fwdekker/randomness/integer/IntegerSchemeEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/integer/IntegerSchemeEditorTest.kt
@@ -5,11 +5,10 @@ import com.fwdekker.randomness.testhelpers.afterNonContainer
 import com.fwdekker.randomness.testhelpers.beforeNonContainer
 import com.fwdekker.randomness.testhelpers.editorApplyTests
 import com.fwdekker.randomness.testhelpers.editorFieldsTests
-import com.fwdekker.randomness.testhelpers.guiGet
-import com.fwdekker.randomness.testhelpers.guiRun
 import com.fwdekker.randomness.testhelpers.isSelectedProp
 import com.fwdekker.randomness.testhelpers.prop
 import com.fwdekker.randomness.testhelpers.requireEnabledIs
+import com.fwdekker.randomness.testhelpers.runEdt
 import com.fwdekker.randomness.testhelpers.textProp
 import com.fwdekker.randomness.testhelpers.useEdtViolationDetection
 import com.fwdekker.randomness.testhelpers.valueProp
@@ -37,7 +36,7 @@ object IntegerSchemeEditorTest : FunSpec({
 
     beforeNonContainer {
         scheme = IntegerScheme()
-        editor = guiGet { IntegerSchemeEditor(scheme) }
+        editor = runEdt { IntegerSchemeEditor(scheme) }
         frame = showInFrame(editor.rootComponent)
     }
 
@@ -50,19 +49,19 @@ object IntegerSchemeEditorTest : FunSpec({
     context("input handling") {
         context("*Value") {
             test("truncates decimals in the minimum value") {
-                guiRun { frame.spinner("minValue").target().value = 285.21f }
+                runEdt { frame.spinner("minValue").target().value = 285.21f }
 
                 frame.spinner("minValue").requireValue(285L)
             }
 
             test("truncates decimals in the maximum value") {
-                guiRun { frame.spinner("maxValue").target().value = 490.34f }
+                runEdt { frame.spinner("maxValue").target().value = 490.34f }
 
                 frame.spinner("maxValue").requireValue(490L)
             }
 
             test("binds the minimum and maximum values") {
-                guiRun { frame.spinner("minValue").target().value = 6804L }
+                runEdt { frame.spinner("minValue").target().value = 6804L }
 
                 frame.spinner("minValue").requireValue(6804L)
                 frame.spinner("maxValue").requireValue(6804L)
@@ -71,7 +70,7 @@ object IntegerSchemeEditorTest : FunSpec({
 
         context("base") {
             test("truncates decimals in the base") {
-                guiRun { frame.spinner("base").target().value = 22.62f }
+                runEdt { frame.spinner("base").target().value = 22.62f }
 
                 frame.spinner("base").requireValue(22)
             }
@@ -80,18 +79,18 @@ object IntegerSchemeEditorTest : FunSpec({
         context("grouping separator") {
             context("enforces the length filter") {
                 beforeNonContainer {
-                    guiRun { frame.checkBox("groupingSeparatorEnabled").target().isSelected = true }
+                    runEdt { frame.checkBox("groupingSeparatorEnabled").target().isSelected = true }
                 }
 
 
                 test("enforces a minimum length of 1") {
-                    guiRun { frame.comboBox("groupingSeparator").target().editor.item = "" }
+                    runEdt { frame.comboBox("groupingSeparator").target().editor.item = "" }
 
                     frame.comboBox("groupingSeparator").requireSelection(",")
                 }
 
                 test("enforces a maximum length of 1") {
-                    guiRun { frame.comboBox("groupingSeparator").target().editor.item = "long" }
+                    runEdt { frame.comboBox("groupingSeparator").target().editor.item = "long" }
 
                     frame.comboBox("groupingSeparator").requireSelection(",")
                 }
@@ -108,7 +107,7 @@ object IntegerSchemeEditorTest : FunSpec({
                     row(12, false, false, false),
                     row(12, true, false, false),
                 ) { (base, checkBoxChecked, expectedCheckBoxEnabled, expectedInputEnabled) ->
-                    guiRun {
+                    runEdt {
                         frame.spinner("base").target().value = base
                         frame.checkBox("groupingSeparatorEnabled").target().isSelected = checkBoxChecked
                     }

--- a/src/test/kotlin/com/fwdekker/randomness/string/StringSchemeEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/string/StringSchemeEditorTest.kt
@@ -6,10 +6,10 @@ import com.fwdekker.randomness.testhelpers.afterNonContainer
 import com.fwdekker.randomness.testhelpers.beforeNonContainer
 import com.fwdekker.randomness.testhelpers.editorApplyTests
 import com.fwdekker.randomness.testhelpers.editorFieldsTests
-import com.fwdekker.randomness.testhelpers.guiGet
 import com.fwdekker.randomness.testhelpers.isSelectedProp
 import com.fwdekker.randomness.testhelpers.itemProp
 import com.fwdekker.randomness.testhelpers.prop
+import com.fwdekker.randomness.testhelpers.runEdt
 import com.fwdekker.randomness.testhelpers.textProp
 import com.fwdekker.randomness.testhelpers.useEdtViolationDetection
 import com.fwdekker.randomness.testhelpers.valueProp
@@ -36,7 +36,7 @@ object StringSchemeEditorTest : FunSpec({
 
     beforeNonContainer {
         scheme = StringScheme()
-        editor = guiGet { StringSchemeEditor(scheme) }
+        editor = runEdt { StringSchemeEditor(scheme) }
         frame = showInFrame(editor.rootComponent)
     }
 

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateActionTests.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateActionTests.kt
@@ -4,10 +4,11 @@ import com.fwdekker.randomness.Icons
 import com.fwdekker.randomness.TypeIcon
 import com.fwdekker.randomness.testhelpers.DummyScheme
 import com.fwdekker.randomness.testhelpers.TRANSPARENCY
-import com.fwdekker.randomness.testhelpers.beSameIconAs
 import com.fwdekker.randomness.testhelpers.getSouthColor
-import com.fwdekker.randomness.testhelpers.matchBundle
 import com.fwdekker.randomness.testhelpers.render
+import com.fwdekker.randomness.testhelpers.shouldBeSameIconAs
+import com.fwdekker.randomness.testhelpers.shouldMatchBundle
+import com.fwdekker.randomness.testhelpers.shouldNotBeSameIconAs
 import com.fwdekker.randomness.testhelpers.typeIcon
 import com.fwdekker.randomness.testhelpers.useBareIdeaFixture
 import com.intellij.util.ui.EmptyIcon
@@ -15,10 +16,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.data.row
 import io.kotest.datatest.withData
 import io.kotest.matchers.collections.shouldContainExactly
-import io.kotest.matchers.nulls.beNull
-import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNot
 import java.awt.Color
 
 
@@ -38,7 +36,7 @@ object TemplateGroupActionTest : FunSpec({
 
             action.templatePresentation.text shouldBe template.name
             action.templatePresentation.description shouldBe "Inserts a(n) Name at all carets."
-            action.templatePresentation.icon should beSameIconAs(template.icon?.get())
+            action.templatePresentation.icon shouldBeSameIconAs template.icon?.get()
         }
     }
 })
@@ -88,7 +86,7 @@ object TemplateInsertActionTest : FunSpec({
 
                 // Test if icon is fully transparent
                 val icon = action.templatePresentation.icon!!
-                icon should beSameIconAs(EmptyIcon.create(icon))
+                icon shouldBeSameIconAs EmptyIcon.create(icon)
             }
 
             test("adds a repeat overlay for a repeat variant") {
@@ -97,7 +95,7 @@ object TemplateInsertActionTest : FunSpec({
 
                 // Test if icon is not fully transparent
                 val icon = action.templatePresentation.icon!!
-                icon shouldNot beSameIconAs(EmptyIcon.create(icon))
+                icon shouldNotBeSameIconAs EmptyIcon.create(icon)
             }
         }
     }
@@ -133,7 +131,7 @@ object TemplateSettingsActionTest : FunSpec({
             test("uses a default text if the template is null") {
                 val action = TemplateSettingsAction(template = null)
 
-                action.templatePresentation.text should matchBundle("template.name.settings")
+                action.templatePresentation.text shouldMatchBundle "template.name.settings"
             }
 
             test("uses the template's name if the template is not null") {
@@ -147,7 +145,7 @@ object TemplateSettingsActionTest : FunSpec({
             test("has no description of the template is null") {
                 val action = TemplateSettingsAction(template = null)
 
-                action.templatePresentation.description should beNull()
+                action.templatePresentation.description shouldBe null
             }
 
             test("uses the template's name to describe the action if the template is not null") {

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateEditorTest.kt
@@ -4,8 +4,8 @@ import com.fwdekker.randomness.testhelpers.Tags
 import com.fwdekker.randomness.testhelpers.afterNonContainer
 import com.fwdekker.randomness.testhelpers.beforeNonContainer
 import com.fwdekker.randomness.testhelpers.editorFieldsTests
-import com.fwdekker.randomness.testhelpers.guiGet
 import com.fwdekker.randomness.testhelpers.prop
+import com.fwdekker.randomness.testhelpers.runEdt
 import com.fwdekker.randomness.testhelpers.textProp
 import com.fwdekker.randomness.testhelpers.useEdtViolationDetection
 import io.kotest.core.spec.style.FunSpec
@@ -32,7 +32,7 @@ object TemplateEditorTest : FunSpec({
 
     beforeNonContainer {
         template = Template()
-        editor = guiGet { TemplateEditor(template) }
+        editor = runEdt { TemplateEditor(template) }
         frame = Containers.showInFrame(editor.rootComponent)
     }
 

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateJTreeModelTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateJTreeModelTest.kt
@@ -4,8 +4,8 @@ import com.fwdekker.randomness.Scheme
 import com.fwdekker.randomness.testhelpers.DummyScheme
 import com.fwdekker.randomness.testhelpers.beEmptyIntArray
 import com.fwdekker.randomness.testhelpers.beforeNonContainer
-import com.fwdekker.randomness.testhelpers.matchBundle
 import com.fwdekker.randomness.testhelpers.shouldContainExactly
+import com.fwdekker.randomness.testhelpers.shouldMatchBundle
 import com.fwdekker.randomness.ui.SimpleTreeModelListener
 import com.intellij.ui.RowsDnDSupport.RefinedDropSupport.Position
 import io.kotest.assertions.throwables.shouldThrow
@@ -18,7 +18,6 @@ import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.collections.shouldNotContain
-import io.kotest.matchers.nulls.beNull
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
@@ -79,7 +78,7 @@ object TemplateJTreeModelTest : FunSpec({
             val child = StateNode(DummyScheme())
 
             shouldThrow<IllegalArgumentException> { model.insertNode(parent, child) }
-                .message should matchBundle("template_list.error.node_not_in_tree")
+                .message shouldMatchBundle "template_list.error.node_not_in_tree"
         }
 
         test("throws an error if the child is not a valid child for the parent") {
@@ -87,7 +86,7 @@ object TemplateJTreeModelTest : FunSpec({
             val child = StateNode(DummyScheme())
 
             shouldThrow<IllegalArgumentException> { model.insertNode(parent, child) }
-                .message should matchBundle("template_list.error.wrong_child_type")
+                .message shouldMatchBundle "template_list.error.wrong_child_type"
         }
 
         test("throws an error when a node is inserted at a negative index") {
@@ -100,7 +99,7 @@ object TemplateJTreeModelTest : FunSpec({
 
         test("throws an error if a node with the same uuid already exists in the parent") {
             shouldThrow<IllegalArgumentException> { model.insertNode(model.root, model.root.children[0]) }
-                .message should matchBundle("template_list.error.duplicate_uuid")
+                .message shouldMatchBundle "template_list.error.duplicate_uuid"
         }
 
 
@@ -175,7 +174,7 @@ object TemplateJTreeModelTest : FunSpec({
 
             lastEvent!!.treePath.lastPathComponent shouldBe model.root
             lastEvent!!.childIndices should beEmptyIntArray()
-            lastEvent!!.children should beNull()
+            lastEvent!!.children shouldBe null
         }
     }
 
@@ -188,7 +187,7 @@ object TemplateJTreeModelTest : FunSpec({
             val child = StateNode(DummyScheme("Child"))
 
             shouldThrow<IllegalArgumentException> { model.insertNodeAfter(parent, after, child) }
-                .message should matchBundle("template_list.error.node_not_in_tree")
+                .message shouldMatchBundle "template_list.error.node_not_in_tree"
         }
 
         test("throws an error if the parent cannot have children") {
@@ -197,7 +196,7 @@ object TemplateJTreeModelTest : FunSpec({
             val child = StateNode(DummyScheme())
 
             shouldThrow<IllegalStateException> { model.insertNodeAfter(parent, after, child) }
-                .message should matchBundle("template_list.error.infertile_parent")
+                .message shouldMatchBundle "template_list.error.infertile_parent"
         }
 
         test("throws an error if the node to insert after is not in the parent") {
@@ -206,7 +205,7 @@ object TemplateJTreeModelTest : FunSpec({
             val child = StateNode(DummyScheme())
 
             shouldThrow<IllegalArgumentException> { model.insertNodeAfter(parent, after, child) }
-                .message should matchBundle("template_list.error.wrong_parent")
+                .message shouldMatchBundle "template_list.error.wrong_parent"
         }
 
 
@@ -224,12 +223,12 @@ object TemplateJTreeModelTest : FunSpec({
     context("removeNode") {
         test("throws an error if the given node is not contained in the model") {
             shouldThrow<IllegalArgumentException> { model.removeNode(StateNode(DummyScheme())) }
-                .message should matchBundle("template_list.error.node_not_in_tree")
+                .message shouldMatchBundle "template_list.error.node_not_in_tree"
         }
 
         test("throws an error if the given node is the root of the model") {
             shouldThrow<IllegalArgumentException> { model.removeNode(model.root) }
-                .message should matchBundle("template_list.error.cannot_remove_root")
+                .message shouldMatchBundle "template_list.error.cannot_remove_root"
         }
 
 
@@ -312,7 +311,7 @@ object TemplateJTreeModelTest : FunSpec({
     context("moveRow") {
         test("cannot swap out-of-bounds indices") {
             shouldThrow<IllegalArgumentException> { model.moveRow(3, 495, Position.BELOW) }
-                .message should matchBundle("template_list.error.cannot_move_row")
+                .message shouldMatchBundle "template_list.error.cannot_move_row"
         }
 
         context("templates") {
@@ -422,7 +421,7 @@ object TemplateJTreeModelTest : FunSpec({
     context("isLeaf") {
         test("throws an error if the given node is not a StateNode") {
             shouldThrow<IllegalArgumentException> { model.isLeaf("not a node") }
-                .message should matchBundle("template_list.error.unknown_node_type")
+                .message shouldMatchBundle "template_list.error.unknown_node_type"
         }
 
         withData(
@@ -438,17 +437,17 @@ object TemplateJTreeModelTest : FunSpec({
     context("getChild") {
         test("throws an error if the given node is not a StateNode") {
             shouldThrow<IllegalArgumentException> { model.getChild("not a node", index = 0) }
-                .message should matchBundle("template_list.error.unknown_node_type")
+                .message shouldMatchBundle "template_list.error.unknown_node_type"
         }
 
         test("throws an error if the given node is not contained in the model") {
             shouldThrow<IllegalArgumentException> { model.getChild(StateNode(DummyScheme()), 4) }
-                .message should matchBundle("template_list.error.node_not_in_tree")
+                .message shouldMatchBundle "template_list.error.node_not_in_tree"
         }
 
         test("throws an error if the given node cannot have children") {
             shouldThrow<IllegalStateException> { model.getChild(model.root.children[0].children[1], index = 0) }
-                .message should matchBundle("template_list.error.infertile_parent")
+                .message shouldMatchBundle "template_list.error.infertile_parent"
         }
 
         test("throws an error if there is no child at the given index") {
@@ -463,12 +462,12 @@ object TemplateJTreeModelTest : FunSpec({
     context("getChildCount") {
         test("throws an error if the given node is not a StateNode") {
             shouldThrow<IllegalArgumentException> { model.getChildCount("not a node") }
-                .message should matchBundle("template_list.error.unknown_node_type")
+                .message shouldMatchBundle "template_list.error.unknown_node_type"
         }
 
         test("throws an error if the given node is not contained in the model") {
             shouldThrow<IllegalArgumentException> { model.getChildCount(StateNode(DummyScheme())) }
-                .message should matchBundle("template_list.error.node_not_in_tree")
+                .message shouldMatchBundle "template_list.error.node_not_in_tree"
         }
 
         withData(
@@ -508,7 +507,7 @@ object TemplateJTreeModelTest : FunSpec({
     context("getParentOf") {
         test("throws an error if the node is not contained in this model") {
             shouldThrow<IllegalArgumentException> { model.getParentOf(StateNode(DummyScheme())) }
-                .message should matchBundle("template_list.error.node_not_in_tree")
+                .message shouldMatchBundle "template_list.error.node_not_in_tree"
         }
 
         withData(
@@ -523,7 +522,7 @@ object TemplateJTreeModelTest : FunSpec({
     context("getPathToRoot") {
         test("throws an error if the node is not contained in this model") {
             shouldThrow<IllegalArgumentException> { model.getPathToRoot(StateNode(DummyScheme())) }
-                .message should matchBundle("template_list.error.node_not_in_tree")
+                .message shouldMatchBundle "template_list.error.node_not_in_tree"
         }
 
         withData(
@@ -621,7 +620,7 @@ object TemplateJTreeModelTest : FunSpec({
                 val node = StateNode(DummyScheme())
 
                 shouldThrow<IllegalArgumentException> { model.fireNodeInserted(model.root, node, 688) }
-                    .message should matchBundle("template_list.error.cannot_insert_root")
+                    .message shouldMatchBundle "template_list.error.cannot_insert_root"
             }
 
             test("does nothing if the given node is null") {
@@ -655,7 +654,7 @@ object TemplateJTreeModelTest : FunSpec({
                 val node = StateNode(DummyScheme())
 
                 shouldThrow<IllegalArgumentException> { model.fireNodeRemoved(model.root, node, 888) }
-                    .message should matchBundle("template_list.error.cannot_remove_root")
+                    .message shouldMatchBundle "template_list.error.cannot_remove_root"
             }
 
             test("fires an event with the given parent, node, and index") {
@@ -682,7 +681,7 @@ object TemplateJTreeModelTest : FunSpec({
                 totalInvoked - structureChangedInvoked shouldBe 0
                 lastEvent!!.treePath.lastPathComponent shouldBe node
                 lastEvent!!.childIndices should beEmptyIntArray()
-                lastEvent!!.children should beNull()
+                lastEvent!!.children shouldBe null
             }
         }
     }
@@ -758,7 +757,7 @@ object StateNodeTest : FunSpec({
 
             test("throws an error for a non-template scheme") {
                 shouldThrow<IllegalStateException> { StateNode(DummyScheme()).children }
-                    .message should matchBundle("template_list.error.infertile_parent")
+                    .message shouldMatchBundle "template_list.error.infertile_parent"
             }
         }
 
@@ -783,7 +782,7 @@ object StateNodeTest : FunSpec({
 
             test("throws an error for a non-template scheme") {
                 shouldThrow<IllegalStateException> { run { StateNode(DummyScheme()).children = emptyList() } }
-                    .message should matchBundle("template_list.error.infertile_parent")
+                    .message shouldMatchBundle "template_list.error.infertile_parent"
             }
         }
     }

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateJTreeTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateJTreeTest.kt
@@ -11,6 +11,7 @@ import com.fwdekker.randomness.testhelpers.guiGet
 import com.fwdekker.randomness.testhelpers.guiRun
 import com.fwdekker.randomness.testhelpers.matchBundle
 import com.fwdekker.randomness.testhelpers.shouldContainExactly
+import com.fwdekker.randomness.testhelpers.shouldMatchBundle
 import com.fwdekker.randomness.testhelpers.useBareIdeaFixture
 import com.fwdekker.randomness.testhelpers.useEdtViolationDetection
 import com.intellij.openapi.actionSystem.ActionToolbar
@@ -77,7 +78,7 @@ object TemplateJTreeTest : FunSpec({
         test("returns null if nothing is selected") {
             guiRun { tree.clearSelection() }
 
-            tree.selectedNodeNotRoot should beNull()
+            tree.selectedNodeNotRoot shouldBe null
         }
 
         test("returns the selected node otherwise") {
@@ -94,7 +95,7 @@ object TemplateJTreeTest : FunSpec({
             test("returns null if nothing is selected") {
                 guiRun { tree.clearSelection() }
 
-                tree.selectedScheme should beNull()
+                tree.selectedScheme shouldBe null
             }
 
             test("returns the selected scheme otherwise") {
@@ -150,7 +151,7 @@ object TemplateJTreeTest : FunSpec({
             test("returns null if nothing is selected") {
                 guiRun { tree.clearSelection() }
 
-                tree.selectedTemplate should beNull()
+                tree.selectedTemplate shouldBe null
             }
 
             test("returns the parent template if a non-template scheme is selected") {
@@ -405,7 +406,7 @@ object TemplateJTreeTest : FunSpec({
                 guiRun { tree.clearSelection() }
 
                 shouldThrow<IllegalArgumentException> { tree.addScheme(DummyScheme()) }
-                    .message should matchBundle("template_list.error.wrong_child_type")
+                    .message shouldMatchBundle "template_list.error.wrong_child_type"
             }
 
             test("inserts the scheme at the bottom of the selected template") {
@@ -469,7 +470,7 @@ object TemplateJTreeTest : FunSpec({
         test("removes the selection if there is nothing to select") {
             guiRun { repeat(3) { tree.removeScheme(currentList.templates[0]) } }
 
-            tree.selectedScheme should beNull()
+            tree.selectedScheme shouldBe null
         }
 
         test("selects the parent if the removed node had no other siblings") {

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateJTreeTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateJTreeTest.kt
@@ -7,9 +7,7 @@ import com.fwdekker.randomness.testhelpers.DummyScheme
 import com.fwdekker.randomness.testhelpers.afterNonContainer
 import com.fwdekker.randomness.testhelpers.beforeNonContainer
 import com.fwdekker.randomness.testhelpers.getActionButton
-import com.fwdekker.randomness.testhelpers.guiGet
-import com.fwdekker.randomness.testhelpers.guiRun
-import com.fwdekker.randomness.testhelpers.matchBundle
+import com.fwdekker.randomness.testhelpers.ideaRunEdt
 import com.fwdekker.randomness.testhelpers.shouldContainExactly
 import com.fwdekker.randomness.testhelpers.shouldMatchBundle
 import com.fwdekker.randomness.testhelpers.useBareIdeaFixture
@@ -24,8 +22,6 @@ import io.kotest.datatest.withData
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldNotContain
-import io.kotest.matchers.nulls.beNull
-import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeSameInstanceAs
@@ -65,7 +61,7 @@ object TemplateJTreeTest : FunSpec({
         currentList = originalList.deepCopy(retainUuid = true)
         currentList.applyContext(Settings(templateList = currentList))
 
-        tree = guiGet { TemplateJTree(originalList, currentList) }
+        tree = ideaRunEdt { TemplateJTree(originalList, currentList) }
         frame = showInFrame(tree)
     }
 
@@ -76,7 +72,7 @@ object TemplateJTreeTest : FunSpec({
 
     context("selectedNodeNotRoot") {
         test("returns null if nothing is selected") {
-            guiRun { tree.clearSelection() }
+            ideaRunEdt { tree.clearSelection() }
 
             tree.selectedNodeNotRoot shouldBe null
         }
@@ -84,7 +80,7 @@ object TemplateJTreeTest : FunSpec({
         test("returns the selected node otherwise") {
             val node = StateNode(currentList.templates[0])
 
-            guiRun { tree.selectionRows = intArrayOf(0) }
+            ideaRunEdt { tree.selectionRows = intArrayOf(0) }
 
             tree.selectedNodeNotRoot shouldBe node
         }
@@ -93,7 +89,7 @@ object TemplateJTreeTest : FunSpec({
     context("selectedScheme") {
         context("get") {
             test("returns null if nothing is selected") {
-                guiRun { tree.clearSelection() }
+                ideaRunEdt { tree.clearSelection() }
 
                 tree.selectedScheme shouldBe null
             }
@@ -101,7 +97,7 @@ object TemplateJTreeTest : FunSpec({
             test("returns the selected scheme otherwise") {
                 val template = currentList.templates[0]
 
-                guiRun { tree.selectionPath = tree.myModel.getPathToRoot(StateNode(template)) }
+                ideaRunEdt { tree.selectionPath = tree.myModel.getPathToRoot(StateNode(template)) }
 
                 tree.selectedScheme shouldBe template
             }
@@ -109,13 +105,13 @@ object TemplateJTreeTest : FunSpec({
 
         context("set") {
             test("removes the selection if null is set") {
-                guiRun { tree.selectedScheme = null }
+                ideaRunEdt { tree.selectedScheme = null }
 
                 tree.selectionCount shouldBe 0
             }
 
             test("removes the selection if the scheme cannot be found") {
-                guiRun { tree.selectedScheme = DummyScheme("Not In Tree") }
+                ideaRunEdt { tree.selectedScheme = DummyScheme("Not In Tree") }
 
                 tree.selectionCount shouldBe 0
             }
@@ -123,7 +119,7 @@ object TemplateJTreeTest : FunSpec({
             test("selects the given scheme otherwise") {
                 val scheme = currentList.templates[1].schemes[0]
 
-                guiRun {
+                ideaRunEdt {
                     tree.expandRow(1)
                     tree.selectedScheme = scheme
                 }
@@ -136,26 +132,26 @@ object TemplateJTreeTest : FunSpec({
             val copy = currentList.templates[0].schemes[1].deepCopy(retainUuid = true)
             (copy as DummyScheme).name = "New Name"
 
-            guiRun {
+            ideaRunEdt {
                 tree.expandRow(0)
                 tree.selectedScheme = copy
             }
 
-            guiGet { tree.selectedScheme?.uuid } shouldBe copy.uuid
-            guiGet { tree.selectedScheme } shouldNotBe copy
+            ideaRunEdt { tree.selectedScheme?.uuid } shouldBe copy.uuid
+            ideaRunEdt { tree.selectedScheme } shouldNotBe copy
         }
     }
 
     context("selectedTemplate") {
         context("get") {
             test("returns null if nothing is selected") {
-                guiRun { tree.clearSelection() }
+                ideaRunEdt { tree.clearSelection() }
 
                 tree.selectedTemplate shouldBe null
             }
 
             test("returns the parent template if a non-template scheme is selected") {
-                guiRun {
+                ideaRunEdt {
                     tree.expandRow(2)
                     tree.selectionRows = intArrayOf(3)
                 }
@@ -164,7 +160,7 @@ object TemplateJTreeTest : FunSpec({
             }
 
             test("returns the selected template otherwise") {
-                guiRun { tree.selectionRows = intArrayOf(1) }
+                ideaRunEdt { tree.selectionRows = intArrayOf(1) }
 
                 tree.selectedTemplate shouldBe currentList.templates[1]
             }
@@ -172,19 +168,19 @@ object TemplateJTreeTest : FunSpec({
 
         context("set") {
             test("removes the selection if null is set") {
-                guiRun { tree.selectedTemplate = null }
+                ideaRunEdt { tree.selectedTemplate = null }
 
                 tree.selectionCount shouldBe 0
             }
 
             test("removes the selection if the template cannot be found") {
-                guiRun { tree.selectedTemplate = Template("New Template") }
+                ideaRunEdt { tree.selectedTemplate = Template("New Template") }
 
                 tree.selectionCount shouldBe 0
             }
 
             test("selects the given template if it exists") {
-                guiRun { tree.selectedTemplate = currentList.templates[2] }
+                ideaRunEdt { tree.selectedTemplate = currentList.templates[2] }
 
                 tree.selectionRows!! shouldContainExactly arrayOf(2)
             }
@@ -194,52 +190,52 @@ object TemplateJTreeTest : FunSpec({
 
     context("reload") {
         test("synchronizes removed nodes") {
-            guiRun { currentList.templates.remove(currentList.templates[2]) }
-            guiGet { tree.rowCount } shouldBe 3
+            ideaRunEdt { currentList.templates.remove(currentList.templates[2]) }
+            ideaRunEdt { tree.rowCount } shouldBe 3
 
-            guiRun { tree.reload() }
+            ideaRunEdt { tree.reload() }
 
-            guiGet { tree.rowCount } shouldBe 2
+            ideaRunEdt { tree.rowCount } shouldBe 2
         }
 
         test("synchronizes added nodes") {
-            guiRun { currentList.templates += Template("New Template", mutableListOf(DummyScheme("New Scheme"))) }
-            guiGet { tree.rowCount } shouldBe 3
+            ideaRunEdt { currentList.templates += Template("New Template", mutableListOf(DummyScheme("New Scheme"))) }
+            ideaRunEdt { tree.rowCount } shouldBe 3
 
-            guiRun { tree.reload() }
+            ideaRunEdt { tree.reload() }
 
-            guiGet { tree.rowCount } shouldBe 5 // Including new scheme
+            ideaRunEdt { tree.rowCount } shouldBe 5 // Including new scheme
         }
 
         test("retains the scheme selection") {
-            guiRun {
+            ideaRunEdt {
                 tree.expandRow(0)
                 tree.selectedScheme = currentList.templates[1].schemes[0]
             }
 
-            guiRun { tree.reload() }
+            ideaRunEdt { tree.reload() }
 
             tree.selectedScheme shouldBe currentList.templates[1].schemes[0]
         }
 
         test("resets the selected scheme's state to the original") {
-            guiRun {
+            ideaRunEdt {
                 tree.expandRow(0)
                 tree.selectedScheme = currentList.templates[1].schemes[0]
             }
 
-            guiRun { tree.reload() }
+            ideaRunEdt { tree.reload() }
 
             tree.selectedScheme shouldBe originalList.templates[1].schemes[0]
         }
 
         test("selects the first template if the selected node was removed") {
-            guiRun {
+            ideaRunEdt {
                 tree.expandRow(1)
                 tree.selectedScheme = currentList.templates[1].schemes[0]
             }
 
-            guiRun {
+            ideaRunEdt {
                 currentList.templates[1].schemes.clear()
                 tree.reload()
             }
@@ -248,63 +244,63 @@ object TemplateJTreeTest : FunSpec({
         }
 
         test("selects the first template if no node was selected before") {
-            guiRun { tree.clearSelection() }
+            ideaRunEdt { tree.clearSelection() }
 
-            guiRun { tree.reload() }
+            ideaRunEdt { tree.reload() }
 
             tree.selectedScheme shouldBe currentList.templates[0]
         }
 
         test("keeps collapsed nodes collapsed") {
-            guiRun { tree.collapseRow(3) }
-            guiGet { tree.isCollapsed(3) } shouldBe true
+            ideaRunEdt { tree.collapseRow(3) }
+            ideaRunEdt { tree.isCollapsed(3) } shouldBe true
 
-            guiRun { tree.reload() }
+            ideaRunEdt { tree.reload() }
 
-            guiGet { tree.isCollapsed(3) } shouldBe true
+            ideaRunEdt { tree.isCollapsed(3) } shouldBe true
         }
 
         test("keeps expanded nodes expanded") {
-            guiRun { tree.expandRow(0) }
-            guiGet { tree.isExpanded(0) } shouldBe true
+            ideaRunEdt { tree.expandRow(0) }
+            ideaRunEdt { tree.isExpanded(0) } shouldBe true
 
-            guiRun { tree.reload() }
+            ideaRunEdt { tree.reload() }
 
-            guiGet { tree.isExpanded(0) } shouldBe true
+            ideaRunEdt { tree.isExpanded(0) } shouldBe true
         }
 
         test("expands new templates") {
             val template = Template("New Template", mutableListOf(DummyScheme("New Scheme")))
-            guiRun { currentList.templates += template }
+            ideaRunEdt { currentList.templates += template }
 
-            guiRun { tree.reload() }
+            ideaRunEdt { tree.reload() }
 
-            guiGet { (tree.getPathForRow(3).lastPathComponent as StateNode).state } shouldBe template
-            guiGet { tree.isExpanded(3) } shouldBe true
+            ideaRunEdt { (tree.getPathForRow(3).lastPathComponent as StateNode).state } shouldBe template
+            ideaRunEdt { tree.isExpanded(3) } shouldBe true
         }
 
         test(
             "keeps collapsed nodes collapsed even if that template's original row index is larger than the new total " +
                 "row count"
         ) {
-            guiRun {
+            ideaRunEdt {
                 currentList.templates.also { it.setAll(it.takeLast(1)) }
                 currentList.templates.single().schemes.also { it.setAll(it.take(1)) }
             }
 
-            guiGet { tree.reload() }
+            ideaRunEdt { tree.reload() }
 
-            guiGet { tree.isCollapsed(0) } shouldBe true
+            ideaRunEdt { tree.isCollapsed(0) } shouldBe true
         }
     }
 
     context("expandAll") {
         test("expands all templates") {
-            guiGet { tree.rowCount } shouldBe 3
+            ideaRunEdt { tree.rowCount } shouldBe 3
 
-            guiRun { tree.expandAll() }
+            ideaRunEdt { tree.expandAll() }
 
-            guiGet { tree.rowCount } shouldBe 8
+            ideaRunEdt { tree.rowCount } shouldBe 8
         }
     }
 
@@ -312,13 +308,13 @@ object TemplateJTreeTest : FunSpec({
     context("addScheme") {
         context("unique name") {
             test("appends (1) if a template with the given name already exists") {
-                guiRun { tree.addScheme(Template("Template0")) }
+                ideaRunEdt { tree.addScheme(Template("Template0")) }
 
                 currentList.templates[1].name shouldBe "Template0 (1)"
             }
 
             test("appends (2) if two templates with the given name already exist") {
-                guiRun {
+                ideaRunEdt {
                     tree.addScheme(Template("Template0"))
                     tree.addScheme(Template("Template0"))
                 }
@@ -327,7 +323,7 @@ object TemplateJTreeTest : FunSpec({
             }
 
             test("appends (2) if a template ending with (1) already exists") {
-                guiRun {
+                ideaRunEdt {
                     tree.addScheme(Template("Template0 (1)"))
                     tree.addScheme(Template("Template0"))
                 }
@@ -336,7 +332,7 @@ object TemplateJTreeTest : FunSpec({
             }
 
             test("replaces (1) with (2) if a template ending with (1) already exists") {
-                guiRun {
+                ideaRunEdt {
                     tree.addScheme(Template("Template0 (1)"))
                     tree.addScheme(Template("Template0 (1)"))
                 }
@@ -345,7 +341,7 @@ object TemplateJTreeTest : FunSpec({
             }
 
             test("replaces (13) with (14) if a template ending with (13) already exists") {
-                guiRun {
+                ideaRunEdt {
                     tree.addScheme(Template("Template0 (13)"))
                     tree.addScheme(Template("Template0 (13)"))
                 }
@@ -356,145 +352,145 @@ object TemplateJTreeTest : FunSpec({
 
         context("template") {
             test("inserts the template at the bottom if nothing is selected") {
-                guiRun { tree.clearSelection() }
+                ideaRunEdt { tree.clearSelection() }
 
-                guiRun { tree.addScheme(Template("New Template")) }
+                ideaRunEdt { tree.addScheme(Template("New Template")) }
 
                 currentList.templates.last().name shouldBe "New Template"
             }
 
             test("inserts the template below the selected template") {
-                guiRun { tree.selectedScheme = currentList.templates[1] }
+                ideaRunEdt { tree.selectedScheme = currentList.templates[1] }
 
-                guiRun { tree.addScheme(Template("New Template")) }
+                ideaRunEdt { tree.addScheme(Template("New Template")) }
 
                 currentList.templates[2].name shouldBe "New Template"
             }
 
             test("inserts the template below the selected scheme") {
-                guiRun {
+                ideaRunEdt {
                     tree.expandRow(0)
                     tree.selectedScheme = currentList.templates[0].schemes[1]
                 }
 
-                guiRun { tree.addScheme(Template("New Template")) }
+                ideaRunEdt { tree.addScheme(Template("New Template")) }
 
                 currentList.templates[1].name shouldBe "New Template"
             }
 
             test("selects the inserted template") {
-                guiRun { tree.selectedScheme = currentList.templates[1] }
+                ideaRunEdt { tree.selectedScheme = currentList.templates[1] }
 
-                guiRun { tree.addScheme(Template("New Template")) }
+                ideaRunEdt { tree.addScheme(Template("New Template")) }
 
                 currentList.templates[2].name shouldBe "New Template"
             }
 
             test("expands the inserted template") {
                 val template = Template("New Template", mutableListOf(DummyScheme("New Scheme")))
-                guiRun { tree.clearSelection() }
+                ideaRunEdt { tree.clearSelection() }
 
-                guiRun { tree.addScheme(template) }
+                ideaRunEdt { tree.addScheme(template) }
 
-                guiGet { (tree.getPathForRow(3).lastPathComponent as StateNode).state } shouldBe template
-                guiGet { tree.isExpanded(3) } shouldBe true
+                ideaRunEdt { (tree.getPathForRow(3).lastPathComponent as StateNode).state } shouldBe template
+                ideaRunEdt { tree.isExpanded(3) } shouldBe true
             }
         }
 
         context("scheme") {
             test("fails if a scheme is inserted while nothing is selected") {
-                guiRun { tree.clearSelection() }
+                ideaRunEdt { tree.clearSelection() }
 
                 shouldThrow<IllegalArgumentException> { tree.addScheme(DummyScheme()) }
                     .message shouldMatchBundle "template_list.error.wrong_child_type"
             }
 
             test("inserts the scheme at the bottom of the selected template") {
-                guiRun { tree.selectedScheme = currentList.templates[1] }
+                ideaRunEdt { tree.selectedScheme = currentList.templates[1] }
 
-                guiRun { tree.addScheme(DummyScheme("New Scheme")) }
+                ideaRunEdt { tree.addScheme(DummyScheme("New Scheme")) }
 
                 currentList.templates[1].schemes.last().name shouldBe "New Scheme"
             }
 
             test("inserts the scheme below the selected scheme") {
-                guiRun {
+                ideaRunEdt {
                     tree.expandRow(2)
                     tree.selectedScheme = currentList.templates[2].schemes[0]
                 }
 
-                guiRun { tree.addScheme(DummyScheme("New Scheme")) }
+                ideaRunEdt { tree.addScheme(DummyScheme("New Scheme")) }
 
                 currentList.templates[2].schemes[1].name shouldBe "New Scheme"
             }
 
             test("selects the inserted scheme") {
-                guiRun {
+                ideaRunEdt {
                     tree.expandRow(1)
                     tree.selectedScheme = currentList.templates[1].schemes[0]
                 }
 
-                guiRun { tree.addScheme(DummyScheme()) }
+                ideaRunEdt { tree.addScheme(DummyScheme()) }
 
                 tree.selectedScheme shouldBe currentList.templates[1].schemes[1]
             }
 
             test("keeps the parent expanded") {
-                guiRun { tree.selectedScheme = currentList.templates[1] }
+                ideaRunEdt { tree.selectedScheme = currentList.templates[1] }
 
-                guiRun { tree.addScheme(DummyScheme()) }
+                ideaRunEdt { tree.addScheme(DummyScheme()) }
 
-                guiGet { tree.isExpanded(1) } shouldBe true
+                ideaRunEdt { tree.isExpanded(1) } shouldBe true
             }
 
             test("expands the parent if it is not currently expanded") {
-                guiRun {
+                ideaRunEdt {
                     tree.removeScheme(currentList.templates[1].schemes[0])
                     tree.selectedScheme = currentList.templates[1]
                 }
 
-                guiRun { tree.addScheme(DummyScheme()) }
+                ideaRunEdt { tree.addScheme(DummyScheme()) }
 
-                guiGet { tree.isExpanded(1) } shouldBe true
+                ideaRunEdt { tree.isExpanded(1) } shouldBe true
             }
         }
     }
 
     context("removeScheme") {
         test("removes the given node from the tree") {
-            guiRun { tree.removeScheme(currentList.templates[1]) }
+            ideaRunEdt { tree.removeScheme(currentList.templates[1]) }
 
             currentList.templates.names() shouldContainExactly listOf("Template0", "Template2")
         }
 
         test("removes the selection if there is nothing to select") {
-            guiRun { repeat(3) { tree.removeScheme(currentList.templates[0]) } }
+            ideaRunEdt { repeat(3) { tree.removeScheme(currentList.templates[0]) } }
 
             tree.selectedScheme shouldBe null
         }
 
         test("selects the parent if the removed node had no other siblings") {
-            guiRun { tree.expandRow(1) }
+            ideaRunEdt { tree.expandRow(1) }
 
-            guiRun { tree.removeScheme(currentList.templates[1].schemes[0]) }
+            ideaRunEdt { tree.removeScheme(currentList.templates[1].schemes[0]) }
 
             tree.selectedScheme?.name shouldBe "Template1"
         }
 
         test("selects the next sibling if the removed node has siblings") {
-            guiRun { tree.expandRow(0) }
+            ideaRunEdt { tree.expandRow(0) }
 
-            guiRun { tree.removeScheme(currentList.templates[0].schemes[0]) }
+            ideaRunEdt { tree.removeScheme(currentList.templates[0].schemes[0]) }
 
             tree.selectedScheme?.name shouldBe "Scheme1"
         }
 
         test("keeps the parent expanded if it still has children") {
-            guiRun { tree.expandRow(0) }
+            ideaRunEdt { tree.expandRow(0) }
 
-            guiRun { tree.removeScheme(currentList.templates[0].schemes[0]) }
+            ideaRunEdt { tree.removeScheme(currentList.templates[0].schemes[0]) }
 
-            guiGet { tree.isExpanded(0) } shouldBe true
+            ideaRunEdt { tree.isExpanded(0) } shouldBe true
         }
     }
 
@@ -502,7 +498,7 @@ object TemplateJTreeTest : FunSpec({
         test("removes the scheme if replaced with `null`") {
             val scheme = currentList.templates[1]
 
-            guiRun { tree.replaceScheme(scheme, null) }
+            ideaRunEdt { tree.replaceScheme(scheme, null) }
 
             currentList.templates shouldNotContain scheme
         }
@@ -511,53 +507,53 @@ object TemplateJTreeTest : FunSpec({
             val oldScheme = currentList.templates[2].schemes[1]
             val newScheme = DummyScheme()
 
-            guiRun { tree.replaceScheme(oldScheme, newScheme) }
+            ideaRunEdt { tree.replaceScheme(oldScheme, newScheme) }
 
             currentList.templates[2].schemes shouldNotContain oldScheme
             currentList.templates[2].schemes shouldContain newScheme
         }
 
         test("retains the current selection") {
-            guiRun { tree.selectedScheme = currentList.templates[2] }
+            ideaRunEdt { tree.selectedScheme = currentList.templates[2] }
 
-            guiRun { tree.replaceScheme(currentList.templates[1].schemes[0], DummyScheme()) }
+            ideaRunEdt { tree.replaceScheme(currentList.templates[1].schemes[0], DummyScheme()) }
 
-            guiGet { tree.selectedScheme } shouldBe currentList.templates[2]
+            ideaRunEdt { tree.selectedScheme } shouldBe currentList.templates[2]
         }
 
         test("keeps the replaced template collapsed") {
             val oldTemplate = currentList.templates[0]
             val newTemplate = Template(schemes = mutableListOf(DummyScheme())).also { it.uuid = oldTemplate.uuid }
-            guiRun { tree.collapseRow(0) }
+            ideaRunEdt { tree.collapseRow(0) }
 
-            guiRun { tree.replaceScheme(oldTemplate, newTemplate) }
+            ideaRunEdt { tree.replaceScheme(oldTemplate, newTemplate) }
 
-            guiGet { tree.isCollapsed(0) } shouldBe true
+            ideaRunEdt { tree.isCollapsed(0) } shouldBe true
         }
 
         test("keeps the replaced template expanded") {
             val oldTemplate = currentList.templates[0]
             val newTemplate = Template(schemes = mutableListOf(DummyScheme())).also { it.uuid = oldTemplate.uuid }
-            guiRun { tree.expandRow(0) }
+            ideaRunEdt { tree.expandRow(0) }
 
-            guiRun { tree.replaceScheme(oldTemplate, newTemplate) }
+            ideaRunEdt { tree.replaceScheme(oldTemplate, newTemplate) }
 
-            guiGet { tree.isExpanded(0) } shouldBe true
+            ideaRunEdt { tree.isExpanded(0) } shouldBe true
         }
 
         test("keeps the parent expanded") {
-            guiRun { tree.expandRow(0) }
+            ideaRunEdt { tree.expandRow(0) }
 
-            guiRun { tree.replaceScheme(currentList.templates[0].schemes[1], DummyScheme()) }
+            ideaRunEdt { tree.replaceScheme(currentList.templates[0].schemes[1], DummyScheme()) }
 
-            guiGet { tree.isExpanded(0) } shouldBe true
+            ideaRunEdt { tree.isExpanded(0) } shouldBe true
         }
     }
 
     context("moveSchemeByOnePosition") {
         context("template") {
             test("moves a template") {
-                guiRun { tree.moveSchemeByOnePosition(currentList.templates[1], moveDown = true) }
+                ideaRunEdt { tree.moveSchemeByOnePosition(currentList.templates[1], moveDown = true) }
 
                 currentList.templates.names() shouldContainExactly listOf("Template0", "Template2", "Template1")
             }
@@ -565,77 +561,77 @@ object TemplateJTreeTest : FunSpec({
             test("selects the moved template") {
                 val template = currentList.templates[2]
 
-                guiRun { tree.selectedTemplate = template }
-                guiRun { tree.moveSchemeByOnePosition(template, moveDown = false) }
+                ideaRunEdt { tree.selectedTemplate = template }
+                ideaRunEdt { tree.moveSchemeByOnePosition(template, moveDown = false) }
 
                 tree.selectedTemplate shouldBe template
             }
 
             test("keeps the moved template expanded") {
                 val template = currentList.templates[2]
-                guiRun { tree.expandRow(2) }
+                ideaRunEdt { tree.expandRow(2) }
 
-                guiRun {
+                ideaRunEdt {
                     tree.selectedTemplate = template
                     tree.moveSchemeByOnePosition(template, moveDown = false)
                 }
 
-                guiGet { tree.isExpanded(1) } shouldBe true
+                ideaRunEdt { tree.isExpanded(1) } shouldBe true
             }
 
             test("keeps the moved template collapsed") {
-                guiRun { tree.collapseRow(2) }
+                ideaRunEdt { tree.collapseRow(2) }
 
-                guiRun {
+                ideaRunEdt {
                     tree.selectedTemplate = currentList.templates[2]
                     tree.moveSchemeByOnePosition(currentList.templates[2], moveDown = false)
                 }
 
-                guiGet { tree.isCollapsed(1) } shouldBe true
+                ideaRunEdt { tree.isCollapsed(1) } shouldBe true
             }
         }
 
         context("scheme") {
             test("moves a scheme") {
-                guiRun { tree.expandRow(0) }
+                ideaRunEdt { tree.expandRow(0) }
 
-                guiRun { tree.moveSchemeByOnePosition(currentList.templates[0].schemes[1], moveDown = false) }
+                ideaRunEdt { tree.moveSchemeByOnePosition(currentList.templates[0].schemes[1], moveDown = false) }
 
                 currentList.templates[0].schemes.names() shouldContainExactly listOf("Scheme1", "Scheme0")
             }
 
             test("retains the selection after moving a scheme") {
                 val scheme = currentList.templates[2].schemes[0]
-                guiRun {
+                ideaRunEdt {
                     tree.expandRow(2)
                     tree.selectedScheme = scheme
                 }
 
-                guiRun { tree.moveSchemeByOnePosition(scheme, moveDown = true) }
+                ideaRunEdt { tree.moveSchemeByOnePosition(scheme, moveDown = true) }
 
                 tree.selectedScheme shouldBe scheme
             }
 
             test("keeps the scheme's parent expanded if the parent does not change") {
-                guiRun { tree.expandRow(0) }
+                ideaRunEdt { tree.expandRow(0) }
 
-                guiRun { tree.moveSchemeByOnePosition(currentList.templates[0].schemes[1], moveDown = false) }
+                ideaRunEdt { tree.moveSchemeByOnePosition(currentList.templates[0].schemes[1], moveDown = false) }
 
-                guiGet { tree.isExpanded(0) } shouldBe true
+                ideaRunEdt { tree.isExpanded(0) } shouldBe true
             }
 
             test("if the parent changes, keeps the old parent expanded and expands the new parent") {
-                guiRun {
+                ideaRunEdt {
                     tree.collapseRow(1)
                     tree.expandRow(0)
                 }
 
                 val scheme = currentList.templates[0].schemes[1]
-                guiRun { tree.moveSchemeByOnePosition(scheme, moveDown = true) }
+                ideaRunEdt { tree.moveSchemeByOnePosition(scheme, moveDown = true) }
 
-                guiGet { tree.isExpanded(0) } shouldBe true
+                ideaRunEdt { tree.isExpanded(0) } shouldBe true
                 tree.myModel.root.descendants()[2].children shouldContain StateNode(scheme)
-                guiGet { tree.isExpanded(2) } shouldBe true
+                ideaRunEdt { tree.isExpanded(2) } shouldBe true
             }
         }
     }
@@ -660,7 +656,7 @@ object TemplateJTreeTest : FunSpec({
 
 
         test("scheme can move up into empty template") {
-            guiRun {
+            ideaRunEdt {
                 currentList.templates.add(index = 2, Template("Template2.5"))
                 tree.reload()
             }
@@ -669,7 +665,7 @@ object TemplateJTreeTest : FunSpec({
         }
 
         test("scheme can move down into empty template") {
-            guiRun {
+            ideaRunEdt {
                 currentList.templates.add(Template("Template3"))
                 tree.reload()
             }
@@ -682,7 +678,7 @@ object TemplateJTreeTest : FunSpec({
     context("buttons") {
         beforeNonContainer {
             frame.cleanUp()
-            frame = showInFrame(guiGet { tree.asDecoratedPanel() })
+            frame = showInFrame(ideaRunEdt { tree.asDecoratedPanel() })
 
             // Cleanup is done in top-level `afterNonContainer` method
         }
@@ -698,7 +694,7 @@ object TemplateJTreeTest : FunSpec({
 
         context("RemoveButton") {
             test("is disabled if nothing is selected") {
-                guiRun {
+                ideaRunEdt {
                     tree.clearSelection()
                     updateButtons()
                 }
@@ -707,12 +703,12 @@ object TemplateJTreeTest : FunSpec({
             }
 
             test("removes the selected scheme") {
-                guiRun {
+                ideaRunEdt {
                     tree.expandRow(0)
                     tree.selectedScheme = currentList.templates[0].schemes[1]
                 }
 
-                guiRun { frame.getActionButton("Remove").click() }
+                ideaRunEdt { frame.getActionButton("Remove").click() }
 
                 currentList.templates[0].schemes.names() shouldContainExactly listOf("Scheme0")
             }
@@ -720,7 +716,7 @@ object TemplateJTreeTest : FunSpec({
 
         context("CopyButton") {
             test("is disabled if nothing is selected") {
-                guiRun {
+                ideaRunEdt {
                     tree.clearSelection()
                     updateButtons()
                 }
@@ -729,23 +725,23 @@ object TemplateJTreeTest : FunSpec({
             }
 
             test("copies the selected scheme") {
-                guiRun {
+                ideaRunEdt {
                     tree.expandRow(1)
                     tree.selectedScheme = currentList.templates[1].schemes[0]
                 }
 
-                guiRun { frame.getActionButton("Copy").click() }
+                ideaRunEdt { frame.getActionButton("Copy").click() }
 
                 currentList.templates[1].schemes.names() shouldContainExactly listOf("Scheme2", "Scheme2")
             }
 
             test("creates an independent copy of the selected scheme") {
-                guiRun {
+                ideaRunEdt {
                     tree.expandRow(2)
                     tree.selectedScheme = currentList.templates[2].schemes[1]
                 }
 
-                guiRun { frame.getActionButton("Copy").click() }
+                ideaRunEdt { frame.getActionButton("Copy").click() }
                 (currentList.templates[2].schemes[2] as DummyScheme).name = "New Name"
 
                 currentList.templates[2].schemes.names() shouldContainExactly listOf("Scheme3", "Scheme4", "New Name")
@@ -760,14 +756,14 @@ object TemplateJTreeTest : FunSpec({
 
                 currentList.templates += referencingTemplate
 
-                guiRun {
+                ideaRunEdt {
                     tree.reload()
                     tree.expandRow(3)
                 }
                 currentList.templates[3] shouldBe referencingTemplate
 
                 // Act
-                guiRun {
+                ideaRunEdt {
                     tree.selectedScheme = currentList.templates[3].schemes[0]
                     frame.getActionButton("Copy").click()
                 }
@@ -782,7 +778,7 @@ object TemplateJTreeTest : FunSpec({
 
         context("UpButton") {
             test("is disabled if nothing is selected") {
-                guiRun {
+                ideaRunEdt {
                     tree.clearSelection()
                     updateButtons()
                 }
@@ -791,7 +787,7 @@ object TemplateJTreeTest : FunSpec({
             }
 
             test("is disabled if the selected scheme cannot be moved up") {
-                guiRun {
+                ideaRunEdt {
                     tree.selectedScheme = currentList.templates[0]
                     updateButtons()
                 }
@@ -800,7 +796,7 @@ object TemplateJTreeTest : FunSpec({
             }
 
             test("is enabled if the selected scheme can be moved up") {
-                guiRun {
+                ideaRunEdt {
                     tree.selectedScheme = currentList.templates[1]
                     updateButtons()
                 }
@@ -809,13 +805,13 @@ object TemplateJTreeTest : FunSpec({
             }
 
             test("moves the selected scheme up") {
-                guiRun {
+                ideaRunEdt {
                     tree.expandRow(0)
                     tree.selectedScheme = currentList.templates[0].schemes[1]
                     updateButtons()
                 }
 
-                guiRun { frame.getActionButton("Up").click() }
+                ideaRunEdt { frame.getActionButton("Up").click() }
 
                 currentList.templates[0].schemes.names() shouldContainExactly listOf("Scheme1", "Scheme0")
             }
@@ -823,7 +819,7 @@ object TemplateJTreeTest : FunSpec({
 
         context("DownButton") {
             test("is disabled if nothing is selected") {
-                guiRun {
+                ideaRunEdt {
                     tree.clearSelection()
                     updateButtons()
                 }
@@ -832,7 +828,7 @@ object TemplateJTreeTest : FunSpec({
             }
 
             test("is disabled if the selected scheme cannot be moved down") {
-                guiRun {
+                ideaRunEdt {
                     tree.selectedScheme = currentList.templates[2]
                     updateButtons()
                 }
@@ -841,7 +837,7 @@ object TemplateJTreeTest : FunSpec({
             }
 
             test("is enabled if the selected scheme can be moved down") {
-                guiRun {
+                ideaRunEdt {
                     tree.selectedScheme = currentList.templates[1]
                     updateButtons()
                 }
@@ -850,12 +846,12 @@ object TemplateJTreeTest : FunSpec({
             }
 
             test("moves the selected scheme down") {
-                guiRun {
+                ideaRunEdt {
                     tree.expandRow(2)
                     tree.selectedScheme = currentList.templates[2].schemes[0]
                 }
 
-                guiRun { frame.getActionButton("Down").click() }
+                ideaRunEdt { frame.getActionButton("Down").click() }
 
                 currentList.templates[2].schemes.names() shouldContainExactly listOf("Scheme4", "Scheme3")
             }
@@ -863,7 +859,7 @@ object TemplateJTreeTest : FunSpec({
 
         context("ResetButton") {
             test("is disabled if nothing is selected") {
-                guiRun {
+                ideaRunEdt {
                     tree.clearSelection()
                     updateButtons()
                 }
@@ -872,7 +868,7 @@ object TemplateJTreeTest : FunSpec({
             }
 
             test("is disabled if the selection has not been modified") {
-                guiRun {
+                ideaRunEdt {
                     tree.selectedScheme = currentList.templates[0]
                     updateButtons()
                 }
@@ -883,13 +879,13 @@ object TemplateJTreeTest : FunSpec({
             test("removes the scheme if it was newly added") {
                 val template = Template("New Template")
                 currentList.templates += template
-                guiRun { tree.reload() }
+                ideaRunEdt { tree.reload() }
 
-                guiRun {
+                ideaRunEdt {
                     tree.selectedScheme = template
                     updateButtons()
                 }
-                guiRun {
+                ideaRunEdt {
                     frame.getActionButton("Reset").click()
                 }
 
@@ -898,26 +894,26 @@ object TemplateJTreeTest : FunSpec({
 
             test("resets changes to the initially selected scheme") {
                 (currentList.templates[0].schemes[0] as DummyScheme).name = "New Name"
-                guiRun {
+                ideaRunEdt {
                     tree.reload()
                     updateButtons()
                 }
                 currentList.templates[0].schemes[0].name shouldBe "New Name"
 
-                guiRun { frame.getActionButton("Reset").click() }
+                ideaRunEdt { frame.getActionButton("Reset").click() }
 
                 currentList.templates[0].schemes[0].name shouldBe "Scheme0"
             }
 
             test("resets changes to a template") {
                 currentList.templates[0].name = "New Name"
-                guiRun {
+                ideaRunEdt {
                     tree.reload()
                     updateButtons()
                 }
                 currentList.templates[0].name shouldBe "New Name"
 
-                guiRun {
+                ideaRunEdt {
                     tree.selectedScheme = currentList.templates[0]
                     frame.getActionButton("Reset").click()
                 }
@@ -927,59 +923,59 @@ object TemplateJTreeTest : FunSpec({
 
             test("resets changes to the selected scheme") {
                 (currentList.templates[1].schemes[0] as DummyScheme).name = "New Name"
-                guiRun { tree.reload() }
+                ideaRunEdt { tree.reload() }
                 currentList.templates[1].schemes[0].name shouldBe "New Name"
 
-                guiRun {
+                ideaRunEdt {
                     tree.selectedScheme = currentList.templates[1].schemes[0]
                     updateButtons()
                 }
-                guiRun { frame.getActionButton("Reset").click() }
+                ideaRunEdt { frame.getActionButton("Reset").click() }
 
                 currentList.templates[1].schemes[0].name shouldBe "Scheme2"
             }
 
             test("resets the selected template's scheme order") {
                 currentList.templates[0].schemes.setAll(currentList.templates[0].schemes.asReversed().toList())
-                guiRun { tree.reload() }
+                ideaRunEdt { tree.reload() }
                 currentList.templates[0].schemes.names() shouldContainExactly listOf("Scheme1", "Scheme0")
 
-                guiRun {
+                ideaRunEdt {
                     tree.selectedScheme = currentList.templates[0]
                     updateButtons()
                 }
-                guiRun { frame.getActionButton("Reset").click() }
+                ideaRunEdt { frame.getActionButton("Reset").click() }
 
                 currentList.templates[0].schemes.names() shouldContainExactly listOf("Scheme0", "Scheme1")
             }
 
             test("resets the selected template's schemes") {
                 (currentList.templates[2].schemes[0] as DummyScheme).name = "New Name"
-                guiRun { tree.reload() }
+                ideaRunEdt { tree.reload() }
                 currentList.templates[2].schemes[0].name shouldBe "New Name"
 
-                guiRun {
+                ideaRunEdt {
                     tree.selectedScheme = currentList.templates[2]
                     updateButtons()
                 }
-                guiRun { frame.getActionButton("Reset").click() }
+                ideaRunEdt { frame.getActionButton("Reset").click() }
 
                 currentList.templates[2].schemes[0].name shouldBe "Scheme3"
             }
 
             test("resets changes multiple times") {
                 (currentList.templates[0].schemes[0] as DummyScheme).name = "New Name"
-                guiRun { tree.reload() }
+                ideaRunEdt { tree.reload() }
                 currentList.templates[0].schemes[0].name shouldBe "New Name"
-                guiRun { frame.getActionButton("Reset").click() }
+                ideaRunEdt { frame.getActionButton("Reset").click() }
                 (currentList.templates[0].schemes[0] as DummyScheme).name = "New Name"
-                guiRun {
+                ideaRunEdt {
                     tree.reload()
                     updateButtons()
                 }
                 currentList.templates[0].schemes[0].name shouldBe "New Name"
 
-                guiRun { frame.getActionButton("Reset").click() }
+                ideaRunEdt { frame.getActionButton("Reset").click() }
 
                 currentList.templates[0].schemes[0].name shouldBe "Scheme0"
             }

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateListConfigurableTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateListConfigurableTest.kt
@@ -3,8 +3,7 @@ package com.fwdekker.randomness.template
 import com.fwdekker.randomness.Settings
 import com.fwdekker.randomness.testhelpers.afterNonContainer
 import com.fwdekker.randomness.testhelpers.beforeNonContainer
-import com.fwdekker.randomness.testhelpers.guiGet
-import com.fwdekker.randomness.testhelpers.guiRun
+import com.fwdekker.randomness.testhelpers.ideaRunEdt
 import com.fwdekker.randomness.testhelpers.shouldContainExactly
 import com.fwdekker.randomness.testhelpers.shouldMatchBundle
 import com.fwdekker.randomness.testhelpers.useBareIdeaFixture
@@ -40,25 +39,25 @@ object TemplateListConfigurableTest : FunSpec({
 
     beforeNonContainer {
         configurable = TemplateListConfigurable()
-        frame = Containers.showInFrame(guiGet { configurable.createComponent() })
+        frame = Containers.showInFrame(ideaRunEdt { configurable.createComponent() })
     }
 
     afterNonContainer {
         frame.cleanUp()
-        guiRun { configurable.disposeUIResources() }
+        ideaRunEdt { configurable.disposeUIResources() }
     }
 
 
     context("templateToSelect") {
         test("selects the template with the given UUID") {
             frame.cleanUp()
-            guiRun { configurable.disposeUIResources() }
+            ideaRunEdt { configurable.disposeUIResources() }
 
             configurable = TemplateListConfigurable()
             configurable.schemeToSelect = Settings.DEFAULT.templates[2].uuid
-            frame = Containers.showInFrame(guiGet { configurable.createComponent() })
+            frame = Containers.showInFrame(ideaRunEdt { configurable.createComponent() })
 
-            guiGet { frame.tree().target().selectionRows!! } shouldContainExactly arrayOf(4)
+            ideaRunEdt { frame.tree().target().selectionRows!! } shouldContainExactly arrayOf(4)
         }
     }
 
@@ -69,14 +68,14 @@ object TemplateListConfigurableTest : FunSpec({
         }
 
         test("returns `true` if modifications were made") {
-            guiRun { frame.textBox("templateName").target().text = "New Name" }
+            ideaRunEdt { frame.textBox("templateName").target().text = "New Name" }
 
             configurable.isModified shouldBe true
         }
 
         test("returns `true` if no modifications were made but the template list is invalid") {
             Settings.DEFAULT.templates[0].name = ""
-            guiRun { configurable.reset() }
+            ideaRunEdt { configurable.reset() }
 
             configurable.editor.isModified() shouldBe false
             configurable.isModified shouldBe true
@@ -85,14 +84,14 @@ object TemplateListConfigurableTest : FunSpec({
 
     context("apply") {
         test("throws an exception if the template list is invalid") {
-            guiRun { frame.textBox("templateName").target().text = "" }
+            ideaRunEdt { frame.textBox("templateName").target().text = "" }
 
             shouldThrow<ConfigurationException> { configurable.apply() }
                 .title shouldMatchBundle "template_list.error.failed_to_save_settings"
         }
 
         test("applies the changes") {
-            guiRun { frame.textBox("templateName").target().text = "New Name" }
+            ideaRunEdt { frame.textBox("templateName").target().text = "New Name" }
 
             configurable.apply()
 
@@ -102,11 +101,11 @@ object TemplateListConfigurableTest : FunSpec({
 
     context("reset") {
         test("resets the editor") {
-            guiRun { frame.textBox("templateName").target().text = "Changed Name" }
+            ideaRunEdt { frame.textBox("templateName").target().text = "Changed Name" }
 
-            guiRun { configurable.reset() }
+            ideaRunEdt { configurable.reset() }
 
-            guiGet { frame.textBox("templateName").target().text } shouldNotBe "Changed Name"
+            ideaRunEdt { frame.textBox("templateName").target().text } shouldNotBe "Changed Name"
         }
     }
 })

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateListConfigurableTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateListConfigurableTest.kt
@@ -5,14 +5,13 @@ import com.fwdekker.randomness.testhelpers.afterNonContainer
 import com.fwdekker.randomness.testhelpers.beforeNonContainer
 import com.fwdekker.randomness.testhelpers.guiGet
 import com.fwdekker.randomness.testhelpers.guiRun
-import com.fwdekker.randomness.testhelpers.matchBundle
 import com.fwdekker.randomness.testhelpers.shouldContainExactly
+import com.fwdekker.randomness.testhelpers.shouldMatchBundle
 import com.fwdekker.randomness.testhelpers.useBareIdeaFixture
 import com.fwdekker.randomness.testhelpers.useEdtViolationDetection
 import com.intellij.openapi.options.ConfigurationException
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import org.assertj.swing.fixture.Containers
@@ -89,7 +88,7 @@ object TemplateListConfigurableTest : FunSpec({
             guiRun { frame.textBox("templateName").target().text = "" }
 
             shouldThrow<ConfigurationException> { configurable.apply() }
-                .title should matchBundle("template_list.error.failed_to_save_settings")
+                .title shouldMatchBundle "template_list.error.failed_to_save_settings"
         }
 
         test("applies the changes") {

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateListEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateListEditorTest.kt
@@ -11,8 +11,7 @@ import com.fwdekker.randomness.testhelpers.DummyScheme
 import com.fwdekker.randomness.testhelpers.Tags
 import com.fwdekker.randomness.testhelpers.afterNonContainer
 import com.fwdekker.randomness.testhelpers.beforeNonContainer
-import com.fwdekker.randomness.testhelpers.guiGet
-import com.fwdekker.randomness.testhelpers.guiRun
+import com.fwdekker.randomness.testhelpers.ideaRunEdt
 import com.fwdekker.randomness.testhelpers.shouldContainExactly
 import com.fwdekker.randomness.testhelpers.shouldMatchBundle
 import com.fwdekker.randomness.testhelpers.useBareIdeaFixture
@@ -66,13 +65,13 @@ object TemplateListEditorTest : FunSpec({
             )
         templateList.applyContext(Settings(templateList = templateList))
 
-        editor = guiGet { TemplateListEditor(templateList) }
+        editor = ideaRunEdt { TemplateListEditor(templateList) }
         frame = Containers.showInFrame(editor.rootComponent)
     }
 
     afterNonContainer {
         frame.cleanUp()
-        guiRun { Disposer.dispose(editor) }
+        ideaRunEdt { Disposer.dispose(editor) }
     }
 
 
@@ -90,12 +89,12 @@ object TemplateListEditorTest : FunSpec({
             )
         ) { (uuid, expectedSelection) ->
             frame.cleanUp()
-            guiRun { Disposer.dispose(editor) }
+            ideaRunEdt { Disposer.dispose(editor) }
 
-            editor = guiGet { TemplateListEditor(templateList, initialSelection = uuid()) }
+            editor = ideaRunEdt { TemplateListEditor(templateList, initialSelection = uuid()) }
             frame = Containers.showInFrame(editor.rootComponent)
 
-            guiGet { frame.tree().target().selectionRows!! } shouldContainExactly arrayOf(expectedSelection)
+            ideaRunEdt { frame.tree().target().selectionRows!! } shouldContainExactly arrayOf(expectedSelection)
         }
     }
 
@@ -115,7 +114,7 @@ object TemplateListEditorTest : FunSpec({
                 templateList.templates.setAll(listOf(Template(schemes = mutableListOf(scheme))))
                 templateList.applyContext(templateList.context)
 
-                guiRun {
+                ideaRunEdt {
                     editor.reset()
                     frame.tree().target().setSelectionRow(1)
                 }
@@ -128,7 +127,7 @@ object TemplateListEditorTest : FunSpec({
             templateList.templates.setAll(listOf(Template(schemes = mutableListOf())))
             templateList.applyContext(templateList.context)
 
-            guiRun { editor.reset() }
+            ideaRunEdt { editor.reset() }
 
             frame.textBox("templateName").requireVisible()
         }
@@ -137,9 +136,9 @@ object TemplateListEditorTest : FunSpec({
             templateList.templates.setAll(listOf(Template(schemes = mutableListOf(DummyScheme()))))
             templateList.applyContext(templateList.context)
 
-            guiRun { editor.reset() }
+            ideaRunEdt { editor.reset() }
 
-            shouldThrow<IllegalStateException> { guiRun { frame.tree().target().setSelectionRow(1) } }
+            shouldThrow<IllegalStateException> { ideaRunEdt { frame.tree().target().setSelectionRow(1) } }
                 .message shouldMatchBundle "template_list.error.unknown_scheme_type"
         }
     }
@@ -147,71 +146,71 @@ object TemplateListEditorTest : FunSpec({
 
     context("doValidate") {
         test("returns `null` for the default list") {
-            guiGet { editor.doValidate() } shouldBe null
+            ideaRunEdt { editor.doValidate() } shouldBe null
         }
 
         test("returns `null` if the template list is valid") {
             templateList.templates.setAll(listOf(Template(schemes = mutableListOf(DummyScheme()))))
             templateList.applyContext(templateList.context)
-            guiRun { editor.reset() }
+            ideaRunEdt { editor.reset() }
 
-            guiGet { editor.doValidate() } shouldBe null
+            ideaRunEdt { editor.doValidate() } shouldBe null
         }
 
         test("returns a string if the template list is invalid") {
             templateList.templates.setAll(listOf(Template(schemes = mutableListOf(DummyScheme(valid = false)))))
             templateList.applyContext(templateList.context)
-            guiRun { editor.reset() }
+            ideaRunEdt { editor.reset() }
 
-            guiGet { editor.doValidate() } shouldNotBe null
+            ideaRunEdt { editor.doValidate() } shouldNotBe null
         }
     }
 
     context("isModified") {
         test("returns `false` if no modifications have been made") {
-            guiGet { editor.isModified() } shouldBe false
+            ideaRunEdt { editor.isModified() } shouldBe false
         }
 
         test("returns `true` if modifications have been made") {
-            guiRun {
+            ideaRunEdt {
                 frame.tree().target().selectionRows = intArrayOf(1)
                 frame.spinner("minValue").target().value = 1
             }
 
-            guiGet { editor.isModified() } shouldBe true
+            ideaRunEdt { editor.isModified() } shouldBe true
         }
 
         test("returns `false` if modifications have been reset") {
-            guiRun {
+            ideaRunEdt {
                 frame.tree().target().selectionRows = intArrayOf(1)
                 frame.spinner("minValue").target().value = 1
             }
 
-            guiRun { editor.reset() }
+            ideaRunEdt { editor.reset() }
 
-            guiGet { editor.isModified() } shouldBe false
+            ideaRunEdt { editor.isModified() } shouldBe false
         }
     }
 
     context("apply") {
         test("applies changes to the original list") {
-            guiRun {
+            ideaRunEdt {
                 frame.tree().target().selectionRows = intArrayOf(1)
                 frame.spinner("minValue").target().value = 3
             }
 
             (templateList.templates[0].schemes[0] as IntegerScheme).minValue shouldNotBe 3
-            guiRun { editor.apply() }
+            ideaRunEdt { editor.apply() }
 
             (templateList.templates[0].schemes[0] as IntegerScheme).minValue shouldBe 3
         }
 
         test("does not couple the applied state to the editor's internal state") {
-            guiRun {
+            ideaRunEdt {
                 frame.tree().target().selectionRows = intArrayOf(2)
                 frame.textBox("pattern").target().text = "old"
 
-                guiRun { editor.apply() }
+                ideaRunEdt { editor.apply() }
 
                 frame.tree().target().selectionRows = intArrayOf(2)
                 frame.textBox("pattern").target().text = "new"
@@ -223,29 +222,29 @@ object TemplateListEditorTest : FunSpec({
 
     context("reset") {
         test("undoes changes to the current selection") {
-            guiRun {
+            ideaRunEdt {
                 frame.tree().target().setSelectionRow(1)
                 frame.spinner("minValue").target().value = 7L
             }
 
-            guiRun { editor.reset() }
+            ideaRunEdt { editor.reset() }
 
             frame.spinner("minValue").target().value shouldBe 0L
         }
 
         test("undoes changes to another selection") {
-            guiRun {
+            ideaRunEdt {
                 frame.tree().target().setSelectionRow(1)
                 frame.spinner("minValue").target().value = 7L
             }
 
-            guiRun {
+            ideaRunEdt {
                 frame.tree().target().setSelectionRow(3)
                 editor.reset()
             }
 
-            guiRun { frame.tree().target().setSelectionRow(1) }
-            guiGet { frame.spinner("minValue").target().value } shouldBe 0L
+            ideaRunEdt { frame.tree().target().setSelectionRow(1) }
+            ideaRunEdt { frame.spinner("minValue").target().value } shouldBe 0L
         }
     }
 })

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateListEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateListEditorTest.kt
@@ -13,8 +13,8 @@ import com.fwdekker.randomness.testhelpers.afterNonContainer
 import com.fwdekker.randomness.testhelpers.beforeNonContainer
 import com.fwdekker.randomness.testhelpers.guiGet
 import com.fwdekker.randomness.testhelpers.guiRun
-import com.fwdekker.randomness.testhelpers.matchBundle
 import com.fwdekker.randomness.testhelpers.shouldContainExactly
+import com.fwdekker.randomness.testhelpers.shouldMatchBundle
 import com.fwdekker.randomness.testhelpers.useBareIdeaFixture
 import com.fwdekker.randomness.testhelpers.useEdtViolationDetection
 import com.fwdekker.randomness.uuid.UuidScheme
@@ -25,10 +25,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.data.Row2
 import io.kotest.data.row
 import io.kotest.datatest.withData
-import io.kotest.matchers.nulls.beNull
-import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNot
 import io.kotest.matchers.shouldNotBe
 import org.assertj.swing.fixture.AbstractComponentFixture
 import org.assertj.swing.fixture.Containers
@@ -143,14 +140,14 @@ object TemplateListEditorTest : FunSpec({
             guiRun { editor.reset() }
 
             shouldThrow<IllegalStateException> { guiRun { frame.tree().target().setSelectionRow(1) } }
-                .message should matchBundle("template_list.error.unknown_scheme_type")
+                .message shouldMatchBundle "template_list.error.unknown_scheme_type"
         }
     }
 
 
     context("doValidate") {
         test("returns `null` for the default list") {
-            guiGet { editor.doValidate() } should beNull()
+            guiGet { editor.doValidate() } shouldBe null
         }
 
         test("returns `null` if the template list is valid") {
@@ -158,7 +155,7 @@ object TemplateListEditorTest : FunSpec({
             templateList.applyContext(templateList.context)
             guiRun { editor.reset() }
 
-            guiGet { editor.doValidate() } should beNull()
+            guiGet { editor.doValidate() } shouldBe null
         }
 
         test("returns a string if the template list is invalid") {
@@ -166,7 +163,7 @@ object TemplateListEditorTest : FunSpec({
             templateList.applyContext(templateList.context)
             guiRun { editor.reset() }
 
-            guiGet { editor.doValidate() } shouldNot beNull()
+            guiGet { editor.doValidate() } shouldNotBe null
         }
     }
 

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateListTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateListTest.kt
@@ -7,8 +7,7 @@ import com.fwdekker.randomness.testhelpers.stateDeepCopyTestFactory
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.data.row
 import io.kotest.datatest.withData
-import io.kotest.matchers.nulls.beNull
-import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeSameInstanceAs
 
 
@@ -42,7 +41,7 @@ object TemplateListTest : FunSpec({
         test("returns null if no such template can be found") {
             val list = TemplateList()
 
-            list.getTemplateByUuid("46840969-0b31-4fef-92b0-42f34dbc9f8b") should beNull()
+            list.getTemplateByUuid("46840969-0b31-4fef-92b0-42f34dbc9f8b") shouldBe null
         }
 
         test("returns the template with the given UUID") {
@@ -58,7 +57,7 @@ object TemplateListTest : FunSpec({
 
             val scheme = list.templates[0].schemes[0]
 
-            list.getTemplateByUuid(scheme.uuid) should beNull()
+            list.getTemplateByUuid(scheme.uuid) shouldBe null
         }
     }
 
@@ -66,7 +65,7 @@ object TemplateListTest : FunSpec({
         test("returns null if no such scheme can be found") {
             val list = TemplateList()
 
-            list.getSchemeByUuid("46840969-0b31-4fef-92b0-42f34dbc9f8b") should beNull()
+            list.getSchemeByUuid("46840969-0b31-4fef-92b0-42f34dbc9f8b") shouldBe null
         }
 
         test("returns the scheme with the given UUID") {

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateReferenceEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateReferenceEditorTest.kt
@@ -7,18 +7,15 @@ import com.fwdekker.randomness.testhelpers.Tags
 import com.fwdekker.randomness.testhelpers.afterNonContainer
 import com.fwdekker.randomness.testhelpers.beforeNonContainer
 import com.fwdekker.randomness.testhelpers.editorFieldsTests
-import com.fwdekker.randomness.testhelpers.guiGet
-import com.fwdekker.randomness.testhelpers.guiRun
 import com.fwdekker.randomness.testhelpers.itemProp
 import com.fwdekker.randomness.testhelpers.prop
+import com.fwdekker.randomness.testhelpers.runEdt
 import com.fwdekker.randomness.testhelpers.textProp
 import com.fwdekker.randomness.testhelpers.useEdtViolationDetection
 import com.fwdekker.randomness.testhelpers.valueProp
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.data.row
 import io.kotest.matchers.collections.shouldNotContain
-import io.kotest.matchers.nulls.beNull
-import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import org.assertj.swing.fixture.Containers
 import org.assertj.swing.fixture.FrameFixture
@@ -55,7 +52,7 @@ object TemplateReferenceEditorTest : FunSpec({
         reference.applyContext(context)
         reference.templateUuid = context.templates[0].uuid
 
-        editor = guiGet { TemplateReferenceEditor(reference) }
+        editor = runEdt { TemplateReferenceEditor(reference) }
         frame = Containers.showInFrame(editor.rootComponent)
     }
 
@@ -67,9 +64,9 @@ object TemplateReferenceEditorTest : FunSpec({
     context("reset") {
         test("selects nothing if the reference refers to null") {
             reference.template = null
-            guiRun { editor.reset() }
+            runEdt { editor.reset() }
 
-            guiGet { frame.comboBox("template").itemProp().get() } shouldBe null
+            runEdt { frame.comboBox("template").itemProp().get() } shouldBe null
         }
 
         test("does not load the reference's parent as a selectable option") {

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateReferenceEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateReferenceEditorTest.kt
@@ -69,7 +69,7 @@ object TemplateReferenceEditorTest : FunSpec({
             reference.template = null
             guiRun { editor.reset() }
 
-            guiGet { frame.comboBox("template").itemProp().get() } should beNull()
+            guiGet { frame.comboBox("template").itemProp().get() } shouldBe null
         }
 
         test("does not load the reference's parent as a selectable option") {

--- a/src/test/kotlin/com/fwdekker/randomness/template/TemplateReferenceTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/template/TemplateReferenceTest.kt
@@ -6,9 +6,9 @@ import com.fwdekker.randomness.Settings
 import com.fwdekker.randomness.setAll
 import com.fwdekker.randomness.testhelpers.DummyScheme
 import com.fwdekker.randomness.testhelpers.Tags
-import com.fwdekker.randomness.testhelpers.beSameIconAs
 import com.fwdekker.randomness.testhelpers.beforeNonContainer
-import com.fwdekker.randomness.testhelpers.matchBundle
+import com.fwdekker.randomness.testhelpers.shouldBeSameIconAs
+import com.fwdekker.randomness.testhelpers.shouldMatchBundle
 import com.fwdekker.randomness.testhelpers.shouldValidateAsBundle
 import com.fwdekker.randomness.testhelpers.stateDeepCopyTestFactory
 import com.fwdekker.randomness.testhelpers.stateSerializationTestFactory
@@ -16,11 +16,9 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.data.row
 import io.kotest.datatest.withData
-import io.kotest.matchers.collections.haveSize
-import io.kotest.matchers.nulls.beNull
-import io.kotest.matchers.should
+import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNot
+import io.kotest.matchers.shouldNotBe
 
 
 /**
@@ -50,7 +48,7 @@ object TemplateReferenceTest : FunSpec({
         test("returns an alternative name if no template is set") {
             reference.template = null
 
-            reference.name should matchBundle("reference.title")
+            reference.name shouldMatchBundle "reference.title"
         }
 
         test("returns the referenced template's name with brackets") {
@@ -80,28 +78,28 @@ object TemplateReferenceTest : FunSpec({
         test("uses the default icon with a link overlay if the template is null") {
             reference.template = null
 
-            reference.icon.base should beSameIconAs(TemplateReference.DEFAULT_ICON)
-            reference.icon.overlays.single() should beSameIconAs(OverlayIcon.REFERENCE)
+            reference.icon.base shouldBeSameIconAs TemplateReference.DEFAULT_ICON
+            reference.icon.overlays.single() shouldBeSameIconAs OverlayIcon.REFERENCE
         }
 
         test("uses the default icon with a link overlay if the template is not in the context's template list") {
             reference.template = Template("new")
 
-            reference.icon.base should beSameIconAs(TemplateReference.DEFAULT_ICON)
-            reference.icon.overlays.single() should beSameIconAs(OverlayIcon.REFERENCE)
+            reference.icon.base shouldBeSameIconAs TemplateReference.DEFAULT_ICON
+            reference.icon.overlays.single() shouldBeSameIconAs OverlayIcon.REFERENCE
         }
 
         test("uses the referenced template's icon with a link overlay") {
-            reference.icon.base should beSameIconAs(referencedTemplate.typeIcon)
-            reference.icon.overlays.single() should beSameIconAs(OverlayIcon.REFERENCE)
+            reference.icon.base shouldBeSameIconAs referencedTemplate.typeIcon
+            reference.icon.overlays.single() shouldBeSameIconAs OverlayIcon.REFERENCE
         }
 
         test("appends the link overlay to its own list of overlays") {
             reference.arrayDecorator.enabled = true
 
-            reference.icon.overlays should haveSize(2)
-            reference.icon.overlays[0] should beSameIconAs(OverlayIcon.ARRAY)
-            reference.icon.overlays[1] should beSameIconAs(OverlayIcon.REFERENCE)
+            reference.icon.overlays shouldHaveSize 2
+            reference.icon.overlays[0] shouldBeSameIconAs OverlayIcon.ARRAY
+            reference.icon.overlays[1] shouldBeSameIconAs OverlayIcon.REFERENCE
         }
     }
 
@@ -128,13 +126,13 @@ object TemplateReferenceTest : FunSpec({
             test("returns null if the UUID is null") {
                 reference.templateUuid = null
 
-                reference.template should beNull()
+                reference.template shouldBe null
             }
 
             test("returns null if there is no template with the given UUID in the template list") {
                 reference.templateUuid = "7a9b9822-c99e-41dc-8e6a-220ca4dec181"
 
-                reference.template should beNull()
+                reference.template shouldBe null
             }
 
             test("returns the template with the given UUID if it is in the template list") {
@@ -161,7 +159,7 @@ object TemplateReferenceTest : FunSpec({
             test("sets the template UUID to null if the given template is null") {
                 reference.template = null
 
-                reference.templateUuid should beNull()
+                reference.templateUuid shouldBe null
             }
 
             test("sets the template UUID regardless of the set template's contents") {
@@ -180,11 +178,11 @@ object TemplateReferenceTest : FunSpec({
 
     context("applyContext") {
         test("changes the list of templates into which this reference refers") {
-            reference.template shouldNot beNull()
+            reference.template shouldNotBe null
 
             reference.applyContext(Settings(templateList = TemplateList(mutableListOf())))
 
-            reference.template should beNull()
+            reference.template shouldBe null
         }
     }
 

--- a/src/test/kotlin/com/fwdekker/randomness/testhelpers/AssertJSwingHelpers.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/testhelpers/AssertJSwingHelpers.kt
@@ -6,20 +6,21 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.assertj.swing.core.GenericTypeMatcher
 import org.assertj.swing.driver.ComponentDriver
+import org.assertj.swing.edt.GuiActionRunner
 import org.assertj.swing.fixture.AbstractComponentFixture
 import org.assertj.swing.fixture.FrameFixture
 import java.awt.Component
 
 
 /**
- * Runs [lambda] in the GUI thread.
- */
-suspend fun guiRun(lambda: suspend () -> Unit) = withContext(Dispatchers.EDT) { lambda() }
-
-/**
  * Runs [lambda] in the GUI thread and returns the result.
  */
-suspend fun <T> guiGet(lambda: suspend () -> T): T = withContext(Dispatchers.EDT) { lambda() }
+fun <T> runEdt(lambda: () -> T): T = GuiActionRunner.execute(lambda)
+
+/**
+ * Runs [lambda] in the IDEA fixture's GUI coroutine and returns the result.
+ */
+suspend fun <T> ideaRunEdt(lambda: suspend () -> T): T = withContext(Dispatchers.EDT) { lambda() }
 
 
 /**

--- a/src/test/kotlin/com/fwdekker/randomness/testhelpers/EditorTestFactories.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/testhelpers/EditorTestFactories.kt
@@ -22,7 +22,7 @@ fun editorApplyTests(editor: () -> SchemeEditor<*>) =
             test("makes no changes by default") {
                 val before = editor().scheme.deepCopy(retainUuid = true)
 
-                guiRun { editor().apply() }
+                runEdt { editor().apply() }
 
                 before shouldBe editor().scheme
             }
@@ -49,8 +49,8 @@ fun <S : Scheme> editorFieldsTests(
 
                     withClue("Pre: Scheme value should not be set value") { schemeProperty.get() shouldNotBe value }
 
-                    guiRun { editorProperty.set(value) }
-                    guiRun { editor().apply() }
+                    runEdt { editorProperty.set(value) }
+                    runEdt { editor().apply() }
 
                     withClue("Post: Scheme value should be set value") { schemeProperty.get() shouldBe value }
                 }
@@ -63,7 +63,7 @@ fun <S : Scheme> editorFieldsTests(
                     withClue("Pre: Editor value should not be set value") { editorProperty.get() shouldNotBe value }
 
                     schemeProperty.set(value)
-                    guiRun { editor().reset() }
+                    runEdt { editor().reset() }
 
                     withClue("Post: Editor value should be set value") { editorProperty.get() shouldBe value }
                 }
@@ -76,7 +76,7 @@ fun <S : Scheme> editorFieldsTests(
                     var invoked = 0
                     editor().addChangeListener { invoked++ }
 
-                    guiRun { editorProperty.set(value) }
+                    runEdt { editorProperty.set(value) }
 
                     withClue("Listener should have been invoked") { invoked shouldBeGreaterThanOrEqual 1 }
                 }

--- a/src/test/kotlin/com/fwdekker/randomness/testhelpers/KotestHelpers.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/testhelpers/KotestHelpers.kt
@@ -53,9 +53,9 @@ fun ContainerScope.afterNonContainer(after: AfterAny) {
 /**
  * Like the regular `test` function, but ensures that the [block] runs in the event-dispatching thread (EDT).
  */
-suspend fun FunSpecContainerScope.edtTest(name: String, block: suspend TestScope.() -> Unit) =
+suspend fun FunSpecContainerScope.ideaEdtTest(name: String, block: suspend TestScope.() -> Unit) =
     test(name) {
-        guiRun {
+        ideaRunEdt {
             block()
         }
     }

--- a/src/test/kotlin/com/fwdekker/randomness/testhelpers/KotestMatchers.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/testhelpers/KotestMatchers.kt
@@ -15,20 +15,20 @@ import io.kotest.matchers.collections.beEmptyArray
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.nulls.beNull
 import io.kotest.matchers.should
+import io.kotest.matchers.shouldNot
 import org.jdom.Element
 import javax.swing.Icon
 
 
 /**
- * @see beEmptyArray
+ * Similar to [beEmptyArray], but also fails if `this` is not specifically an array of [Int]s.
  */
 fun beEmptyIntArray() = Matcher<IntArray> { self -> beEmptyArray<Int>().test(self.toTypedArray()) }
 
 /**
  * @see shouldContainExactly
  */
-infix fun IntArray.shouldContainExactly(collection: Array<Int>) =
-    this.toTypedArray() shouldContainExactly collection
+infix fun IntArray.shouldContainExactly(collection: Array<Int>) = toTypedArray() shouldContainExactly collection
 
 
 /**
@@ -46,6 +46,14 @@ fun matchBundle(key: String, vararg args: String): Matcher<String?> =
             { "string was '$string' and should not have matched format '$format'" },
         )
     }
+
+/**
+ * Infix version of [matchBundle], without additional arguments.
+ */
+infix fun <S : String?> S.shouldMatchBundle(key: String): S {
+    this should matchBundle(key)
+    return this
+}
 
 /**
  * Matches [State.doValidate] against the [Bundle] entry at [key], based on [matchBundle] (without `args`).
@@ -103,6 +111,14 @@ fun beSameIconAs(other: Icon?): Matcher<Icon?> =
  */
 infix fun <I : Icon?> I.shouldBeSameIconAs(other: Icon?): I {
     this should beSameIconAs(other)
+    return this
+}
+
+/**
+ * Negated infix version of [beSameIconAs].
+ */
+infix fun <I : Icon?> I.shouldNotBeSameIconAs(other: Icon?): I {
+    this shouldNot beSameIconAs(other)
     return this
 }
 

--- a/src/test/kotlin/com/fwdekker/randomness/testhelpers/StateReflectionTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/testhelpers/StateReflectionTest.kt
@@ -13,9 +13,7 @@ import com.intellij.util.xmlb.annotations.XCollection
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.data.row
 import io.kotest.datatest.withData
-import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
-import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 
 
@@ -57,7 +55,7 @@ object StateReflectionTest : FunSpec({
                     row(ParametersAndFieldsSub(), listOf("foo", "bar", "baz", "qux")),
             )
         ) { (state, parameters) ->
-            state.properties().callableNames() should containExactlyInAnyOrder(parameters + listOf("context", "uuid"))
+            state.properties().callableNames() shouldContainExactlyInAnyOrder parameters + listOf("context", "uuid")
         }
     }
 

--- a/src/test/kotlin/com/fwdekker/randomness/ui/JDateTimeFieldTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/ui/JDateTimeFieldTest.kt
@@ -4,11 +4,10 @@ import com.fwdekker.randomness.Timestamp
 import com.fwdekker.randomness.testhelpers.beforeNonContainer
 import com.fwdekker.randomness.testhelpers.guiGet
 import com.fwdekker.randomness.testhelpers.guiRun
-import com.fwdekker.randomness.testhelpers.matchBundle
+import com.fwdekker.randomness.testhelpers.shouldMatchBundle
 import com.fwdekker.randomness.testhelpers.useEdtViolationDetection
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 
 
@@ -39,7 +38,7 @@ object JDateTimeFieldTest : FunSpec({
         context("set") {
             test("throws an error if a non-date-time is set") {
                 shouldThrow<IllegalArgumentException> { guiRun { field.setValue("invalid") } }
-                    .message should matchBundle("datetime_field.error.invalid_type")
+                    .message shouldMatchBundle "datetime_field.error.invalid_type"
             }
         }
 

--- a/src/test/kotlin/com/fwdekker/randomness/ui/JDateTimeFieldTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/ui/JDateTimeFieldTest.kt
@@ -2,8 +2,7 @@ package com.fwdekker.randomness.ui
 
 import com.fwdekker.randomness.Timestamp
 import com.fwdekker.randomness.testhelpers.beforeNonContainer
-import com.fwdekker.randomness.testhelpers.guiGet
-import com.fwdekker.randomness.testhelpers.guiRun
+import com.fwdekker.randomness.testhelpers.runEdt
 import com.fwdekker.randomness.testhelpers.shouldMatchBundle
 import com.fwdekker.randomness.testhelpers.useEdtViolationDetection
 import io.kotest.assertions.throwables.shouldThrow
@@ -21,7 +20,7 @@ object JDateTimeFieldTest : FunSpec({
     useEdtViolationDetection()
 
     beforeNonContainer {
-        field = guiGet { JDateTimeField() }
+        field = runEdt { JDateTimeField() }
     }
 
 
@@ -29,7 +28,7 @@ object JDateTimeFieldTest : FunSpec({
         context("get") {
             test("returns the default if no value has been set") {
                 val default = Timestamp("2034")
-                val myField = guiGet { JDateTimeField(default) }
+                val myField = runEdt { JDateTimeField(default) }
 
                 myField.value shouldBe default
             }
@@ -37,7 +36,7 @@ object JDateTimeFieldTest : FunSpec({
 
         context("set") {
             test("throws an error if a non-date-time is set") {
-                shouldThrow<IllegalArgumentException> { guiRun { field.setValue("invalid") } }
+                shouldThrow<IllegalArgumentException> { runEdt { field.setValue("invalid") } }
                     .message shouldMatchBundle "datetime_field.error.invalid_type"
             }
         }
@@ -45,7 +44,7 @@ object JDateTimeFieldTest : FunSpec({
         test("returns the value that is set to it") {
             val dateTime = Timestamp("0006-08-17 23:50:51.974")
 
-            guiRun { field.value = dateTime }
+            runEdt { field.value = dateTime }
 
             field.value shouldBe dateTime
         }
@@ -54,7 +53,7 @@ object JDateTimeFieldTest : FunSpec({
 
     context("formatter") {
         test("stores valid timestamps") {
-            guiRun {
+            runEdt {
                 field.text = "9017-07-12 05:22:05.767"
                 field.commitEdit()
             }
@@ -63,7 +62,7 @@ object JDateTimeFieldTest : FunSpec({
         }
 
         test("stores liberally interpreted timestamps") {
-            guiRun {
+            runEdt {
                 field.text = "4494-09"
                 field.commitEdit()
             }
@@ -72,7 +71,7 @@ object JDateTimeFieldTest : FunSpec({
         }
 
         test("stores values that cannot be interpreted as timestamps") {
-            guiRun {
+            runEdt {
                 field.text = "How are you?"
                 field.commitEdit()
             }
@@ -81,7 +80,7 @@ object JDateTimeFieldTest : FunSpec({
         }
 
         test("interprets `null` as an empty string") {
-            guiRun {
+            runEdt {
                 field.text = null
                 field.commitEdit()
             }
@@ -100,21 +99,21 @@ object BindDateTimesTest : FunSpec({
 
     context("updating") {
         test("updates the minimum date-time if the maximum goes below its value") {
-            val min = guiGet { JDateTimeField(Timestamp("1970-01-01 00:00:00.000")) }
-            val max = guiGet { JDateTimeField(Timestamp("1970-01-01 00:00:00.000")) }
+            val min = runEdt { JDateTimeField(Timestamp("1970-01-01 00:00:00.000")) }
+            val max = runEdt { JDateTimeField(Timestamp("1970-01-01 00:00:00.000")) }
             bindDateTimes(min, max)
 
-            guiRun { max.value = Timestamp("0760-06-24 09:38:00.747") }
+            runEdt { max.value = Timestamp("0760-06-24 09:38:00.747") }
 
             min.value shouldBe Timestamp("0760-06-24 09:38:00.747")
         }
 
         test("updates the maximum date-time if the minimum goes above its value") {
-            val min = guiGet { JDateTimeField(Timestamp("1970-01-01 00:00:00.000")) }
-            val max = guiGet { JDateTimeField(Timestamp("1970-01-01 00:00:00.000")) }
+            val min = runEdt { JDateTimeField(Timestamp("1970-01-01 00:00:00.000")) }
+            val max = runEdt { JDateTimeField(Timestamp("1970-01-01 00:00:00.000")) }
             bindDateTimes(min, max)
 
-            guiRun { min.value = Timestamp("8660-05-28 06:11:32.199") }
+            runEdt { min.value = Timestamp("8660-05-28 06:11:32.199") }
 
             max.value shouldBe Timestamp("8660-05-28 06:11:32.199")
         }

--- a/src/test/kotlin/com/fwdekker/randomness/ui/JNumberSpinnerTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/ui/JNumberSpinnerTest.kt
@@ -117,7 +117,7 @@ object JDoubleSpinnerTest : FunSpec({
             test("returns null if the current value is already at the minimum") {
                 val spinner = guiGet { JDoubleSpinner(-637.8, minValue = -637.8) }
 
-                spinner.previousValue should beNull()
+                spinner.previousValue shouldBe null
             }
         }
 
@@ -131,7 +131,7 @@ object JDoubleSpinnerTest : FunSpec({
             test("returns null if the current value is already at the maximum") {
                 val spinner = guiGet { JDoubleSpinner(-28.3, maxValue = -28.3) }
 
-                spinner.nextValue should beNull()
+                spinner.nextValue shouldBe null
             }
         }
     }
@@ -165,7 +165,7 @@ object JLongSpinnerTest : FunSpec({
             test("returns null if the current value is already at the minimum") {
                 val spinner = guiGet { JLongSpinner(203L, minValue = 203L) }
 
-                spinner.previousValue should beNull()
+                spinner.previousValue shouldBe null
             }
         }
 
@@ -179,7 +179,7 @@ object JLongSpinnerTest : FunSpec({
             test("returns null if the current value is already at the maximum") {
                 val spinner = guiGet { JLongSpinner(119L, maxValue = 119L) }
 
-                spinner.nextValue should beNull()
+                spinner.nextValue shouldBe null
             }
         }
     }
@@ -221,7 +221,7 @@ object JIntSpinnerTest : FunSpec({
             test("returns null if the current value is already at the minimum") {
                 val spinner = guiGet { JIntSpinner(188, minValue = 188) }
 
-                spinner.previousValue should beNull()
+                spinner.previousValue shouldBe null
             }
         }
 
@@ -235,7 +235,7 @@ object JIntSpinnerTest : FunSpec({
             test("returns null if the current value is already at the maximum") {
                 val spinner = guiGet { JIntSpinner(182, maxValue = 182) }
 
-                spinner.nextValue should beNull()
+                spinner.nextValue shouldBe null
             }
         }
     }

--- a/src/test/kotlin/com/fwdekker/randomness/ui/JNumberSpinnerTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/ui/JNumberSpinnerTest.kt
@@ -1,12 +1,9 @@
 package com.fwdekker.randomness.ui
 
-import com.fwdekker.randomness.testhelpers.guiGet
-import com.fwdekker.randomness.testhelpers.guiRun
+import com.fwdekker.randomness.testhelpers.runEdt
 import com.fwdekker.randomness.testhelpers.useEdtViolationDetection
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.matchers.nulls.beNull
-import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import javax.swing.JSpinner
 
@@ -32,17 +29,17 @@ object JNumberSpinnerTest : FunSpec({
 
     context("input handling") {
         test("should get and set the value") {
-            val spinner = guiGet { JIntSpinner() }
+            val spinner = runEdt { JIntSpinner() }
 
-            guiRun { spinner.value = 179 }
+            runEdt { spinner.value = 179 }
 
             spinner.value shouldBe 179
         }
 
         test("should return an int even if a long is set") {
-            val spinner = guiGet { JIntSpinner() }
+            val spinner = runEdt { JIntSpinner() }
 
-            guiRun { (spinner as JSpinner).value = 638L }
+            runEdt { (spinner as JSpinner).value = 638L }
 
             spinner.value shouldBe 638
         }
@@ -58,8 +55,8 @@ object BindSpinnersTest : FunSpec({
 
     context("binding") {
         test("throws an exception if the range is negative") {
-            val min = guiGet { JSpinner() }
-            val max = guiGet { JSpinner() }
+            val min = runEdt { JSpinner() }
+            val max = runEdt { JSpinner() }
 
             shouldThrow<IllegalArgumentException> { bindSpinners(min, max, -37.20) }
                 .message shouldBe "maxRange must be a positive number."
@@ -68,21 +65,21 @@ object BindSpinnersTest : FunSpec({
 
     context("updating") {
         test("updates the minimum spinner if the maximum goes below its value") {
-            val min = guiGet { JSpinner() }
-            val max = guiGet { JSpinner() }
+            val min = runEdt { JSpinner() }
+            val max = runEdt { JSpinner() }
             bindSpinners(min, max)
 
-            guiRun { max.value = -284.85 }
+            runEdt { max.value = -284.85 }
 
             min.value shouldBe -284.85
         }
 
         test("updates the maximum spinner if the minimum goes above its value") {
-            val min = guiGet { JSpinner() }
-            val max = guiGet { JSpinner() }
+            val min = runEdt { JSpinner() }
+            val max = runEdt { JSpinner() }
             bindSpinners(min, max)
 
-            guiRun { min.value = 684.41 }
+            runEdt { min.value = 684.41 }
 
             max.value shouldBe 684.41
         }
@@ -98,9 +95,9 @@ object JDoubleSpinnerTest : FunSpec({
 
     context("input handling") {
         test("should return a double even if a long is set") {
-            val spinner = guiGet { JDoubleSpinner() }
+            val spinner = runEdt { JDoubleSpinner() }
 
-            guiRun { (spinner as JSpinner).value = -750L }
+            runEdt { (spinner as JSpinner).value = -750L }
 
             spinner.value shouldBe -750.0
         }
@@ -109,13 +106,13 @@ object JDoubleSpinnerTest : FunSpec({
     context("getting surrounding values") {
         context("previous value") {
             test("returns the previous value") {
-                val spinner = guiGet { JDoubleSpinner(741.4) }
+                val spinner = runEdt { JDoubleSpinner(741.4) }
 
                 spinner.previousValue shouldBe 741.3
             }
 
             test("returns null if the current value is already at the minimum") {
-                val spinner = guiGet { JDoubleSpinner(-637.8, minValue = -637.8) }
+                val spinner = runEdt { JDoubleSpinner(-637.8, minValue = -637.8) }
 
                 spinner.previousValue shouldBe null
             }
@@ -123,13 +120,13 @@ object JDoubleSpinnerTest : FunSpec({
 
         context("next value") {
             test("returns the next value") {
-                val spinner = guiGet { JDoubleSpinner(629.9) }
+                val spinner = runEdt { JDoubleSpinner(629.9) }
 
                 spinner.nextValue shouldBe 630.0
             }
 
             test("returns null if the current value is already at the maximum") {
-                val spinner = guiGet { JDoubleSpinner(-28.3, maxValue = -28.3) }
+                val spinner = runEdt { JDoubleSpinner(-28.3, maxValue = -28.3) }
 
                 spinner.nextValue shouldBe null
             }
@@ -146,9 +143,9 @@ object JLongSpinnerTest : FunSpec({
 
     context("input handling") {
         test("truncates when storing a double") {
-            val spinner = guiGet { JLongSpinner() }
+            val spinner = runEdt { JLongSpinner() }
 
-            guiRun { spinner.setValue(786.79) }
+            runEdt { spinner.setValue(786.79) }
 
             spinner.value shouldBe 786L
         }
@@ -157,13 +154,13 @@ object JLongSpinnerTest : FunSpec({
     context("getting surrounding values") {
         context("previous value") {
             test("returns the previous value") {
-                val spinner = guiGet { JLongSpinner(56L) }
+                val spinner = runEdt { JLongSpinner(56L) }
 
                 spinner.previousValue shouldBe 55L
             }
 
             test("returns null if the current value is already at the minimum") {
-                val spinner = guiGet { JLongSpinner(203L, minValue = 203L) }
+                val spinner = runEdt { JLongSpinner(203L, minValue = 203L) }
 
                 spinner.previousValue shouldBe null
             }
@@ -171,13 +168,13 @@ object JLongSpinnerTest : FunSpec({
 
         context("next value") {
             test("returns the next value") {
-                val spinner = guiGet { JLongSpinner(112L) }
+                val spinner = runEdt { JLongSpinner(112L) }
 
                 spinner.nextValue shouldBe 113L
             }
 
             test("returns null if the current value is already at the maximum") {
-                val spinner = guiGet { JLongSpinner(119L, maxValue = 119L) }
+                val spinner = runEdt { JLongSpinner(119L, maxValue = 119L) }
 
                 spinner.nextValue shouldBe null
             }
@@ -194,17 +191,17 @@ object JIntSpinnerTest : FunSpec({
 
     context("input handling") {
         test("truncates when storing a double") {
-            val spinner = guiGet { JIntSpinner() }
+            val spinner = runEdt { JIntSpinner() }
 
-            guiRun { spinner.setValue(850.45) }
+            runEdt { spinner.setValue(850.45) }
 
             spinner.value shouldBe 850
         }
 
         test("overflows when storing a large long") {
-            val spinner = guiGet { JIntSpinner() }
+            val spinner = runEdt { JIntSpinner() }
 
-            guiRun { spinner.setValue(Integer.MAX_VALUE.toLong() + 2) }
+            runEdt { spinner.setValue(Integer.MAX_VALUE.toLong() + 2) }
 
             spinner.value shouldBe Integer.MIN_VALUE + 1
         }
@@ -213,13 +210,13 @@ object JIntSpinnerTest : FunSpec({
     context("getting surrounding values") {
         context("previous value") {
             test("returns the previous value") {
-                val spinner = guiGet { JIntSpinner(205) }
+                val spinner = runEdt { JIntSpinner(205) }
 
                 spinner.previousValue shouldBe 204
             }
 
             test("returns null if the current value is already at the minimum") {
-                val spinner = guiGet { JIntSpinner(188, minValue = 188) }
+                val spinner = runEdt { JIntSpinner(188, minValue = 188) }
 
                 spinner.previousValue shouldBe null
             }
@@ -227,13 +224,13 @@ object JIntSpinnerTest : FunSpec({
 
         context("next value") {
             test("returns the next value") {
-                val spinner = guiGet { JIntSpinner(96) }
+                val spinner = runEdt { JIntSpinner(96) }
 
                 spinner.nextValue shouldBe 97
             }
 
             test("returns null if the current value is already at the maximum") {
-                val spinner = guiGet { JIntSpinner(182, maxValue = 182) }
+                val spinner = runEdt { JIntSpinner(182, maxValue = 182) }
 
                 spinner.nextValue shouldBe null
             }

--- a/src/test/kotlin/com/fwdekker/randomness/ui/ListenerHelpersTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/ui/ListenerHelpersTest.kt
@@ -3,8 +3,7 @@ package com.fwdekker.randomness.ui
 import com.fwdekker.randomness.Timestamp
 import com.fwdekker.randomness.testhelpers.DummySchemeEditor
 import com.fwdekker.randomness.testhelpers.beforeNonContainer
-import com.fwdekker.randomness.testhelpers.guiGet
-import com.fwdekker.randomness.testhelpers.guiRun
+import com.fwdekker.randomness.testhelpers.ideaRunEdt
 import com.fwdekker.randomness.testhelpers.useBareIdeaFixture
 import com.fwdekker.randomness.testhelpers.useEdtViolationDetection
 import com.intellij.openapi.ui.ComboBox
@@ -136,11 +135,11 @@ object ListenerHelpersTest : FunSpec({
                     ),
             )
         ) { (createComponent, changeComponent): Row2<() -> Any, (Any) -> Unit> ->
-            val component = guiGet { createComponent() }
+            val component = ideaRunEdt { createComponent() }
             addChangeListenerTo(component, listener = listener)
 
             listenerInvoked shouldBe false
-            guiRun { changeComponent(component) }
+            ideaRunEdt { changeComponent(component) }
 
             listenerInvoked shouldBe true
         }
@@ -151,12 +150,12 @@ object ListenerHelpersTest : FunSpec({
         // Committing the input may result in the `AbstractFormatter` changing the `value` of the field, even though
         // the `text` field is not changed. Therefore, this event should be listened to separately.
 
-        val component = guiGet { JFormattedTextField("old text") }
-        guiRun { component.text = "uncommitted text" }
+        val component = ideaRunEdt { JFormattedTextField("old text") }
+        ideaRunEdt { component.text = "uncommitted text" }
         addChangeListenerTo(component, listener = listener)
 
         listenerInvoked shouldBe false
-        guiRun { component.commitEdit() }
+        ideaRunEdt { component.commitEdit() }
 
         listenerInvoked shouldBe true
     }

--- a/src/test/kotlin/com/fwdekker/randomness/ui/PreviewPanelTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/ui/PreviewPanelTest.kt
@@ -5,8 +5,7 @@ import com.fwdekker.randomness.testhelpers.DummyScheme
 import com.fwdekker.randomness.testhelpers.afterNonContainer
 import com.fwdekker.randomness.testhelpers.beforeNonContainer
 import com.fwdekker.randomness.testhelpers.find
-import com.fwdekker.randomness.testhelpers.guiGet
-import com.fwdekker.randomness.testhelpers.guiRun
+import com.fwdekker.randomness.testhelpers.ideaRunEdt
 import com.fwdekker.randomness.testhelpers.matcher
 import com.fwdekker.randomness.testhelpers.useBareIdeaFixture
 import com.fwdekker.randomness.testhelpers.useEdtViolationDetection
@@ -34,7 +33,7 @@ object PreviewPanelTest : FunSpec({
     useBareIdeaFixture()
 
     beforeNonContainer {
-        panel = guiGet { PreviewPanel { DummyScheme().also { scheme = it } } }
+        panel = ideaRunEdt { PreviewPanel { DummyScheme().also { scheme = it } } }
         frame = Containers.showInFrame(panel.rootComponent)
 
         panel.previewText shouldBe placeholder
@@ -42,13 +41,13 @@ object PreviewPanelTest : FunSpec({
 
     afterNonContainer {
         frame.cleanUp()
-        guiRun { Disposer.dispose(panel) }
+        ideaRunEdt { Disposer.dispose(panel) }
     }
 
 
     context("updatePreview") {
         test("updates the label's contents") {
-            guiRun { panel.updatePreview() }
+            ideaRunEdt { panel.updatePreview() }
 
             panel.previewText shouldBe "text0"
         }
@@ -56,22 +55,22 @@ object PreviewPanelTest : FunSpec({
 
     context("seed") {
         test("reuses the old seed if the button is not pressed") {
-            guiRun { panel.updatePreview() }
+            ideaRunEdt { panel.updatePreview() }
             val oldRandom = scheme?.random
 
-            guiRun { panel.updatePreview() }
+            ideaRunEdt { panel.updatePreview() }
             val newRandom = scheme?.random
 
             newRandom?.nextInt() shouldBe oldRandom?.nextInt()
         }
 
         test("uses a new seed when the button is pressed") {
-            guiRun { panel.updatePreview() }
+            ideaRunEdt { panel.updatePreview() }
             val oldRandom = scheme?.random
 
-            guiRun { frame.find(matcher(InplaceButton::class.java)).doClick() }
+            ideaRunEdt { frame.find(matcher(InplaceButton::class.java)).doClick() }
 
-            guiRun { panel.updatePreview() }
+            ideaRunEdt { panel.updatePreview() }
             val newRandom = scheme?.random
 
             newRandom?.nextInt() shouldNotBe oldRandom?.nextInt()

--- a/src/test/kotlin/com/fwdekker/randomness/uuid/UuidSchemeEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/uuid/UuidSchemeEditorTest.kt
@@ -5,10 +5,10 @@ import com.fwdekker.randomness.testhelpers.afterNonContainer
 import com.fwdekker.randomness.testhelpers.beforeNonContainer
 import com.fwdekker.randomness.testhelpers.editorApplyTests
 import com.fwdekker.randomness.testhelpers.editorFieldsTests
-import com.fwdekker.randomness.testhelpers.guiGet
 import com.fwdekker.randomness.testhelpers.isSelectedProp
 import com.fwdekker.randomness.testhelpers.itemProp
 import com.fwdekker.randomness.testhelpers.prop
+import com.fwdekker.randomness.testhelpers.runEdt
 import com.fwdekker.randomness.testhelpers.textProp
 import com.fwdekker.randomness.testhelpers.useEdtViolationDetection
 import com.fwdekker.randomness.testhelpers.valueProp
@@ -35,7 +35,7 @@ object UuidSchemeEditorTest : FunSpec({
 
     beforeNonContainer {
         scheme = UuidScheme()
-        editor = guiGet { UuidSchemeEditor(scheme) }
+        editor = runEdt { UuidSchemeEditor(scheme) }
         frame = showInFrame(editor.rootComponent)
     }
 

--- a/src/test/kotlin/com/fwdekker/randomness/word/DefaultWordListTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/word/DefaultWordListTest.kt
@@ -1,7 +1,7 @@
 package com.fwdekker.randomness.word
 
 import com.fwdekker.randomness.testhelpers.beforeNonContainer
-import com.fwdekker.randomness.testhelpers.matchBundle
+import com.fwdekker.randomness.testhelpers.shouldMatchBundle
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.beEmpty
@@ -25,7 +25,7 @@ object DefaultWordListTest : FunSpec({
         test("throws an exception if the file does not exist") {
             val list = DefaultWordList("name", "word-lists/does-not-exist.txt")
 
-            shouldThrow<IOException> { list.words }.message should matchBundle("word_list.error.file_not_found")
+            shouldThrow<IOException> { list.words }.message shouldMatchBundle "word_list.error.file_not_found"
         }
 
         test("returns an empty list of words if the file is empty") {
@@ -51,7 +51,7 @@ object DefaultWordListTest : FunSpec({
                 val list = DefaultWordList("name", "word-lists/does-not-exist.txt")
 
                 shouldThrow<IOException> { list.words }
-                    .message should matchBundle("word_list.error.file_not_found")
+                    .message shouldMatchBundle "word_list.error.file_not_found"
             }
 
             test("returns words quicker if read again from the same instance") {

--- a/src/test/kotlin/com/fwdekker/randomness/word/WordSchemeEditorTest.kt
+++ b/src/test/kotlin/com/fwdekker/randomness/word/WordSchemeEditorTest.kt
@@ -7,11 +7,10 @@ import com.fwdekker.randomness.testhelpers.beforeNonContainer
 import com.fwdekker.randomness.testhelpers.editorApplyTests
 import com.fwdekker.randomness.testhelpers.editorFieldsTests
 import com.fwdekker.randomness.testhelpers.find
-import com.fwdekker.randomness.testhelpers.guiGet
-import com.fwdekker.randomness.testhelpers.guiRun
 import com.fwdekker.randomness.testhelpers.itemProp
 import com.fwdekker.randomness.testhelpers.matcher
 import com.fwdekker.randomness.testhelpers.prop
+import com.fwdekker.randomness.testhelpers.runEdt
 import com.fwdekker.randomness.testhelpers.textProp
 import com.fwdekker.randomness.testhelpers.useEdtViolationDetection
 import com.fwdekker.randomness.testhelpers.valueProp
@@ -44,7 +43,7 @@ object WordSchemeEditorTest : FunSpec({
 
     beforeNonContainer {
         scheme = WordScheme()
-        editor = guiGet { WordSchemeEditor(scheme) }
+        editor = runEdt { WordSchemeEditor(scheme) }
         frame = showInFrame(editor.rootComponent)
 
         wordsEditor = frame.find(matcher(EditorComponentImpl::class.java))
@@ -52,7 +51,7 @@ object WordSchemeEditorTest : FunSpec({
 
     afterNonContainer {
         frame.cleanUp()
-        guiRun { Disposer.dispose(editor) }
+        runEdt { Disposer.dispose(editor) }
     }
 
 
@@ -71,32 +70,32 @@ object WordSchemeEditorTest : FunSpec({
             context("pre-selection") {
                 test("selects the placeholder if the initial words do no match any word list") {
                     scheme.words = listOf("word1", "word2")
-                    guiRun { editor.reset() }
+                    runEdt { editor.reset() }
 
                     frame.comboBox("presets").target().selectedIndex shouldBe 0
                 }
 
                 test("selects the corresponding word list if the contents match that list") {
                     scheme.words = firstList.words
-                    guiRun { editor.reset() }
+                    runEdt { editor.reset() }
 
                     frame.comboBox("presets").target().selectedIndex shouldBe 1
                 }
 
                 test("selects the placeholder if a word is changed") {
                     scheme.words = firstList.words
-                    guiRun { editor.reset() }
+                    runEdt { editor.reset() }
 
-                    guiRun { runWriteAction { wordsEditor.editor.document.setText("${firstListAsString}jealous") } }
+                    runEdt { runWriteAction { wordsEditor.editor.document.setText("${firstListAsString}jealous") } }
 
                     frame.comboBox("presets").target().selectedIndex shouldBe 0
                 }
 
                 test("retains the non-placeholder selection if a newline is appended") {
                     scheme.words = firstList.words
-                    guiRun { editor.reset() }
+                    runEdt { editor.reset() }
 
-                    guiRun { runWriteAction { wordsEditor.editor.document.setText("$firstListAsString\n \n") } }
+                    runEdt { runWriteAction { wordsEditor.editor.document.setText("$firstListAsString\n \n") } }
 
                     frame.comboBox("presets").target().selectedIndex shouldBe 1
                 }
@@ -105,26 +104,26 @@ object WordSchemeEditorTest : FunSpec({
             context("insertion") {
                 test("does nothing if the placeholder is selected") {
                     scheme.words = listOf("word1", "word2")
-                    guiRun { editor.reset() }
+                    runEdt { editor.reset() }
 
-                    guiRun { frame.comboBox("presets").target().selectedIndex = 0 }
+                    runEdt { frame.comboBox("presets").target().selectedIndex = 0 }
 
                     wordsEditor.text shouldBe "word1\nword2\n"
                 }
 
                 test("does nothing if another entry is selected and then the placeholder is selected") {
-                    guiRun { frame.comboBox("presets").target().selectedIndex = 1 }
+                    runEdt { frame.comboBox("presets").target().selectedIndex = 1 }
 
-                    guiRun { frame.comboBox("presets").target().selectedIndex = 0 }
+                    runEdt { frame.comboBox("presets").target().selectedIndex = 0 }
 
                     wordsEditor.text shouldBe firstListAsString
                 }
 
                 test("inserts the words of the selected entry") {
                     scheme.words = listOf("word1", "word2")
-                    guiRun { editor.reset() }
+                    runEdt { editor.reset() }
 
-                    guiRun { frame.comboBox("presets").target().selectedIndex = 1 }
+                    runEdt { frame.comboBox("presets").target().selectedIndex = 1 }
 
                     wordsEditor.text shouldBe firstListAsString
                 }
@@ -133,11 +132,11 @@ object WordSchemeEditorTest : FunSpec({
 
         context("words") {
             test("removes blank lines from the input field") {
-                guiRun { runWriteAction { wordsEditor.editor.document.setText("word1\n  \nword2\n") } }
+                runEdt { runWriteAction { wordsEditor.editor.document.setText("word1\n  \nword2\n") } }
 
                 editor.apply()
 
-                guiGet { editor.scheme.words } shouldContainExactly listOf("word1", "word2")
+                runEdt { editor.scheme.words } shouldContainExactly listOf("word1", "word2")
             }
         }
     }


### PR DESCRIPTION
Fixes #572 and #574.

I decided the following:
* Kotest assertions should use infix methods wherever possible. I simply think that this reads nicer, and allows for easier chaining. So use `foo shouldHaveSize 3` instead of `foo should haveSize(3)`. However, (only) if the assertion takes no argument, then use the infix `should`, so use `foo should beEmpty()` instead of `foo.shouldBeEmpty()`. (Indeed, the `should beEmpty()` notation does not allow chaining. Ah well.)
* I created `runEdt` and `ideaRunEdt`. The former is the standard and actually uses the event-dispatching thread, while the latter uses the coroutine. They have been documented as such.